### PR TITLE
Fix model builder api to return unique ptr

### DIFF
--- a/src/model/api/include/builder.h
+++ b/src/model/api/include/builder.h
@@ -9,6 +9,6 @@ namespace model {
       ModelBuilderBase() = default;
       ~ModelBuilderBase() = default;
 
-      model::ModelApi<FloatType, ScalarType> getModel() const;
+      unique_ptr<model::ModelApi<FloatType, ScalarType>> getModel() const;
     };
 }


### PR DESCRIPTION
Model builder api now returns a unique ptr.
Not sure if it changes anything at execution time, but it may raise compilation on some machine such as P3.

Should fix Issue #39 