### PR TITLE
Performance optimization with moving sponge coefficient udpates into updatePressureField function

### DIFF
--- a/src/solver/src/SEMsolver.cpp
+++ b/src/solver/src/SEMsolver.cpp
@@ -37,8 +37,6 @@ void SEMsolver::computeOneStep(const int &timeSample, const int &order,
   FENCE
   updatePressureField(i1, i2, myInfo, pnGlobal);
   FENCE
-  //spongeUpdate(pnGlobal, i1, i2);
-  //FENCE
 }
 
 void SEMsolver::resetGlobalVectors(int numNodes) {
@@ -113,7 +111,6 @@ void SEMsolver::updatePressureField(int i1, int i2, SEMinfo &myInfo,
 
   float const dt2 = myInfo.myTimeStep * myInfo.myTimeStep;
   LOOPHEAD(myInfo.numberOfNodes, I)
-    //int const I =listOfInteriorNodes[i];
     pnGlobal(I, i1) = 2 * pnGlobal(I, i2) - pnGlobal(I, i1) - dt2 * yGlobal[I] / massMatrixGlobal[I];
     pnGlobal(I, i1) *= spongeTaperCoeff(I);
     pnGlobal(I, i2) *= spongeTaperCoeff(I);


### PR DESCRIPTION
In this pull request, the following changes have been made:
- moving pressure wavefield update with sponge coefficient into the function updatePressureField
- removing the redundant calculation of iterator in the main loop of updatePressureField

The tests has been done on the following hardwares:
- Nvidia RTX 4070 GPU
- Nvidia GH200

With the above optimizations, performance improvements (for example the Elapsed Kernel Time running with Shiva method) have been observed by more than 10% on both:
- Nvidia RTX 4070 GPU (4.33986 seconds v.s. 5.16407 seconds)
- Nvidia GH200 (0.776524 seconds v.s. 0.878431 seconds)