### PR TITLE
add necessary binding

### DIFF
--- a/src/model/mesh/pywrap/include/bindings_model.h
+++ b/src/model/mesh/pywrap/include/bindings_model.h
@@ -61,7 +61,10 @@ void bind_modelapi(py::module_ &m)
       .def("get_number_of_faces", &T::getNumberOfFaces)
       .def("is_boundary_face", &T::isBoundaryFace)
       .def("get_global_node_from_face", &T::getGlobalNodeFromFace)
-      .def("get_global_face", &T::getGlobalFace);
+      .def("get_global_face", &T::getGlobalFace)
+      .def("set_free_surface_enabled", &T::setFreeSurfaceEnabled)
+      .def("init_free_surface", &T::initFreeSurface)
+      .def("is_free_surface", &T::isFreeSurface);
 }
 
 // templated binder for one ModelStruct instantiation


### PR DESCRIPTION
Add python bindings to allow setting free surface. By default there is no free surface, thus this feature is essential to allow realistic simulations.

To use this feature, simply add:

```
model.set_free_surface_enabled(True) # To enable
model.init_free_surface() # To create
```

One may also check if a node belongs to the free surface using `model.is_free_surface(node num.)`