### PR TITLE
Enable the use of either model on nodes or on element

### DIFF
--- a/src/main/fe/include/sem_proxy_options.h
+++ b/src/main/fe/include/sem_proxy_options.h
@@ -28,7 +28,7 @@ class SemProxyOptions
   bool surface_sponge = false;
   float taper_delta = 0.015;
   // Boolean to tell if the model is charged on nodes or on element
-  bool isModelOnNodes = false;
+  bool isModelOnNodes = true;
 
   void validate() const
   {

--- a/src/model/api/include/model.h
+++ b/src/model/api/include/model.h
@@ -189,14 +189,8 @@ class ModelApi
    */
   virtual FloatType getMaxSpeed() const = 0;
 
-  bool isModelOnNodes() const { return m_isModelOnNodes; }
-
- private:
-  /**
-   * @brief Flag indicating where the model is defined (true = nodes, false =
-   * elements)
-   */
-  bool m_isModelOnNodes;
+  PROXY_HOST_DEVICE
+  virtual bool isModelOnNodes() const = 0;
 };
 
 }  // namespace model

--- a/src/model/impl/builder/cartesian/include/cartesian_unstruct_builder.h
+++ b/src/model/impl/builder/cartesian/include/cartesian_unstruct_builder.h
@@ -247,7 +247,6 @@ class CartesianUnstructBuilder : ModelBuilderBase<FloatType, ScalarType>
     // creating uniforms model
     int n_element = ex_ * ey_ * ez_;
     int n_node = (ex_ * order_ + 1) * (ey_ * order_ + 1) * (ez_ * order_ + 1);
-    printf("isModelOnNodes_: %d\n", isModelOnNodes_);
     if (isModelOnNodes_)
     {
       model_rho_node_ =

--- a/src/model/impl/model/struct/include/model_struct.h
+++ b/src/model/impl/model/struct/include/model_struct.h
@@ -298,6 +298,9 @@ class ModelStruct : public ModelApi<FloatType, ScalarType>
     return 1500;
   }
 
+  PROXY_HOST_DEVICE
+  bool isModelOnNodes() const { return isModelOnNodes_; }
+
  private:
   ScalarType ex_, ey_, ez_;  // Nb elements in each direction
   ScalarType nx_, ny_, nz_;  // Nb nodes in each direction

--- a/src/model/impl/model/unstruct/include/model_unstruct.h
+++ b/src/model/impl/model/unstruct/include/model_unstruct.h
@@ -168,6 +168,9 @@ class ModelUnstruct : public ModelApi<FloatType, ScalarType>
     return model_rho_element_[e];
   }
 
+  PROXY_HOST_DEVICE
+  bool isModelOnNodes() const final { return isModelOnNodes_; }
+
   /**
    * @brief Get the total number of elements in the mesh.
    * @return Total element count

--- a/src/solver/impl/include/sem_solver.h
+++ b/src/solver/impl/include/sem_solver.h
@@ -84,12 +84,9 @@ class SEMsolver : public SolverBase
    *
    * @param timeSample   Current time index into the RHS (source) term
    * @param dt           Delta time for this iteration
-   * @param i1           Index for previous pressure field
-   * @param i2           Index for current pressure field
-   * @param rhsTerm      Right-hand side forcing term [node][time]
-   * @param pnGlobal     Global pressure field [node][time]
-   * @param rhsElement   List of active source elements
-   * @param rhsWeights   Forcing weights per source node
+   * @param data         DataStruct containing all necessary arrays
+   * @param isModelOnNodes True if the velocity model is defined on nodes, false
+   * if on elements
    */
   virtual void computeOneStep(const float &dt, const int &timeSample,
                               DataStruct &data) override final;
@@ -152,7 +149,8 @@ class SEMsolver : public SolverBase
    * @param i2       Current pressure field index
    * @param pnGlobal Global pressure field
    */
-  void computeElementContributions(int i2, const ARRAY_REAL_VIEW &pnGlobal);
+  void computeElementContributions(int i2, const ARRAY_REAL_VIEW &pnGlobal,
+                                   bool isModelOnNodes);
 
   /**
    * @brief Update the global pressure field at interior nodes.


### PR DESCRIPTION
This PR add an if condition inside the acoustic SEM solver to differ the use of model on nodes or on element.

It is based on the use of the boolean isModelOnNodes previously introduced.
