### PR TITLE
Remove Shiva run from pytest

### DIFF
--- a/tests/units/solver/pywrap/test_solver_struct.py
+++ b/tests/units/solver/pywrap/test_solver_struct.py
@@ -51,7 +51,7 @@ test_cases_struct = [
 class TestSolverStruct:
     @pytest.mark.parametrize("struct", test_cases_struct, indirect=True)
     @pytest.mark.parametrize(
-        "implem", [Solver.ImplemType.MAKUTU, Solver.ImplemType.SHIVA]
+        "implem", [Solver.ImplemType.MAKUTU]
     )
     def test_solver_one_step(self, struct, implem):
         sd, builder, is_model_on_nodes, is_elastic = struct

--- a/tests/units/solver/pywrap/test_solver_unstruct.py
+++ b/tests/units/solver/pywrap/test_solver_unstruct.py
@@ -124,7 +124,7 @@ test_cases_struct = [
 class TestSolverUnstruct:
     @pytest.mark.parametrize("unstruct", test_cases_struct, indirect=True)
     @pytest.mark.parametrize(
-        "implem", [Solver.ImplemType.MAKUTU, Solver.ImplemType.SHIVA]
+        "implem", [Solver.ImplemType.MAKUTU]
     )
     def test_solver_one_step(self, unstruct, implem):
         sd, _, builder, is_model_on_nodes, is_elastic = (


### PR DESCRIPTION
This PR remove Shiva pytest from tests as now the cmake option is on OFF by default.