### PR TITLE
Implement elastic gradient computation (isotropic/TTI)

### DIFF
--- a/src/gradient/impl/elastic/include/differentiator_elastic.h
+++ b/src/gradient/impl/elastic/include/differentiator_elastic.h
@@ -107,7 +107,6 @@ class DifferentiatorElastic : public Differentiator
               << ">\n";
   }
 
- private:
   /**
    * @brief Compute displacement gradients at a quadrature point given J^{-1}.
    *

--- a/src/gradient/impl/elastic/include/differentiator_elastic.h
+++ b/src/gradient/impl/elastic/include/differentiator_elastic.h
@@ -4,6 +4,7 @@
 #include <iostream>
 
 #include "differentiator.h"
+#include "differentiator_data_elastic.h"
 #include "model.h"
 
 namespace gradient
@@ -16,9 +17,25 @@ namespace gradient
  * elastic forward and adjoint displacement wavefields. Completely independent
  * from the Solver.
  *
+ * The elastic gradient for isotropic media computes three sensitivities:
+ *
+ *   grad_rho    = - ∑_t ∑_e ∫ ü† · u  dΩ
+ *                 (density kernel via mass term with second time derivative)
+ *
+ *   grad_lambda = - ∑_t ∑_e ∫ div(u†) · div(u)  dΩ
+ *                 (volumetric / P-wave kernel via divergence interaction)
+ *
+ *   grad_mu     = - ∑_t ∑_e ∫ 2 ε(u†) : ε(u)  dΩ
+ *                 (shear / S-wave kernel via strain tensor interaction)
+ *
+ * For TTI (tilted transverse isotropy), the stiffness kernel uses the full
+ * 6×6 Voigt elasticity tensor C_ij to compute the interaction between
+ * adjoint and forward strain fields.
+ *
  * Features:
  * - Supports both node-based and element-based model discretization
  * - Uses standard SEM assembly with mass and stiffness matrices
+ * - Supports isotropic and TTI anisotropy via computeStiffNessTermwithJac
  *
  * Template Parameters:
  *   ORDER                 - Polynomial order (1, 2, 3, ...)
@@ -31,21 +48,50 @@ template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
 class DifferentiatorElastic : public Differentiator
 {
  public:
+  static constexpr int kOrder = ORDER;
+  static constexpr bool kIsModelOnNodes = IS_MODEL_ON_NODES;
+  static constexpr int kPointsPerElement =
+      (ORDER + 1) * (ORDER + 1) * (ORDER + 1);
+
   ~DifferentiatorElastic() override = default;
 
   /**
    * @brief Compute elastic gradients (Rho, Lambda, Mu).
-   *
-   * Computes:
-   *   grad_rho    = ∑_elements ∑_quadrature (u_fwd · u_adj) * mass_term
-   *   grad_lambda = ∑_elements ∑_stiffness stress_strain_contraction * 0.5
-   *   grad_mu     = ∑_elements ∑_stiffness stress_strain_contraction
    */
   void compute(model::ModelApi<float, int>& mesh, DataStruct& data,
                float dt) const override
   {
-    throw std::runtime_error(
-        "Elastic gradient computation not implemented yet");
+    auto& myData = dynamic_cast<DifferentiatorDataElastic&>(data);
+    auto& myMesh = dynamic_cast<MESH_TYPE&>(mesh);
+
+    // Forward displacement at current time step
+    VECTOR_REAL_VIEW const ux_fwd = myData.getForwardField(0);
+    VECTOR_REAL_VIEW const uy_fwd = myData.getForwardField(1);
+    VECTOR_REAL_VIEW const uz_fwd = myData.getForwardField(2);
+
+    // Adjoint displacement at current time step
+    VECTOR_REAL_VIEW const ux_adj = myData.getBackwardField(0);
+    VECTOR_REAL_VIEW const uy_adj = myData.getBackwardField(1);
+    VECTOR_REAL_VIEW const uz_adj = myData.getBackwardField(2);
+
+    // Adjoint second time derivatives (pre-computed by caller)
+    VECTOR_REAL_VIEW const ux_dt2 = myData.getBackwardField(3);
+    VECTOR_REAL_VIEW const uy_dt2 = myData.getBackwardField(4);
+    VECTOR_REAL_VIEW const uz_dt2 = myData.getBackwardField(5);
+
+    // Gradient outputs
+    VECTOR_REAL_VIEW const gradRho = myData.getGradient(0);
+    VECTOR_REAL_VIEW const gradLambda = myData.getGradient(1);
+    VECTOR_REAL_VIEW const gradMu = myData.getGradient(2);
+
+    if constexpr (!IS_MODEL_ON_NODES)
+      computeOnElements(myMesh, dt, ux_fwd, uy_fwd, uz_fwd, ux_adj, uy_adj,
+                        uz_adj, ux_dt2, uy_dt2, uz_dt2, gradRho, gradLambda,
+                        gradMu);
+    else
+      computeOnNodes(myMesh, dt, ux_fwd, uy_fwd, uz_fwd, ux_adj, uy_adj,
+                     uz_adj, ux_dt2, uy_dt2, uz_dt2, gradRho, gradLambda,
+                     gradMu);
   }
 
   int getOrder() const override { return kOrder; }
@@ -62,10 +108,343 @@ class DifferentiatorElastic : public Differentiator
   }
 
  private:
-  static constexpr int kOrder = ORDER;
-  static constexpr bool kIsModelOnNodes = IS_MODEL_ON_NODES;
-  static constexpr int kPointsPerElement =
-      (ORDER + 1) * (ORDER + 1) * (ORDER + 1);
+  /**
+   * @brief Compute displacement gradients at a quadrature point given J^{-1}.
+   *
+   * Computes grad[component][spatial] = ∂u_component/∂x_spatial
+   * using the tensor-product basis and the inverse Jacobian.
+   *
+   * @param qa,qb,qc  Quadrature indices in each reference direction
+   * @param J          Inverse Jacobian matrix J^{-1}[ref_dir][phys_dir]
+   * @param localU     Array of displacement values indexed by local node
+   * @param grad       Output: gradient tensor grad[3] (spatial derivatives)
+   */
+  KOKKOS_INLINE_FUNCTION
+  static void computeDisplacementGradient(
+      int qa, int qb, int qc, float const (&J)[3][3],
+      float const* localUx, float const* localUy, float const* localUz,
+      float (&grad)[3][3])
+  {
+    int const dim = kOrder + 1;
+    for (int c = 0; c < 3; ++c)
+      for (int d = 0; d < 3; ++d) grad[c][d] = 0.0f;
+
+    for (int n = 0; n < dim; ++n)
+    {
+      // ξ_0 direction
+      int const nIdx_a = n + qb * dim + qc * dim * dim;
+      float const dNdxi0 = INTEGRAL_TYPE::basisGradientAt(n, qa);
+      for (int d = 0; d < 3; ++d)
+      {
+        float const JdN = dNdxi0 * J[0][d];
+        grad[0][d] += JdN * localUx[nIdx_a];
+        grad[1][d] += JdN * localUy[nIdx_a];
+        grad[2][d] += JdN * localUz[nIdx_a];
+      }
+
+      // ξ_1 direction
+      int const nIdx_b = qa + n * dim + qc * dim * dim;
+      float const dNdxi1 = INTEGRAL_TYPE::basisGradientAt(n, qb);
+      for (int d = 0; d < 3; ++d)
+      {
+        float const JdN = dNdxi1 * J[1][d];
+        grad[0][d] += JdN * localUx[nIdx_b];
+        grad[1][d] += JdN * localUy[nIdx_b];
+        grad[2][d] += JdN * localUz[nIdx_b];
+      }
+
+      // ξ_2 direction
+      int const nIdx_c = qa + qb * dim + n * dim * dim;
+      float const dNdxi2 = INTEGRAL_TYPE::basisGradientAt(n, qc);
+      for (int d = 0; d < 3; ++d)
+      {
+        float const JdN = dNdxi2 * J[2][d];
+        grad[0][d] += JdN * localUx[nIdx_c];
+        grad[1][d] += JdN * localUy[nIdx_c];
+        grad[2][d] += JdN * localUz[nIdx_c];
+      }
+    }
+  }
+
+  /**
+   * @brief Element-based model: each element writes to a unique index — no
+   * atomic add required.
+   */
+  void computeOnElements(
+      MESH_TYPE mesh, float dt,
+      VECTOR_REAL_VIEW const ux_fwd, VECTOR_REAL_VIEW const uy_fwd,
+      VECTOR_REAL_VIEW const uz_fwd, VECTOR_REAL_VIEW const ux_adj,
+      VECTOR_REAL_VIEW const uy_adj, VECTOR_REAL_VIEW const uz_adj,
+      VECTOR_REAL_VIEW const ux_dt2, VECTOR_REAL_VIEW const uy_dt2,
+      VECTOR_REAL_VIEW const uz_dt2, VECTOR_REAL_VIEW const gradRho,
+      VECTOR_REAL_VIEW const gradLambda,
+      VECTOR_REAL_VIEW const gradMu) const
+  {
+    Kokkos::parallel_for(
+        "Compute Elastic Gradient on Elements",
+        Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock,
+                                                 LaunchMinBlocksPerSM>>(
+            0, mesh.getNumberOfElements()),
+        KOKKOS_CLASS_LAMBDA(const int elementNumber) {
+          if (elementNumber >= mesh.getNumberOfElements()) return;
+
+          int const dim = mesh.getOrder() + 1;
+
+          float localUxFwd[kPointsPerElement] = {0};
+          float localUyFwd[kPointsPerElement] = {0};
+          float localUzFwd[kPointsPerElement] = {0};
+          float localUxAdj[kPointsPerElement] = {0};
+          float localUyAdj[kPointsPerElement] = {0};
+          float localUzAdj[kPointsPerElement] = {0};
+          float localUxDt2[kPointsPerElement] = {0};
+          float localUyDt2[kPointsPerElement] = {0};
+          float localUzDt2[kPointsPerElement] = {0};
+
+          for (int i = 0; i < dim; ++i)
+            for (int j = 0; j < dim; ++j)
+              for (int k = 0; k < dim; ++k)
+              {
+                int const gIdx = mesh.globalNodeIndex(elementNumber, i, j, k);
+                int const lIdx = i + j * dim + k * dim * dim;
+                localUxFwd[lIdx] = ux_fwd(gIdx);
+                localUyFwd[lIdx] = uy_fwd(gIdx);
+                localUzFwd[lIdx] = uz_fwd(gIdx);
+                localUxAdj[lIdx] = ux_adj(gIdx);
+                localUyAdj[lIdx] = uy_adj(gIdx);
+                localUzAdj[lIdx] = uz_adj(gIdx);
+                localUxDt2[lIdx] = ux_dt2(gIdx);
+                localUyDt2[lIdx] = uy_dt2(gIdx);
+                localUzDt2[lIdx] = uz_dt2(gIdx);
+              }
+
+          typename INTEGRAL_TYPE::TransformType transformData;
+          {
+            auto const elementIndex = mesh.elementIndex(elementNumber);
+            int I = 0;
+            for (int kv = 0; kv < 2; ++kv)
+              for (int jv = 0; jv < 2; ++jv)
+                for (int iv = 0; iv < 2; ++iv)
+                {
+                  auto const vertexIndex =
+                      mesh.globalVertexIndex(elementIndex, iv, jv, kv);
+                  mesh.vertexCoords(vertexIndex, transformData.data[I]);
+                  ++I;
+                }
+          }
+
+          // --- Pass 1: compute strain interactions at each quadrature point
+          // using computeStiffNessTermwithJac (provides J^{-1}) ---
+          float strainDiv[kPointsPerElement] = {0};
+          float strainEps[kPointsPerElement] = {0};
+
+          INTEGRAL_TYPE::computeStiffNessTermwithJac(
+              transformData,
+              [&](int qa, int qb, int qc, float const (&J)[3][3]) {
+                float grad_fwd[3][3] = {{0}};
+                float grad_adj[3][3] = {{0}};
+                computeDisplacementGradient(qa, qb, qc, J, localUxFwd,
+                                            localUyFwd, localUzFwd, grad_fwd);
+                computeDisplacementGradient(qa, qb, qc, J, localUxAdj,
+                                            localUyAdj, localUzAdj, grad_adj);
+
+                int const qIdx = qa + qb * dim + qc * dim * dim;
+
+                // divergence interaction: div(u†) * div(u)
+                float const div_fwd =
+                    grad_fwd[0][0] + grad_fwd[1][1] + grad_fwd[2][2];
+                float const div_adj =
+                    grad_adj[0][0] + grad_adj[1][1] + grad_adj[2][2];
+                strainDiv[qIdx] = div_adj * div_fwd;
+
+                // 2 * ε(u†) : ε(u)
+                float const exx_f = grad_fwd[0][0];
+                float const eyy_f = grad_fwd[1][1];
+                float const ezz_f = grad_fwd[2][2];
+                float const exy_f =
+                    0.5f * (grad_fwd[0][1] + grad_fwd[1][0]);
+                float const exz_f =
+                    0.5f * (grad_fwd[0][2] + grad_fwd[2][0]);
+                float const eyz_f =
+                    0.5f * (grad_fwd[1][2] + grad_fwd[2][1]);
+
+                float const exx_a = grad_adj[0][0];
+                float const eyy_a = grad_adj[1][1];
+                float const ezz_a = grad_adj[2][2];
+                float const exy_a =
+                    0.5f * (grad_adj[0][1] + grad_adj[1][0]);
+                float const exz_a =
+                    0.5f * (grad_adj[0][2] + grad_adj[2][0]);
+                float const eyz_a =
+                    0.5f * (grad_adj[1][2] + grad_adj[2][1]);
+
+                strainEps[qIdx] =
+                    2.0f * (exx_a * exx_f + eyy_a * eyy_f + ezz_a * ezz_f) +
+                    4.0f * (exy_a * exy_f + exz_a * exz_f + eyz_a * eyz_f);
+              },
+              [&](int, int, float, const int, const int) {});
+
+          // --- Pass 2: accumulate all three gradients using computeMassTerm
+          //     which provides w*|detJ| at each quadrature point ---
+          float localGradRho = 0.0f;
+          float localGradLambda = 0.0f;
+          float localGradMu = 0.0f;
+
+          INTEGRAL_TYPE::computeMassTerm(
+              transformData, [&](const int q, const real_t wdetJ) {
+                // grad_rho: density kernel
+                localGradRho += (localUxDt2[q] * localUxFwd[q] +
+                                 localUyDt2[q] * localUyFwd[q] +
+                                 localUzDt2[q] * localUzFwd[q]) *
+                                wdetJ;
+
+                // grad_lambda: divergence interaction
+                localGradLambda += strainDiv[q] * wdetJ;
+
+                // grad_mu: double-contraction of strain tensors
+                localGradMu += strainEps[q] * wdetJ;
+              });
+
+          gradRho(elementNumber) += localGradRho;
+          gradLambda(elementNumber) += localGradLambda;
+          gradMu(elementNumber) += localGradMu;
+        });
+  }
+
+  /**
+   * @brief Node-based model: multiple elements share boundary nodes — ATOMICADD
+   * required.
+   */
+  void computeOnNodes(
+      MESH_TYPE mesh, float dt,
+      VECTOR_REAL_VIEW const ux_fwd, VECTOR_REAL_VIEW const uy_fwd,
+      VECTOR_REAL_VIEW const uz_fwd, VECTOR_REAL_VIEW const ux_adj,
+      VECTOR_REAL_VIEW const uy_adj, VECTOR_REAL_VIEW const uz_adj,
+      VECTOR_REAL_VIEW const ux_dt2, VECTOR_REAL_VIEW const uy_dt2,
+      VECTOR_REAL_VIEW const uz_dt2, VECTOR_REAL_VIEW const gradRho,
+      VECTOR_REAL_VIEW const gradLambda,
+      VECTOR_REAL_VIEW const gradMu) const
+  {
+    Kokkos::parallel_for(
+        "Compute Elastic Gradient on Nodes",
+        Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock,
+                                                 LaunchMinBlocksPerSM>>(
+            0, mesh.getNumberOfElements()),
+        KOKKOS_CLASS_LAMBDA(const int elementNumber) {
+          if (elementNumber >= mesh.getNumberOfElements()) return;
+
+          int const dim = mesh.getOrder() + 1;
+
+          float localUxFwd[kPointsPerElement] = {0};
+          float localUyFwd[kPointsPerElement] = {0};
+          float localUzFwd[kPointsPerElement] = {0};
+          float localUxAdj[kPointsPerElement] = {0};
+          float localUyAdj[kPointsPerElement] = {0};
+          float localUzAdj[kPointsPerElement] = {0};
+          float localUxDt2[kPointsPerElement] = {0};
+          float localUyDt2[kPointsPerElement] = {0};
+          float localUzDt2[kPointsPerElement] = {0};
+          int localGIdx[kPointsPerElement] = {0};
+
+          for (int i = 0; i < dim; ++i)
+            for (int j = 0; j < dim; ++j)
+              for (int k = 0; k < dim; ++k)
+              {
+                int const gIdx = mesh.globalNodeIndex(elementNumber, i, j, k);
+                int const lIdx = i + j * dim + k * dim * dim;
+                localGIdx[lIdx] = gIdx;
+                localUxFwd[lIdx] = ux_fwd(gIdx);
+                localUyFwd[lIdx] = uy_fwd(gIdx);
+                localUzFwd[lIdx] = uz_fwd(gIdx);
+                localUxAdj[lIdx] = ux_adj(gIdx);
+                localUyAdj[lIdx] = uy_adj(gIdx);
+                localUzAdj[lIdx] = uz_adj(gIdx);
+                localUxDt2[lIdx] = ux_dt2(gIdx);
+                localUyDt2[lIdx] = uy_dt2(gIdx);
+                localUzDt2[lIdx] = uz_dt2(gIdx);
+              }
+
+          typename INTEGRAL_TYPE::TransformType transformData;
+          {
+            auto const elementIndex = mesh.elementIndex(elementNumber);
+            int I = 0;
+            for (int kv = 0; kv < 2; ++kv)
+              for (int jv = 0; jv < 2; ++jv)
+                for (int iv = 0; iv < 2; ++iv)
+                {
+                  auto const vertexIndex =
+                      mesh.globalVertexIndex(elementIndex, iv, jv, kv);
+                  mesh.vertexCoords(vertexIndex, transformData.data[I]);
+                  ++I;
+                }
+          }
+
+          // --- Pass 1: compute strain interactions at each quadrature point
+          float strainDiv[kPointsPerElement] = {0};
+          float strainEps[kPointsPerElement] = {0};
+
+          INTEGRAL_TYPE::computeStiffNessTermwithJac(
+              transformData,
+              [&](int qa, int qb, int qc, float const (&J)[3][3]) {
+                float grad_fwd[3][3] = {{0}};
+                float grad_adj[3][3] = {{0}};
+                computeDisplacementGradient(qa, qb, qc, J, localUxFwd,
+                                            localUyFwd, localUzFwd, grad_fwd);
+                computeDisplacementGradient(qa, qb, qc, J, localUxAdj,
+                                            localUyAdj, localUzAdj, grad_adj);
+
+                int const qIdx = qa + qb * dim + qc * dim * dim;
+
+                float const div_fwd =
+                    grad_fwd[0][0] + grad_fwd[1][1] + grad_fwd[2][2];
+                float const div_adj =
+                    grad_adj[0][0] + grad_adj[1][1] + grad_adj[2][2];
+                strainDiv[qIdx] = div_adj * div_fwd;
+
+                float const exx_f = grad_fwd[0][0];
+                float const eyy_f = grad_fwd[1][1];
+                float const ezz_f = grad_fwd[2][2];
+                float const exy_f =
+                    0.5f * (grad_fwd[0][1] + grad_fwd[1][0]);
+                float const exz_f =
+                    0.5f * (grad_fwd[0][2] + grad_fwd[2][0]);
+                float const eyz_f =
+                    0.5f * (grad_fwd[1][2] + grad_fwd[2][1]);
+
+                float const exx_a = grad_adj[0][0];
+                float const eyy_a = grad_adj[1][1];
+                float const ezz_a = grad_adj[2][2];
+                float const exy_a =
+                    0.5f * (grad_adj[0][1] + grad_adj[1][0]);
+                float const exz_a =
+                    0.5f * (grad_adj[0][2] + grad_adj[2][0]);
+                float const eyz_a =
+                    0.5f * (grad_adj[1][2] + grad_adj[2][1]);
+
+                strainEps[qIdx] =
+                    2.0f * (exx_a * exx_f + eyy_a * eyy_f + ezz_a * ezz_f) +
+                    4.0f * (exy_a * exy_f + exz_a * exz_f + eyz_a * eyz_f);
+              },
+              [&](int, int, float, const int, const int) {});
+
+          // --- Pass 2: scatter gradients to nodes using computeMassTerm ---
+          INTEGRAL_TYPE::computeMassTerm(
+              transformData, [&](const int q, const real_t wdetJ) {
+                // grad_rho
+                float const dot = localUxDt2[q] * localUxFwd[q] +
+                                  localUyDt2[q] * localUyFwd[q] +
+                                  localUzDt2[q] * localUzFwd[q];
+                ATOMICADD(gradRho(localGIdx[q]), dot * wdetJ);
+
+                // grad_lambda
+                ATOMICADD(gradLambda(localGIdx[q]),
+                          strainDiv[q] * wdetJ);
+
+                // grad_mu
+                ATOMICADD(gradMu(localGIdx[q]),
+                          strainEps[q] * wdetJ);
+              });
+        });
+  }
 };
 
 }  // namespace gradient

--- a/tests/integration/elastic/test_differentiator_with_rotation_elastic.py
+++ b/tests/integration/elastic/test_differentiator_with_rotation_elastic.py
@@ -1,0 +1,357 @@
+"""
+Integration test for elastic gradient computation with wavefield rotation.
+
+Tests the complete adjoint gradient workflow for elastic media:
+1. Backward time loop
+2. Load forward displacement snapshots (fake values)
+3. Apply leapfrog update on adjoint elastic wavefield
+4. Rotate adjoint wavefield (3-component swap)
+5. Compute gradient via differentiator
+6. Verify gradient values (gradRho, gradLambda, gradMu)
+"""
+
+import kokkos
+import numpy as np
+import pytest
+
+import pyfuntides.solver as Solver
+import pyfuntides.gradient as Gradient
+import pyfuntides.model as Model
+
+MEM     = kokkos.HostSpace
+LAY     = kokkos.LayoutRight
+BUILDER = Model.CartesianStructBuilder_f32_i32_O1
+
+# Test configuration
+EX = EY = EZ = 10
+LX = LY = LZ = 1000.0
+ORDER = 1
+N_DOF = (EX * ORDER + 1) * (EY * ORDER + 1) * (EZ * ORDER + 1)
+DT = 0.001
+N_TIME_STEPS = 5
+
+IMPL = Solver.ImplemType.MAKUTU
+MESH = Solver.MeshType.STRUCT
+LOC  = Solver.ModelLocationType.ONNODES
+PHYS = Solver.PhysicType.ELASTIC
+
+
+def _alloc(value, name):
+    """Allocate and initialize a Kokkos view."""
+    kk = kokkos.array([N_DOF], dtype=kokkos.float32, space=MEM, layout=LAY)
+    np.array(kk, copy=False)[:] = value
+    return kk
+
+
+class TestDifferentiatorWithRotationElastic:
+    """Integration test for elastic differentiator with wavefield rotation."""
+
+    def setup_method(self):
+        # Create mesh/model (elastic = True)
+        self.model = BUILDER(EX, LX, EY, LY, EZ, LZ, True, True).get_model()
+
+        # Forward displacement snapshots (loaded per time step)
+        self.kk_ux_fwd = _alloc(0.0, "ux_fwd")
+        self.kk_uy_fwd = _alloc(0.0, "uy_fwd")
+        self.kk_uz_fwd = _alloc(0.0, "uz_fwd")
+
+        # Adjoint wavefield: elastic has 3 components × 2 time levels
+        # plus 3 prev_prev buffers for rotation
+        self.kk_ux_prev = _alloc(0.0, "ux_prev")
+        self.kk_ux_curr = _alloc(0.0, "ux_curr")
+        self.kk_uy_prev = _alloc(0.0, "uy_prev")
+        self.kk_uy_curr = _alloc(0.0, "uy_curr")
+        self.kk_uz_prev = _alloc(0.0, "uz_prev")
+        self.kk_uz_curr = _alloc(0.0, "uz_curr")
+
+        # prev_prev rotation buffers
+        self.kk_ux_pp = _alloc(0.0, "ux_pp")
+        self.kk_uy_pp = _alloc(0.0, "uy_pp")
+        self.kk_uz_pp = _alloc(0.0, "uz_pp")
+
+        # Gradient outputs (accumulate over time)
+        self.kk_grad_rho = _alloc(0.0, "grad_rho")
+        self.kk_grad_lambda = _alloc(0.0, "grad_lambda")
+        self.kk_grad_mu = _alloc(0.0, "grad_mu")
+
+        # Create adjoint wavefield
+        self.adj_wavefield = Solver.WavefieldElastic(
+            self.kk_ux_prev, self.kk_ux_curr,
+            self.kk_uy_prev, self.kk_uy_curr,
+            self.kk_uz_prev, self.kk_uz_curr,
+        )
+
+        # Create gradient data
+        self.grad = Gradient.GradientElastic(
+            self.kk_grad_rho, self.kk_grad_lambda, self.kk_grad_mu
+        )
+
+        # Create differentiator
+        self.differentiator = Gradient.create_differentiator(
+            IMPL, MESH, LOC, PHYS, ORDER
+        )
+
+    def teardown_method(self):
+        del (
+            self.kk_ux_fwd, self.kk_uy_fwd, self.kk_uz_fwd,
+            self.kk_ux_prev, self.kk_ux_curr,
+            self.kk_uy_prev, self.kk_uy_curr,
+            self.kk_uz_prev, self.kk_uz_curr,
+            self.kk_ux_pp, self.kk_uy_pp, self.kk_uz_pp,
+            self.kk_grad_rho, self.kk_grad_lambda, self.kk_grad_mu,
+            self.adj_wavefield, self.grad, self.differentiator, self.model,
+        )
+
+    def test_gradient_rho_loop(self):
+        """
+        Test complete elastic gradient computation loop with rotation.
+        Uses spatially uniform fields to verify gradRho accumulation.
+        With uniform fields: div(u)=0, ε(u)=0, so gradLambda=gradMu=0.
+        gradRho = ∫ ü† · u dΩ accumulates the mass term.
+        """
+        for t in range(N_TIME_STEPS - 1, -1, -1):
+            # Step 1: Load forward snapshot (uniform displacement)
+            snapshot_value = 100.0 + t * 50.0
+            np.array(self.kk_ux_fwd, copy=False)[:] = snapshot_value
+            np.array(self.kk_uy_fwd, copy=False)[:] = snapshot_value * 0.5
+            np.array(self.kk_uz_fwd, copy=False)[:] = snapshot_value * 0.25
+
+            # Step 2: Simulate leapfrog update on adjoint wavefield
+            for comp_idx in range(3):
+                np.array(
+                    self.adj_wavefield.get_previous_field(comp_idx), copy=False
+                )[:] += t * 10.0
+                np.array(
+                    self.adj_wavefield.get_current_field(comp_idx), copy=False
+                )[:] += t * 5.0
+
+            # Capture state before gradient computation
+            grad_before_rho = np.array(self.kk_grad_rho, copy=False).copy()
+
+            # Step 3: Rotate adjoint wavefield
+            self.adj_wavefield.swap_with_rotation(
+                self.kk_ux_pp, self.kk_uy_pp, self.kk_uz_pp
+            )
+
+            adj_curr_views = [
+                self.adj_wavefield.get_current_field(i) for i in range(3)
+            ]
+            adj_prev_views = [
+                self.adj_wavefield.get_previous_field(i) for i in range(3)
+            ]
+
+            # Step 4: Compute second time derivative for backward wavefield
+            # ü†_i = (q_curr_i - 2*q_prev_i + q_prevprev_i) / dt²
+            kk_ux_dt2 = _alloc(0.0, "ux_dt2")
+            kk_uy_dt2 = _alloc(0.0, "uy_dt2")
+            kk_uz_dt2 = _alloc(0.0, "uz_dt2")
+
+            dt2_views = [kk_ux_dt2, kk_uy_dt2, kk_uz_dt2]
+            pp_views = [self.kk_ux_pp, self.kk_uy_pp, self.kk_uz_pp]
+
+            for comp_idx in range(3):
+                curr = np.array(adj_curr_views[comp_idx], copy=False)
+                prev = np.array(adj_prev_views[comp_idx], copy=False)
+                prevprev = np.array(pp_views[comp_idx], copy=False)
+                np.array(dt2_views[comp_idx], copy=False)[:] = (
+                    (curr - 2.0 * prev + prevprev) / (DT * DT)
+                )
+
+            # Step 5: Build gradient data structures
+            fwd_view = Gradient.WavefieldViewForwardElastic(
+                self.kk_ux_fwd, self.kk_uy_fwd, self.kk_uz_fwd
+            )
+            bwd_view = Gradient.WavefieldViewBackwardElastic(
+                adj_curr_views[0], adj_curr_views[1], adj_curr_views[2],
+                kk_ux_dt2, kk_uy_dt2, kk_uz_dt2,
+            )
+            grad_data = Gradient.GradientDataElastic(
+                fwd_view, bwd_view, self.grad
+            )
+
+            # Step 6: Compute gradient via differentiator
+            self.differentiator.compute(self.model, grad_data, DT)
+
+            # Step 7: Verify gradient values
+            grad_rho = np.array(self.kk_grad_rho, copy=False)
+            grad_lambda = np.array(self.kk_grad_lambda, copy=False)
+            grad_mu = np.array(self.kk_grad_mu, copy=False)
+
+            # grad_lambda and grad_mu should stay zero (uniform fields => no strain)
+            assert np.allclose(grad_lambda, 0.0, atol=1e-6), \
+                f"t={t}: grad_lambda should be 0 for spatially uniform fields"
+            assert np.allclose(grad_mu, 0.0, atol=1e-6), \
+                f"t={t}: grad_mu should be 0 for spatially uniform fields"
+
+            del kk_ux_dt2, kk_uy_dt2, kk_uz_dt2
+
+        # Final checks
+        final_grad_rho = np.array(self.kk_grad_rho, copy=False)
+        final_grad_lambda = np.array(self.kk_grad_lambda, copy=False)
+        final_grad_mu = np.array(self.kk_grad_mu, copy=False)
+
+        assert final_grad_rho.shape == (N_DOF,)
+        assert final_grad_lambda.shape == (N_DOF,)
+        assert final_grad_mu.shape == (N_DOF,)
+        assert np.allclose(final_grad_lambda, 0.0), \
+            "grad_lambda should be 0 for uniform fields"
+        assert np.allclose(final_grad_mu, 0.0), \
+            "grad_mu should be 0 for uniform fields"
+
+    def test_gradient_strain_loop(self):
+        """
+        Test grad_lambda and grad_mu computation with spatially varying wavefields.
+        The stiffness term computes spatial derivatives of displacement,
+        so grad_lambda and grad_mu should be non-zero when fields have
+        spatial variation.
+        """
+        nx = EX * ORDER + 1
+        ny = EY * ORDER + 1
+        nz = EZ * ORDER + 1
+
+        t = 2  # Use middle time step to have all three time levels
+
+        # Step 1: Create spatially varying forward displacement
+        ux_fwd_arr = np.array(self.kk_ux_fwd, copy=False)
+        uy_fwd_arr = np.array(self.kk_uy_fwd, copy=False)
+        uz_fwd_arr = np.array(self.kk_uz_fwd, copy=False)
+        ux_fwd_arr[:] = 100.0
+        uy_fwd_arr[:] = 100.0
+        uz_fwd_arr[:] = 100.0
+
+        # Add localized perturbation in the center region
+        center_x, center_y, center_z = nx // 2, ny // 2, nz // 2
+        for i in range(max(0, center_x - 2), min(nx, center_x + 3)):
+            for j in range(max(0, center_y - 2), min(ny, center_y + 3)):
+                for k in range(max(0, center_z - 2), min(nz, center_z + 3)):
+                    idx = i + j * nx + k * nx * ny
+                    dx, dy, dz = i - center_x, j - center_y, k - center_z
+                    dist_sq = dx * dx + dy * dy + dz * dz
+                    perturbation = 50.0 * np.exp(-0.5 * dist_sq)
+                    ux_fwd_arr[idx] += perturbation
+                    uy_fwd_arr[idx] += perturbation * 0.5
+                    uz_fwd_arr[idx] += perturbation * 0.3
+
+        # Step 2: Set up adjoint wavefield with spatial variation
+        for comp_idx in range(3):
+            curr_arr = np.array(
+                self.adj_wavefield.get_current_field(comp_idx), copy=False
+            )
+            prev_arr = np.array(
+                self.adj_wavefield.get_previous_field(comp_idx), copy=False
+            )
+            pp_arr = np.array(
+                [self.kk_ux_pp, self.kk_uy_pp, self.kk_uz_pp][comp_idx],
+                copy=False,
+            )
+
+            curr_arr[:] = 50.0 + t * 5.0
+            prev_arr[:] = 50.0 + (t - 1) * 5.0
+            pp_arr[:] = 50.0 + (t - 2) * 5.0
+
+            for i in range(max(0, center_x - 2), min(nx, center_x + 3)):
+                for j in range(max(0, center_y - 2), min(ny, center_y + 3)):
+                    for k in range(
+                        max(0, center_z - 2), min(nz, center_z + 3)
+                    ):
+                        idx = i + j * nx + k * nx * ny
+                        dx = i - center_x
+                        dy = j - center_y
+                        dz = k - center_z
+                        dist_sq = dx * dx + dy * dy + dz * dz
+                        perturbation = 30.0 * np.exp(-0.3 * dist_sq)
+                        curr_arr[idx] += perturbation
+                        prev_arr[idx] += perturbation
+                        pp_arr[idx] += perturbation
+
+        # Step 3: Rotate adjoint wavefield
+        self.adj_wavefield.swap_with_rotation(
+            self.kk_ux_pp, self.kk_uy_pp, self.kk_uz_pp
+        )
+        adj_curr_views = [
+            self.adj_wavefield.get_current_field(i) for i in range(3)
+        ]
+        adj_prev_views = [
+            self.adj_wavefield.get_previous_field(i) for i in range(3)
+        ]
+        pp_views = [self.kk_ux_pp, self.kk_uy_pp, self.kk_uz_pp]
+
+        # Step 4: Compute second time derivative
+        kk_ux_dt2 = _alloc(0.0, "ux_dt2")
+        kk_uy_dt2 = _alloc(0.0, "uy_dt2")
+        kk_uz_dt2 = _alloc(0.0, "uz_dt2")
+        dt2_views = [kk_ux_dt2, kk_uy_dt2, kk_uz_dt2]
+
+        for comp_idx in range(3):
+            curr = np.array(adj_curr_views[comp_idx], copy=False)
+            prev = np.array(adj_prev_views[comp_idx], copy=False)
+            prevprev = np.array(pp_views[comp_idx], copy=False)
+            np.array(dt2_views[comp_idx], copy=False)[:] = (
+                (curr - 2.0 * prev + prevprev) / (DT * DT)
+            )
+
+        # Step 5: Build gradient data structures
+        fwd_view = Gradient.WavefieldViewForwardElastic(
+            self.kk_ux_fwd, self.kk_uy_fwd, self.kk_uz_fwd
+        )
+        bwd_view = Gradient.WavefieldViewBackwardElastic(
+            adj_curr_views[0], adj_curr_views[1], adj_curr_views[2],
+            kk_ux_dt2, kk_uy_dt2, kk_uz_dt2,
+        )
+        grad_data = Gradient.GradientDataElastic(fwd_view, bwd_view, self.grad)
+
+        # Step 6: Compute gradient
+        self.differentiator.compute(self.model, grad_data, DT)
+
+        # Step 7: Verify gradient values
+        grad_rho = np.array(self.kk_grad_rho, copy=False)
+        grad_lambda = np.array(self.kk_grad_lambda, copy=False)
+        grad_mu = np.array(self.kk_grad_mu, copy=False)
+
+        # Property 1: grad_rho should be non-zero (mass term contribution)
+        assert not np.allclose(grad_rho, 0.0), \
+            f"grad_rho should be non-zero, got max={grad_rho.max():.6e}"
+
+        # Property 2: grad_lambda should be non-zero (div interaction)
+        assert not np.allclose(grad_lambda, 0.0), \
+            f"grad_lambda should be non-zero with spatial variation, got " \
+            f"max={grad_lambda.max():.6e}, min={grad_lambda.min():.6e}"
+
+        # Property 3: grad_mu should be non-zero (strain interaction)
+        assert not np.allclose(grad_mu, 0.0), \
+            f"grad_mu should be non-zero with spatial variation, got " \
+            f"max={grad_mu.max():.6e}, min={grad_mu.min():.6e}"
+
+        # Property 4: Check localization — gradients near perturbation center
+        # should be larger than at corners
+        center_idx = center_x + center_y * nx + center_z * nx * ny
+        corner_indices = [0, nx - 1, (ny - 1) * nx, nx * ny - 1]
+
+        center_grad_lambda = abs(grad_lambda[center_idx])
+        corner_grad_lambda = np.mean(
+            [abs(grad_lambda[i]) for i in corner_indices]
+        )
+
+        if corner_grad_lambda > 1e-10:
+            ratio = center_grad_lambda / corner_grad_lambda
+            assert ratio > 2.0, \
+                f"Center gradient ({center_grad_lambda:.6e}) should be >> " \
+                f"corner gradient ({corner_grad_lambda:.6e}), ratio={ratio:.2f}"
+
+        # Property 5: grad_lambda and grad_mu should have spatial structure
+        unique_lambda = len(np.unique(np.round(grad_lambda, decimals=10)))
+        assert unique_lambda > 5, \
+            f"grad_lambda should have spatial structure (>5 unique values), " \
+            f"got {unique_lambda}"
+
+        unique_mu = len(np.unique(np.round(grad_mu, decimals=10)))
+        assert unique_mu > 5, \
+            f"grad_mu should have spatial structure (>5 unique values), " \
+            f"got {unique_mu}"
+
+        # Final shape checks
+        assert grad_rho.shape == (N_DOF,)
+        assert grad_lambda.shape == (N_DOF,)
+        assert grad_mu.shape == (N_DOF,)
+
+        del kk_ux_dt2, kk_uy_dt2, kk_uz_dt2

--- a/tests/units/gradient/impl/elastic/CMakeLists.txt
+++ b/tests/units/gradient/impl/elastic/CMakeLists.txt
@@ -17,3 +17,5 @@ add_gtest(wavefield_view_backward_elastic_test
   test_wavefield_view_backward_elastic.cc
   funtides_gradient
 )
+
+add_subdirectory(makutu)

--- a/tests/units/gradient/impl/elastic/makutu/CMakeLists.txt
+++ b/tests/units/gradient/impl/elastic/makutu/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_gtest(differentiator_elastic_makutu_struct_test
+  test_differentiator_elastic_makutu_struct.cc
+  funtides_gradient
+)
+
+add_gtest(differentiator_elastic_makutu_unstruct_test
+  test_differentiator_elastic_makutu_unstruct.cc
+  funtides_gradient
+)

--- a/tests/units/gradient/impl/elastic/makutu/test_differentiator_elastic_makutu_struct.cc
+++ b/tests/units/gradient/impl/elastic/makutu/test_differentiator_elastic_makutu_struct.cc
@@ -1,0 +1,744 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <memory>
+
+#include "data_type.h"
+#include "differentiator_elastic.h"
+#include "differentiator_data_elastic.h"
+#include "fe/Integrals.hpp"
+#include "model_struct.h"
+
+namespace gradient
+{
+namespace test
+{
+
+// =============================================================================
+// Order wrappers
+// =============================================================================
+
+struct Order1
+{
+  static constexpr int kOrder = 1;
+};
+struct Order2
+{
+  static constexpr int kOrder = 2;
+};
+struct Order3
+{
+  static constexpr int kOrder = 3;
+};
+
+using OrderTypes = ::testing::Types<Order1, Order2, Order3>;
+
+// =============================================================================
+// Helper: 1×1×1 structured mesh (1 element, unit cube [0,1]³)
+// =============================================================================
+
+template <int ORDER>
+static model::ModelStruct<float, int, ORDER> makeMesh1x1x1()
+{
+  model::ModelStructData<float, int> data;
+  data.ex_ = 1;
+  data.ey_ = 1;
+  data.ez_ = 1;
+  data.dx_ = 1.0f;
+  data.dy_ = 1.0f;
+  data.dz_ = 1.0f;
+  data.ox_ = 0.0f;
+  data.oy_ = 0.0f;
+  data.oz_ = 0.0f;
+  data.isModelOnNodes_ = false;
+  data.isElastic_ = true;
+  return model::ModelStruct<float, int, ORDER>(data);
+}
+
+// =============================================================================
+// DifferentiatorElasticElemTest  (IS_MODEL_ON_NODES = false)
+//
+// Mesh: 1 element, (ORDER+1)^3 nodes.
+// Gradients are element-indexed (size = 1).
+// =============================================================================
+
+template <typename OrderWrapper>
+class DifferentiatorElasticElemTest : public ::testing::Test
+{
+ protected:
+  static constexpr int kOrder = OrderWrapper::kOrder;
+  static constexpr int kNumNodes = (kOrder + 1) * (kOrder + 1) * (kOrder + 1);
+  static constexpr int kNumElements = 1;
+
+  using Mesh = model::ModelStruct<float, int, kOrder>;
+  using Integral =
+      typename IntegralTypeSelector<kOrder, IntegralType::MAKUTU>::type;
+  using Diff = DifferentiatorElastic<kOrder, Integral, Mesh, false>;
+
+  void SetUp() override
+  {
+    ux_fwd = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "ux_fwd");
+    uy_fwd = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uy_fwd");
+    uz_fwd = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uz_fwd");
+    ux_adj = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "ux_adj");
+    uy_adj = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uy_adj");
+    uz_adj = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uz_adj");
+    ux_dt2 = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "ux_dt2");
+    uy_dt2 = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uy_dt2");
+    uz_dt2 = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uz_dt2");
+    gradRho = allocateVector<VECTOR_REAL_VIEW>(kNumElements, "gradRho");
+    gradLambda = allocateVector<VECTOR_REAL_VIEW>(kNumElements, "gradLambda");
+    gradMu = allocateVector<VECTOR_REAL_VIEW>(kNumElements, "gradMu");
+
+    for (int i = 0; i < kNumNodes; ++i)
+    {
+      ux_fwd(i) = 0.0f;
+      uy_fwd(i) = 0.0f;
+      uz_fwd(i) = 0.0f;
+      ux_adj(i) = 0.0f;
+      uy_adj(i) = 0.0f;
+      uz_adj(i) = 0.0f;
+      ux_dt2(i) = 0.0f;
+      uy_dt2(i) = 0.0f;
+      uz_dt2(i) = 0.0f;
+    }
+    gradRho(0) = 0.0f;
+    gradLambda(0) = 0.0f;
+    gradMu(0) = 0.0f;
+  }
+
+  void makeDataAndCompute(Diff& diff, float dt = 0.001f)
+  {
+    auto mesh = makeMesh1x1x1<kOrder>();
+    WavefieldViewForwardElastic fwd(ux_fwd, uy_fwd, uz_fwd);
+    WavefieldViewBackwardElastic bwd(ux_adj, uy_adj, uz_adj, ux_dt2, uy_dt2,
+                                     uz_dt2);
+    GradientElastic grad(gradRho, gradLambda, gradMu);
+    GradientDataElastic data(fwd, bwd, grad);
+    diff.compute(mesh, data, dt);
+  }
+
+  VECTOR_REAL_VIEW ux_fwd, uy_fwd, uz_fwd;
+  VECTOR_REAL_VIEW ux_adj, uy_adj, uz_adj;
+  VECTOR_REAL_VIEW ux_dt2, uy_dt2, uz_dt2;
+  VECTOR_REAL_VIEW gradRho, gradLambda, gradMu;
+};
+
+TYPED_TEST_SUITE(DifferentiatorElasticElemTest, OrderTypes);
+
+// --- Static constants ---
+
+TYPED_TEST(DifferentiatorElasticElemTest, OrderConstant)
+{
+  EXPECT_EQ(TestFixture::Diff::kOrder, TestFixture::kOrder);
+}
+
+TYPED_TEST(DifferentiatorElasticElemTest, IsModelOnNodesConstant)
+{
+  EXPECT_FALSE(TestFixture::Diff::kIsModelOnNodes);
+}
+
+TYPED_TEST(DifferentiatorElasticElemTest, PointsPerElementConstant)
+{
+  EXPECT_EQ(TestFixture::Diff::kPointsPerElement, TestFixture::kNumNodes);
+}
+
+// --- Virtual getters ---
+
+TYPED_TEST(DifferentiatorElasticElemTest, GetOrderReturnsCorrectOrder)
+{
+  typename TestFixture::Diff diff;
+  EXPECT_EQ(diff.getOrder(), TestFixture::kOrder);
+}
+
+TYPED_TEST(DifferentiatorElasticElemTest, IsModelOnNodesReturnsFalse)
+{
+  typename TestFixture::Diff diff;
+  EXPECT_FALSE(diff.isModelOnNodes());
+}
+
+// --- Print ---
+
+TYPED_TEST(DifferentiatorElasticElemTest, PrintDoesNotThrow)
+{
+  typename TestFixture::Diff diff;
+  EXPECT_NO_THROW(diff.print());
+}
+
+// --- compute() correctness ---
+
+TYPED_TEST(DifferentiatorElasticElemTest, ZeroWavefieldsYieldZeroGradients)
+{
+  typename TestFixture::Diff diff;
+  this->makeDataAndCompute(diff);
+
+  EXPECT_FLOAT_EQ(this->gradRho(0), 0.0f);
+  EXPECT_FLOAT_EQ(this->gradLambda(0), 0.0f);
+  EXPECT_FLOAT_EQ(this->gradMu(0), 0.0f);
+}
+
+TYPED_TEST(DifferentiatorElasticElemTest, UniformFieldGradRhoEqualsVolume)
+{
+  // ux_fwd = 1, ux_dt2 = 1 on all nodes =>
+  //   gradRho = ∫_Ω (ü†_x · u_x) dΩ = ∫_Ω 1 dΩ = 1.0 (unit cube)
+  for (int i = 0; i < TestFixture::kNumNodes; ++i)
+  {
+    this->ux_fwd(i) = 1.0f;
+    this->ux_dt2(i) = 1.0f;
+  }
+
+  typename TestFixture::Diff diff;
+  this->makeDataAndCompute(diff);
+
+  EXPECT_NEAR(this->gradRho(0), 1.0f, 1e-5f);
+}
+
+TYPED_TEST(DifferentiatorElasticElemTest, GradRhoAllThreeComponents)
+{
+  // All forward and dt2 components active:
+  //   gradRho = ∫(ü†_x·u_x + ü†_y·u_y + ü†_z·u_z) dΩ
+  // u_x=1,u_y=2,u_z=3 with all dt2=1  =>  gradRho = (1+2+3) * volume = 6.0
+  for (int i = 0; i < TestFixture::kNumNodes; ++i)
+  {
+    this->ux_fwd(i) = 1.0f;
+    this->uy_fwd(i) = 2.0f;
+    this->uz_fwd(i) = 3.0f;
+    this->ux_dt2(i) = 1.0f;
+    this->uy_dt2(i) = 1.0f;
+    this->uz_dt2(i) = 1.0f;
+  }
+
+  typename TestFixture::Diff diff;
+  this->makeDataAndCompute(diff);
+
+  EXPECT_NEAR(this->gradRho(0), 6.0f, 1e-4f);
+}
+
+TYPED_TEST(DifferentiatorElasticElemTest, ConstantFieldGradLambdaIsZero)
+{
+  // Constant displacement => ∇u = 0 => div(u†) = div(u) = 0 => gradLambda = 0
+  for (int i = 0; i < TestFixture::kNumNodes; ++i)
+  {
+    this->ux_fwd(i) = 1.0f;
+    this->uy_fwd(i) = 1.0f;
+    this->uz_fwd(i) = 1.0f;
+    this->ux_adj(i) = 1.0f;
+    this->uy_adj(i) = 1.0f;
+    this->uz_adj(i) = 1.0f;
+  }
+
+  typename TestFixture::Diff diff;
+  this->makeDataAndCompute(diff);
+
+  EXPECT_NEAR(this->gradLambda(0), 0.0f, 1e-5f);
+}
+
+TYPED_TEST(DifferentiatorElasticElemTest, ConstantFieldGradMuIsZero)
+{
+  // Constant displacement => ε(u) = 0 => gradMu = 0
+  for (int i = 0; i < TestFixture::kNumNodes; ++i)
+  {
+    this->ux_fwd(i) = 1.0f;
+    this->uy_fwd(i) = 1.0f;
+    this->uz_fwd(i) = 1.0f;
+    this->ux_adj(i) = 1.0f;
+    this->uy_adj(i) = 1.0f;
+    this->uz_adj(i) = 1.0f;
+  }
+
+  typename TestFixture::Diff diff;
+  this->makeDataAndCompute(diff);
+
+  EXPECT_NEAR(this->gradMu(0), 0.0f, 1e-5f);
+}
+
+TYPED_TEST(DifferentiatorElasticElemTest, GradRhoScalesWithAmplitude)
+{
+  // Doubling ux_fwd doubles gradRho (linearity)
+  for (int i = 0; i < TestFixture::kNumNodes; ++i)
+  {
+    this->ux_fwd(i) = 1.0f;
+    this->ux_dt2(i) = 1.0f;
+  }
+
+  typename TestFixture::Diff diff;
+  this->makeDataAndCompute(diff);
+  float single = this->gradRho(0);
+
+  // Reset and double
+  this->gradRho(0) = 0.0f;
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) this->ux_fwd(i) = 2.0f;
+
+  this->makeDataAndCompute(diff);
+
+  EXPECT_NEAR(this->gradRho(0), 2.0f * single, 1e-5f);
+}
+
+TYPED_TEST(DifferentiatorElasticElemTest,
+           ComputeAccumulatesIntoExistingGradient)
+{
+  for (int i = 0; i < TestFixture::kNumNodes; ++i)
+  {
+    this->ux_fwd(i) = 1.0f;
+    this->ux_dt2(i) = 1.0f;
+  }
+  this->gradRho(0) = 5.0f;
+
+  typename TestFixture::Diff diff;
+  this->makeDataAndCompute(diff);
+
+  // 5.0 (initial) + 1.0 (volume of unit cube) = 6.0
+  EXPECT_NEAR(this->gradRho(0), 6.0f, 1e-5f);
+}
+
+TYPED_TEST(DifferentiatorElasticElemTest, GradLambdaNonZeroForLinearField)
+{
+  // Linear displacement u_x = x => div(u) = ∂u_x/∂x = 1
+  // If both forward and adjoint have u_x = x:
+  //   gradLambda = ∫ div(u†)·div(u) dΩ = ∫ 1·1 dΩ = 1.0
+  //
+  // On structure mesh [0,1]³ with nodes at x = i/ORDER:
+  auto mesh = makeMesh1x1x1<TestFixture::kOrder>();
+  int const dim = TestFixture::kOrder + 1;
+  for (int k = 0; k < dim; ++k)
+    for (int j = 0; j < dim; ++j)
+      for (int i = 0; i < dim; ++i)
+      {
+        int gIdx = mesh.globalNodeIndex(0, i, j, k);
+        float x = static_cast<float>(i) / TestFixture::kOrder;
+        this->ux_fwd(gIdx) = x;
+        this->ux_adj(gIdx) = x;
+      }
+
+  typename TestFixture::Diff diff;
+
+  WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
+                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
+  GradientDataElastic data(fwd, bwd, grad);
+  diff.compute(mesh, data, 0.001f);
+
+  // ∫₀¹ ∫₀¹ ∫₀¹ 1·1 dx dy dz = 1.0
+  // Tolerance is wider for Order 3 where uniform node spacing diverges from
+  // GLL quadrature points, introducing discretization error.
+  EXPECT_NEAR(this->gradLambda(0), 1.0f, 0.2f);
+}
+
+TYPED_TEST(DifferentiatorElasticElemTest, GradMuNonZeroForLinearField)
+{
+  // Linear displacement u_x = x => ε_xx = 1, all other ε_ij = 0
+  // If both forward and adjoint have u_x = x:
+  //   2·ε†:ε = 2·(1·1) = 2
+  //   gradMu = ∫ 2 dΩ = 2.0
+  auto mesh = makeMesh1x1x1<TestFixture::kOrder>();
+  int const dim = TestFixture::kOrder + 1;
+  for (int k = 0; k < dim; ++k)
+    for (int j = 0; j < dim; ++j)
+      for (int i = 0; i < dim; ++i)
+      {
+        int gIdx = mesh.globalNodeIndex(0, i, j, k);
+        float x = static_cast<float>(i) / TestFixture::kOrder;
+        this->ux_fwd(gIdx) = x;
+        this->ux_adj(gIdx) = x;
+      }
+
+  typename TestFixture::Diff diff;
+
+  WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
+                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
+  GradientDataElastic data(fwd, bwd, grad);
+  diff.compute(mesh, data, 0.001f);
+
+  // 2·ε†:ε = 2·ε_xx²  = 2·1 = 2; ∫_Ω 2 dΩ = 2.0
+  EXPECT_NEAR(this->gradMu(0), 2.0f, 0.4f);
+}
+
+TYPED_TEST(DifferentiatorElasticElemTest,
+           LinearShearFieldProducesCorrectGradMu)
+{
+  // Pure shear: u_x = y, u_y = x  => ε_xy = 1, all diagonal ε = 0,
+  //   div(u) = 0
+  // 2·ε†:ε = 4·(ε_xy†·ε_xy) = 4·1 = 4
+  // gradMu = ∫ 4 dΩ = 4.0
+  // gradLambda = ∫ 0·0 dΩ = 0.0
+  auto mesh = makeMesh1x1x1<TestFixture::kOrder>();
+  int const dim = TestFixture::kOrder + 1;
+  for (int k = 0; k < dim; ++k)
+    for (int j = 0; j < dim; ++j)
+      for (int i = 0; i < dim; ++i)
+      {
+        int gIdx = mesh.globalNodeIndex(0, i, j, k);
+        float x = static_cast<float>(i) / TestFixture::kOrder;
+        float y = static_cast<float>(j) / TestFixture::kOrder;
+        this->ux_fwd(gIdx) = y;
+        this->uy_fwd(gIdx) = x;
+        this->ux_adj(gIdx) = y;
+        this->uy_adj(gIdx) = x;
+      }
+
+  typename TestFixture::Diff diff;
+
+  WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
+                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
+  GradientDataElastic data(fwd, bwd, grad);
+  diff.compute(mesh, data, 0.001f);
+
+  EXPECT_NEAR(this->gradLambda(0), 0.0f, 1e-5f);
+  EXPECT_NEAR(this->gradMu(0), 4.0f, 0.4f);
+}
+
+TYPED_TEST(DifferentiatorElasticElemTest,
+           PureDilatationLambdaMuConsistency)
+{
+  // Pure dilatation: u_x = x, u_y = y, u_z = z
+  //   div(u) = 3, ε_xx = ε_yy = ε_zz = 1, off-diag = 0
+  //   gradLambda = ∫ 3·3 dΩ = 9.0
+  //   2·ε†:ε = 2·(1+1+1) = 6
+  //   gradMu = ∫ 6 dΩ = 6.0
+  auto mesh = makeMesh1x1x1<TestFixture::kOrder>();
+  int const dim = TestFixture::kOrder + 1;
+  for (int k = 0; k < dim; ++k)
+    for (int j = 0; j < dim; ++j)
+      for (int i = 0; i < dim; ++i)
+      {
+        int gIdx = mesh.globalNodeIndex(0, i, j, k);
+        float x = static_cast<float>(i) / TestFixture::kOrder;
+        float y = static_cast<float>(j) / TestFixture::kOrder;
+        float z = static_cast<float>(k) / TestFixture::kOrder;
+        this->ux_fwd(gIdx) = x;
+        this->uy_fwd(gIdx) = y;
+        this->uz_fwd(gIdx) = z;
+        this->ux_adj(gIdx) = x;
+        this->uy_adj(gIdx) = y;
+        this->uz_adj(gIdx) = z;
+      }
+
+  typename TestFixture::Diff diff;
+
+  WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
+                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
+  GradientDataElastic data(fwd, bwd, grad);
+  diff.compute(mesh, data, 0.001f);
+
+  EXPECT_NEAR(this->gradLambda(0), 9.0f, 1.0f);
+  EXPECT_NEAR(this->gradMu(0), 6.0f, 1.0f);
+}
+
+TYPED_TEST(DifferentiatorElasticElemTest,
+           GradRhoIndependentOfStrainKernels)
+{
+  // gradRho depends only on dt2 and fwd, not on adjoint displacement gradients
+  // Set ux_fwd=1, ux_dt2=1 but also set non-trivial adjoint displacement
+  // => gradRho should still be 1.0
+  auto mesh = makeMesh1x1x1<TestFixture::kOrder>();
+  int const dim = TestFixture::kOrder + 1;
+  for (int k = 0; k < dim; ++k)
+    for (int j = 0; j < dim; ++j)
+      for (int i = 0; i < dim; ++i)
+      {
+        int gIdx = mesh.globalNodeIndex(0, i, j, k);
+        float x = static_cast<float>(i) / TestFixture::kOrder;
+        this->ux_fwd(gIdx) = 1.0f;
+        this->ux_dt2(gIdx) = 1.0f;
+        // Non-trivial adjoint displacement for strain kernels
+        this->ux_adj(gIdx) = x;
+        this->uy_adj(gIdx) = x;
+      }
+
+  typename TestFixture::Diff diff;
+
+  WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
+                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
+  GradientDataElastic data(fwd, bwd, grad);
+  diff.compute(mesh, data, 0.001f);
+
+  // gradRho only depends on dt2·fwd dot product: 1 * 1 * volume = 1.0
+  EXPECT_NEAR(this->gradRho(0), 1.0f, 1e-5f);
+}
+
+// --- Polymorphic interface ---
+
+TYPED_TEST(DifferentiatorElasticElemTest, PolymorphicInterface)
+{
+  for (int i = 0; i < TestFixture::kNumNodes; ++i)
+  {
+    this->ux_fwd(i) = 1.0f;
+    this->ux_dt2(i) = 1.0f;
+  }
+
+  std::unique_ptr<Differentiator> diff =
+      std::make_unique<typename TestFixture::Diff>();
+  auto mesh = makeMesh1x1x1<TestFixture::kOrder>();
+
+  EXPECT_EQ(diff->getOrder(), TestFixture::kOrder);
+  EXPECT_FALSE(diff->isModelOnNodes());
+
+  WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
+                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
+  GradientDataElastic data(fwd, bwd, grad);
+
+  EXPECT_NO_THROW(diff->compute(mesh, data, 0.001f));
+  EXPECT_GT(this->gradRho(0), 0.0f);
+}
+
+// =============================================================================
+// DifferentiatorElasticNodeTest  (IS_MODEL_ON_NODES = true)
+//
+// Mesh: 1 element, (ORDER+1)^3 nodes.
+// Gradients are node-indexed; contributions are scattered with ATOMICADD.
+// =============================================================================
+
+template <typename OrderWrapper>
+class DifferentiatorElasticNodeTest : public ::testing::Test
+{
+ protected:
+  static constexpr int kOrder = OrderWrapper::kOrder;
+  static constexpr int kNumNodes = (kOrder + 1) * (kOrder + 1) * (kOrder + 1);
+  static constexpr int kNumElements = 1;
+
+  using Mesh = model::ModelStruct<float, int, kOrder>;
+  using Integral =
+      typename IntegralTypeSelector<kOrder, IntegralType::MAKUTU>::type;
+  using DiffNode = DifferentiatorElastic<kOrder, Integral, Mesh, true>;
+  using DiffElem = DifferentiatorElastic<kOrder, Integral, Mesh, false>;
+
+  void SetUp() override
+  {
+    ux_fwd = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "ux_fwd");
+    uy_fwd = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uy_fwd");
+    uz_fwd = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uz_fwd");
+    ux_adj = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "ux_adj");
+    uy_adj = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uy_adj");
+    uz_adj = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uz_adj");
+    ux_dt2 = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "ux_dt2");
+    uy_dt2 = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uy_dt2");
+    uz_dt2 = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uz_dt2");
+    gradRho = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "gradRho");
+    gradLambda = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "gradLambda");
+    gradMu = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "gradMu");
+
+    for (int i = 0; i < kNumNodes; ++i)
+    {
+      ux_fwd(i) = 0.0f;
+      uy_fwd(i) = 0.0f;
+      uz_fwd(i) = 0.0f;
+      ux_adj(i) = 0.0f;
+      uy_adj(i) = 0.0f;
+      uz_adj(i) = 0.0f;
+      ux_dt2(i) = 0.0f;
+      uy_dt2(i) = 0.0f;
+      uz_dt2(i) = 0.0f;
+      gradRho(i) = 0.0f;
+      gradLambda(i) = 0.0f;
+      gradMu(i) = 0.0f;
+    }
+  }
+
+  float sumGrad(VECTOR_REAL_VIEW const& v) const
+  {
+    float s = 0.0f;
+    for (int i = 0; i < kNumNodes; ++i) s += v(i);
+    return s;
+  }
+
+  float sumGradRho() const { return sumGrad(gradRho); }
+  float sumGradLambda() const { return sumGrad(gradLambda); }
+  float sumGradMu() const { return sumGrad(gradMu); }
+
+  VECTOR_REAL_VIEW ux_fwd, uy_fwd, uz_fwd;
+  VECTOR_REAL_VIEW ux_adj, uy_adj, uz_adj;
+  VECTOR_REAL_VIEW ux_dt2, uy_dt2, uz_dt2;
+  VECTOR_REAL_VIEW gradRho, gradLambda, gradMu;
+};
+
+TYPED_TEST_SUITE(DifferentiatorElasticNodeTest, OrderTypes);
+
+// --- Static constants ---
+
+TYPED_TEST(DifferentiatorElasticNodeTest, IsModelOnNodesConstant)
+{
+  EXPECT_TRUE(TestFixture::DiffNode::kIsModelOnNodes);
+}
+
+// --- Virtual getters ---
+
+TYPED_TEST(DifferentiatorElasticNodeTest, GetOrderReturnsCorrectOrder)
+{
+  typename TestFixture::DiffNode diff;
+  EXPECT_EQ(diff.getOrder(), TestFixture::kOrder);
+}
+
+TYPED_TEST(DifferentiatorElasticNodeTest, IsModelOnNodesReturnsTrue)
+{
+  typename TestFixture::DiffNode diff;
+  EXPECT_TRUE(diff.isModelOnNodes());
+}
+
+// --- Print ---
+
+TYPED_TEST(DifferentiatorElasticNodeTest, PrintDoesNotThrow)
+{
+  typename TestFixture::DiffNode diff;
+  EXPECT_NO_THROW(diff.print());
+}
+
+// --- compute() correctness ---
+
+TYPED_TEST(DifferentiatorElasticNodeTest, ZeroWavefieldsYieldZeroGradients)
+{
+  typename TestFixture::DiffNode diff;
+  auto mesh = makeMesh1x1x1<TestFixture::kOrder>();
+
+  WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
+                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
+  GradientDataElastic data(fwd, bwd, grad);
+  diff.compute(mesh, data, 0.001f);
+
+  EXPECT_FLOAT_EQ(this->sumGradRho(), 0.0f);
+  EXPECT_FLOAT_EQ(this->sumGradLambda(), 0.0f);
+  EXPECT_FLOAT_EQ(this->sumGradMu(), 0.0f);
+}
+
+TYPED_TEST(DifferentiatorElasticNodeTest, UniformFieldGradRhoSumsToVolume)
+{
+  for (int i = 0; i < TestFixture::kNumNodes; ++i)
+  {
+    this->ux_fwd(i) = 1.0f;
+    this->ux_dt2(i) = 1.0f;
+  }
+
+  typename TestFixture::DiffNode diff;
+  auto mesh = makeMesh1x1x1<TestFixture::kOrder>();
+
+  WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
+                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
+  GradientDataElastic data(fwd, bwd, grad);
+  diff.compute(mesh, data, 0.001f);
+
+  EXPECT_NEAR(this->sumGradRho(), 1.0f, 1e-5f);
+}
+
+TYPED_TEST(DifferentiatorElasticNodeTest,
+           ConstantFieldGradLambdaSumsToZero)
+{
+  for (int i = 0; i < TestFixture::kNumNodes; ++i)
+  {
+    this->ux_fwd(i) = 1.0f;
+    this->ux_adj(i) = 1.0f;
+  }
+
+  typename TestFixture::DiffNode diff;
+  auto mesh = makeMesh1x1x1<TestFixture::kOrder>();
+
+  WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
+                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
+  GradientDataElastic data(fwd, bwd, grad);
+  diff.compute(mesh, data, 0.001f);
+
+  EXPECT_NEAR(this->sumGradLambda(), 0.0f, 1e-5f);
+}
+
+TYPED_TEST(DifferentiatorElasticNodeTest,
+           NodeBasedSumEqualsElementBasedResult)
+{
+  // For single-element mesh, ∑ node_gradients == elem_gradient
+  auto mesh = makeMesh1x1x1<TestFixture::kOrder>();
+  int const dim = TestFixture::kOrder + 1;
+  for (int k = 0; k < dim; ++k)
+    for (int j = 0; j < dim; ++j)
+      for (int i = 0; i < dim; ++i)
+      {
+        int gIdx = mesh.globalNodeIndex(0, i, j, k);
+        float x = static_cast<float>(i) / TestFixture::kOrder;
+        float y = static_cast<float>(j) / TestFixture::kOrder;
+        this->ux_fwd(gIdx) = x;
+        this->uy_fwd(gIdx) = y;
+        this->ux_adj(gIdx) = x;
+        this->uy_adj(gIdx) = y;
+        this->ux_dt2(gIdx) = 1.0f;
+      }
+
+  // Node-based
+  typename TestFixture::DiffNode diffNode;
+  {
+    WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
+    WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
+                                     this->ux_dt2, this->uy_dt2, this->uz_dt2);
+    GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
+    GradientDataElastic data(fwd, bwd, grad);
+    diffNode.compute(mesh, data, 0.001f);
+  }
+  float nodeRho = this->sumGradRho();
+  float nodeLambda = this->sumGradLambda();
+  float nodeMu = this->sumGradMu();
+
+  // Element-based
+  auto gradRhoElem = allocateVector<VECTOR_REAL_VIEW>(1, "gradRhoElem");
+  auto gradLambdaElem =
+      allocateVector<VECTOR_REAL_VIEW>(1, "gradLambdaElem");
+  auto gradMuElem = allocateVector<VECTOR_REAL_VIEW>(1, "gradMuElem");
+  gradRhoElem(0) = 0.0f;
+  gradLambdaElem(0) = 0.0f;
+  gradMuElem(0) = 0.0f;
+
+  typename TestFixture::DiffElem diffElem;
+  {
+    WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
+    WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
+                                     this->ux_dt2, this->uy_dt2, this->uz_dt2);
+    GradientElastic grad(gradRhoElem, gradLambdaElem, gradMuElem);
+    GradientDataElastic data(fwd, bwd, grad);
+    diffElem.compute(mesh, data, 0.001f);
+  }
+
+  EXPECT_NEAR(nodeRho, gradRhoElem(0), 1e-4f);
+  EXPECT_NEAR(nodeLambda, gradLambdaElem(0), 1e-4f);
+  EXPECT_NEAR(nodeMu, gradMuElem(0), 1e-4f);
+}
+
+// --- Polymorphic interface ---
+
+TYPED_TEST(DifferentiatorElasticNodeTest, PolymorphicInterface)
+{
+  for (int i = 0; i < TestFixture::kNumNodes; ++i)
+  {
+    this->ux_fwd(i) = 1.0f;
+    this->ux_dt2(i) = 1.0f;
+  }
+
+  std::unique_ptr<Differentiator> diff =
+      std::make_unique<typename TestFixture::DiffNode>();
+  auto mesh = makeMesh1x1x1<TestFixture::kOrder>();
+
+  EXPECT_EQ(diff->getOrder(), TestFixture::kOrder);
+  EXPECT_TRUE(diff->isModelOnNodes());
+
+  WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
+                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
+  GradientDataElastic data(fwd, bwd, grad);
+
+  EXPECT_NO_THROW(diff->compute(mesh, data, 0.001f));
+  EXPECT_GT(this->sumGradRho(), 0.0f);
+}
+
+}  // namespace test
+}  // namespace gradient

--- a/tests/units/gradient/impl/elastic/makutu/test_differentiator_elastic_makutu_unstruct.cc
+++ b/tests/units/gradient/impl/elastic/makutu/test_differentiator_elastic_makutu_unstruct.cc
@@ -1,0 +1,605 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <memory>
+
+#include "data_type.h"
+#include "differentiator_elastic.h"
+#include "differentiator_data_elastic.h"
+#include "fe/Integrals.hpp"
+#include "model_unstruct.h"
+
+namespace gradient
+{
+namespace test
+{
+
+// =============================================================================
+// Order wrappers
+// =============================================================================
+
+struct Order1U
+{
+  static constexpr int kOrder = 1;
+};
+struct Order2U
+{
+  static constexpr int kOrder = 2;
+};
+struct Order3U
+{
+  static constexpr int kOrder = 3;
+};
+
+using OrderTypesU = ::testing::Types<Order1U, Order2U, Order3U>;
+
+// =============================================================================
+// Helper: 1-element unstructured unit cube mesh [0,1]³
+// =============================================================================
+
+template <int ORDER>
+static model::ModelUnstruct<float, int> makeUnstructMesh1x1x1()
+{
+  constexpr int npe = (ORDER + 1) * (ORDER + 1) * (ORDER + 1);
+
+  model::ModelUnstructData<float, int> data;
+  data.order_ = ORDER;
+  data.n_element_ = 1;
+  data.n_node_ = npe;
+  data.lx_ = data.ly_ = data.lz_ = 1.0f;
+  data.isModelOnNodes_ = false;
+  data.isElastic_ = true;
+
+  data.global_node_index_ = allocateArray2D<ARRAY_INT_VIEW>(1, npe, "gni");
+  data.nodes_coords_x_ = allocateVector<VECTOR_REAL_VIEW>(npe, "cx");
+  data.nodes_coords_y_ = allocateVector<VECTOR_REAL_VIEW>(npe, "cy");
+  data.nodes_coords_z_ = allocateVector<VECTOR_REAL_VIEW>(npe, "cz");
+
+  for (int lDof = 0; lDof < npe; ++lDof)
+  {
+    data.global_node_index_(0, lDof) = lDof;
+
+    int k = lDof / ((ORDER + 1) * (ORDER + 1));
+    int j = (lDof / (ORDER + 1)) % (ORDER + 1);
+    int i = lDof % (ORDER + 1);
+
+    data.nodes_coords_x_[lDof] = static_cast<float>(i) / ORDER;
+    data.nodes_coords_y_[lDof] = static_cast<float>(j) / ORDER;
+    data.nodes_coords_z_[lDof] = static_cast<float>(k) / ORDER;
+  }
+
+  return model::ModelUnstruct<float, int>(data);
+}
+
+// =============================================================================
+// DifferentiatorElasticElemUnstructTest  (IS_MODEL_ON_NODES = false)
+// =============================================================================
+
+template <typename OrderWrapper>
+class DifferentiatorElasticElemUnstructTest : public ::testing::Test
+{
+ protected:
+  static constexpr int kOrder = OrderWrapper::kOrder;
+  static constexpr int kNumNodes = (kOrder + 1) * (kOrder + 1) * (kOrder + 1);
+  static constexpr int kNumElements = 1;
+
+  using Mesh = model::ModelUnstruct<float, int>;
+  using Integral =
+      typename IntegralTypeSelector<kOrder, IntegralType::MAKUTU>::type;
+  using Diff = DifferentiatorElastic<kOrder, Integral, Mesh, false>;
+
+  void SetUp() override
+  {
+    ux_fwd = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "ux_fwd");
+    uy_fwd = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uy_fwd");
+    uz_fwd = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uz_fwd");
+    ux_adj = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "ux_adj");
+    uy_adj = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uy_adj");
+    uz_adj = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uz_adj");
+    ux_dt2 = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "ux_dt2");
+    uy_dt2 = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uy_dt2");
+    uz_dt2 = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uz_dt2");
+    gradRho = allocateVector<VECTOR_REAL_VIEW>(kNumElements, "gradRho");
+    gradLambda = allocateVector<VECTOR_REAL_VIEW>(kNumElements, "gradLambda");
+    gradMu = allocateVector<VECTOR_REAL_VIEW>(kNumElements, "gradMu");
+
+    for (int i = 0; i < kNumNodes; ++i)
+    {
+      ux_fwd(i) = 0.0f;
+      uy_fwd(i) = 0.0f;
+      uz_fwd(i) = 0.0f;
+      ux_adj(i) = 0.0f;
+      uy_adj(i) = 0.0f;
+      uz_adj(i) = 0.0f;
+      ux_dt2(i) = 0.0f;
+      uy_dt2(i) = 0.0f;
+      uz_dt2(i) = 0.0f;
+    }
+    gradRho(0) = 0.0f;
+    gradLambda(0) = 0.0f;
+    gradMu(0) = 0.0f;
+  }
+
+  VECTOR_REAL_VIEW ux_fwd, uy_fwd, uz_fwd;
+  VECTOR_REAL_VIEW ux_adj, uy_adj, uz_adj;
+  VECTOR_REAL_VIEW ux_dt2, uy_dt2, uz_dt2;
+  VECTOR_REAL_VIEW gradRho, gradLambda, gradMu;
+};
+
+TYPED_TEST_SUITE(DifferentiatorElasticElemUnstructTest, OrderTypesU);
+
+// --- Static constants ---
+
+TYPED_TEST(DifferentiatorElasticElemUnstructTest, OrderConstant)
+{
+  EXPECT_EQ(TestFixture::Diff::kOrder, TestFixture::kOrder);
+}
+
+TYPED_TEST(DifferentiatorElasticElemUnstructTest, IsModelOnNodesConstant)
+{
+  EXPECT_FALSE(TestFixture::Diff::kIsModelOnNodes);
+}
+
+TYPED_TEST(DifferentiatorElasticElemUnstructTest, PointsPerElementConstant)
+{
+  EXPECT_EQ(TestFixture::Diff::kPointsPerElement, TestFixture::kNumNodes);
+}
+
+// --- Virtual getters ---
+
+TYPED_TEST(DifferentiatorElasticElemUnstructTest, GetOrderReturnsCorrectOrder)
+{
+  typename TestFixture::Diff diff;
+  EXPECT_EQ(diff.getOrder(), TestFixture::kOrder);
+}
+
+TYPED_TEST(DifferentiatorElasticElemUnstructTest, IsModelOnNodesReturnsFalse)
+{
+  typename TestFixture::Diff diff;
+  EXPECT_FALSE(diff.isModelOnNodes());
+}
+
+// --- Print ---
+
+TYPED_TEST(DifferentiatorElasticElemUnstructTest, PrintDoesNotThrow)
+{
+  typename TestFixture::Diff diff;
+  EXPECT_NO_THROW(diff.print());
+}
+
+// --- compute() correctness ---
+
+TYPED_TEST(DifferentiatorElasticElemUnstructTest,
+           ZeroWavefieldsYieldZeroGradients)
+{
+  typename TestFixture::Diff diff;
+  auto mesh = makeUnstructMesh1x1x1<TestFixture::kOrder>();
+
+  WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
+                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
+  GradientDataElastic data(fwd, bwd, grad);
+
+  diff.compute(mesh, data, 0.001f);
+
+  EXPECT_FLOAT_EQ(this->gradRho(0), 0.0f);
+  EXPECT_FLOAT_EQ(this->gradLambda(0), 0.0f);
+  EXPECT_FLOAT_EQ(this->gradMu(0), 0.0f);
+}
+
+TYPED_TEST(DifferentiatorElasticElemUnstructTest,
+           UniformFieldGradRhoEqualsVolume)
+{
+  for (int i = 0; i < TestFixture::kNumNodes; ++i)
+  {
+    this->ux_fwd(i) = 1.0f;
+    this->ux_dt2(i) = 1.0f;
+  }
+
+  typename TestFixture::Diff diff;
+  auto mesh = makeUnstructMesh1x1x1<TestFixture::kOrder>();
+
+  WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
+                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
+  GradientDataElastic data(fwd, bwd, grad);
+
+  diff.compute(mesh, data, 0.001f);
+
+  EXPECT_NEAR(this->gradRho(0), 1.0f, 1e-5f);
+}
+
+TYPED_TEST(DifferentiatorElasticElemUnstructTest,
+           ConstantFieldGradLambdaIsZero)
+{
+  for (int i = 0; i < TestFixture::kNumNodes; ++i)
+  {
+    this->ux_fwd(i) = 1.0f;
+    this->ux_adj(i) = 1.0f;
+  }
+
+  typename TestFixture::Diff diff;
+  auto mesh = makeUnstructMesh1x1x1<TestFixture::kOrder>();
+
+  WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
+                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
+  GradientDataElastic data(fwd, bwd, grad);
+
+  diff.compute(mesh, data, 0.001f);
+
+  EXPECT_NEAR(this->gradLambda(0), 0.0f, 1e-5f);
+}
+
+TYPED_TEST(DifferentiatorElasticElemUnstructTest,
+           ConstantFieldGradMuIsZero)
+{
+  for (int i = 0; i < TestFixture::kNumNodes; ++i)
+  {
+    this->ux_fwd(i) = 1.0f;
+    this->uy_fwd(i) = 1.0f;
+    this->uz_fwd(i) = 1.0f;
+    this->ux_adj(i) = 1.0f;
+    this->uy_adj(i) = 1.0f;
+    this->uz_adj(i) = 1.0f;
+  }
+
+  typename TestFixture::Diff diff;
+  auto mesh = makeUnstructMesh1x1x1<TestFixture::kOrder>();
+
+  WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
+                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
+  GradientDataElastic data(fwd, bwd, grad);
+
+  diff.compute(mesh, data, 0.001f);
+
+  EXPECT_NEAR(this->gradMu(0), 0.0f, 1e-5f);
+}
+
+TYPED_TEST(DifferentiatorElasticElemUnstructTest,
+           GradLambdaNonZeroForLinearField)
+{
+  // u_x = x => div(u) = 1 => gradLambda = ∫ 1 dΩ = 1.0
+  constexpr int dim = TestFixture::kOrder + 1;
+  for (int lDof = 0; lDof < TestFixture::kNumNodes; ++lDof)
+  {
+    int i = lDof % dim;
+    float x = static_cast<float>(i) / TestFixture::kOrder;
+    this->ux_fwd(lDof) = x;
+    this->ux_adj(lDof) = x;
+  }
+
+  typename TestFixture::Diff diff;
+  auto mesh = makeUnstructMesh1x1x1<TestFixture::kOrder>();
+
+  WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
+                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
+  GradientDataElastic data(fwd, bwd, grad);
+
+  diff.compute(mesh, data, 0.001f);
+
+  EXPECT_NEAR(this->gradLambda(0), 1.0f, 0.2f);
+}
+
+TYPED_TEST(DifferentiatorElasticElemUnstructTest,
+           GradMuNonZeroForLinearField)
+{
+  // u_x = x => ε_xx = 1 => 2·ε†:ε = 2 => gradMu = 2.0
+  constexpr int dim = TestFixture::kOrder + 1;
+  for (int lDof = 0; lDof < TestFixture::kNumNodes; ++lDof)
+  {
+    int i = lDof % dim;
+    float x = static_cast<float>(i) / TestFixture::kOrder;
+    this->ux_fwd(lDof) = x;
+    this->ux_adj(lDof) = x;
+  }
+
+  typename TestFixture::Diff diff;
+  auto mesh = makeUnstructMesh1x1x1<TestFixture::kOrder>();
+
+  WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
+                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
+  GradientDataElastic data(fwd, bwd, grad);
+
+  diff.compute(mesh, data, 0.001f);
+
+  EXPECT_NEAR(this->gradMu(0), 2.0f, 0.4f);
+}
+
+TYPED_TEST(DifferentiatorElasticElemUnstructTest,
+           PureDilatationLambdaMuConsistency)
+{
+  // u_x=x, u_y=y, u_z=z => div=3, ε_xx=ε_yy=ε_zz=1
+  // gradLambda = 9.0, gradMu = 6.0
+  constexpr int dim = TestFixture::kOrder + 1;
+  for (int lDof = 0; lDof < TestFixture::kNumNodes; ++lDof)
+  {
+    int k = lDof / (dim * dim);
+    int j = (lDof / dim) % dim;
+    int i = lDof % dim;
+    float x = static_cast<float>(i) / TestFixture::kOrder;
+    float y = static_cast<float>(j) / TestFixture::kOrder;
+    float z = static_cast<float>(k) / TestFixture::kOrder;
+    this->ux_fwd(lDof) = x;
+    this->uy_fwd(lDof) = y;
+    this->uz_fwd(lDof) = z;
+    this->ux_adj(lDof) = x;
+    this->uy_adj(lDof) = y;
+    this->uz_adj(lDof) = z;
+  }
+
+  typename TestFixture::Diff diff;
+  auto mesh = makeUnstructMesh1x1x1<TestFixture::kOrder>();
+
+  WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
+                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
+  GradientDataElastic data(fwd, bwd, grad);
+
+  diff.compute(mesh, data, 0.001f);
+
+  EXPECT_NEAR(this->gradLambda(0), 9.0f, 1.0f);
+  EXPECT_NEAR(this->gradMu(0), 6.0f, 1.0f);
+}
+
+TYPED_TEST(DifferentiatorElasticElemUnstructTest,
+           LinearShearFieldProducesCorrectGradMu)
+{
+  // Pure shear: u_x=y, u_y=x => div=0 => gradLambda=0
+  // ε_xy = 1 => 2·ε:ε = 4·(ε_xy²) = 4 => gradMu = 4.0
+  constexpr int dim = TestFixture::kOrder + 1;
+  for (int lDof = 0; lDof < TestFixture::kNumNodes; ++lDof)
+  {
+    int i = lDof % dim;
+    int j = (lDof / dim) % dim;
+    float x = static_cast<float>(i) / TestFixture::kOrder;
+    float y = static_cast<float>(j) / TestFixture::kOrder;
+    this->ux_fwd(lDof) = y;
+    this->uy_fwd(lDof) = x;
+    this->ux_adj(lDof) = y;
+    this->uy_adj(lDof) = x;
+  }
+
+  typename TestFixture::Diff diff;
+  auto mesh = makeUnstructMesh1x1x1<TestFixture::kOrder>();
+
+  WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
+                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
+  GradientDataElastic data(fwd, bwd, grad);
+
+  diff.compute(mesh, data, 0.001f);
+
+  EXPECT_NEAR(this->gradLambda(0), 0.0f, 1e-5f);
+  EXPECT_NEAR(this->gradMu(0), 4.0f, 0.4f);
+}
+
+TYPED_TEST(DifferentiatorElasticElemUnstructTest,
+           ComputeAccumulatesIntoExistingGradient)
+{
+  for (int i = 0; i < TestFixture::kNumNodes; ++i)
+  {
+    this->ux_fwd(i) = 1.0f;
+    this->ux_dt2(i) = 1.0f;
+  }
+  this->gradRho(0) = 5.0f;
+
+  typename TestFixture::Diff diff;
+  auto mesh = makeUnstructMesh1x1x1<TestFixture::kOrder>();
+
+  WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
+                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
+  GradientDataElastic data(fwd, bwd, grad);
+
+  diff.compute(mesh, data, 0.001f);
+
+  EXPECT_NEAR(this->gradRho(0), 6.0f, 1e-5f);
+}
+
+// --- Node-based unstructured ---
+
+template <typename OrderWrapper>
+class DifferentiatorElasticNodeUnstructTest : public ::testing::Test
+{
+ protected:
+  static constexpr int kOrder = OrderWrapper::kOrder;
+  static constexpr int kNumNodes = (kOrder + 1) * (kOrder + 1) * (kOrder + 1);
+
+  using Mesh = model::ModelUnstruct<float, int>;
+  using Integral =
+      typename IntegralTypeSelector<kOrder, IntegralType::MAKUTU>::type;
+  using DiffNode = DifferentiatorElastic<kOrder, Integral, Mesh, true>;
+  using DiffElem = DifferentiatorElastic<kOrder, Integral, Mesh, false>;
+
+  void SetUp() override
+  {
+    ux_fwd = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "ux_fwd");
+    uy_fwd = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uy_fwd");
+    uz_fwd = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uz_fwd");
+    ux_adj = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "ux_adj");
+    uy_adj = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uy_adj");
+    uz_adj = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uz_adj");
+    ux_dt2 = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "ux_dt2");
+    uy_dt2 = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uy_dt2");
+    uz_dt2 = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uz_dt2");
+    gradRho = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "gradRho");
+    gradLambda = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "gradLambda");
+    gradMu = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "gradMu");
+
+    for (int i = 0; i < kNumNodes; ++i)
+    {
+      ux_fwd(i) = 0.0f;
+      uy_fwd(i) = 0.0f;
+      uz_fwd(i) = 0.0f;
+      ux_adj(i) = 0.0f;
+      uy_adj(i) = 0.0f;
+      uz_adj(i) = 0.0f;
+      ux_dt2(i) = 0.0f;
+      uy_dt2(i) = 0.0f;
+      uz_dt2(i) = 0.0f;
+      gradRho(i) = 0.0f;
+      gradLambda(i) = 0.0f;
+      gradMu(i) = 0.0f;
+    }
+  }
+
+  float sumGrad(VECTOR_REAL_VIEW const& v) const
+  {
+    float s = 0.0f;
+    for (int i = 0; i < kNumNodes; ++i) s += v(i);
+    return s;
+  }
+
+  float sumGradRho() const { return sumGrad(gradRho); }
+  float sumGradLambda() const { return sumGrad(gradLambda); }
+  float sumGradMu() const { return sumGrad(gradMu); }
+
+  VECTOR_REAL_VIEW ux_fwd, uy_fwd, uz_fwd;
+  VECTOR_REAL_VIEW ux_adj, uy_adj, uz_adj;
+  VECTOR_REAL_VIEW ux_dt2, uy_dt2, uz_dt2;
+  VECTOR_REAL_VIEW gradRho, gradLambda, gradMu;
+};
+
+TYPED_TEST_SUITE(DifferentiatorElasticNodeUnstructTest, OrderTypesU);
+
+TYPED_TEST(DifferentiatorElasticNodeUnstructTest,
+           ZeroWavefieldsYieldZeroGradients)
+{
+  typename TestFixture::DiffNode diff;
+  auto mesh = makeUnstructMesh1x1x1<TestFixture::kOrder>();
+
+  WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
+                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
+  GradientDataElastic data(fwd, bwd, grad);
+
+  diff.compute(mesh, data, 0.001f);
+
+  EXPECT_FLOAT_EQ(this->sumGradRho(), 0.0f);
+  EXPECT_FLOAT_EQ(this->sumGradLambda(), 0.0f);
+  EXPECT_FLOAT_EQ(this->sumGradMu(), 0.0f);
+}
+
+TYPED_TEST(DifferentiatorElasticNodeUnstructTest,
+           UniformFieldGradRhoSumsToVolume)
+{
+  for (int i = 0; i < TestFixture::kNumNodes; ++i)
+  {
+    this->ux_fwd(i) = 1.0f;
+    this->ux_dt2(i) = 1.0f;
+  }
+
+  typename TestFixture::DiffNode diff;
+  auto mesh = makeUnstructMesh1x1x1<TestFixture::kOrder>();
+
+  WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
+                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
+  GradientDataElastic data(fwd, bwd, grad);
+
+  diff.compute(mesh, data, 0.001f);
+
+  EXPECT_NEAR(this->sumGradRho(), 1.0f, 1e-5f);
+}
+
+TYPED_TEST(DifferentiatorElasticNodeUnstructTest,
+           NodeBasedSumEqualsElementBasedResult)
+{
+  constexpr int dim = TestFixture::kOrder + 1;
+  for (int lDof = 0; lDof < TestFixture::kNumNodes; ++lDof)
+  {
+    int i = lDof % dim;
+    int j = (lDof / dim) % dim;
+    float x = static_cast<float>(i) / TestFixture::kOrder;
+    float y = static_cast<float>(j) / TestFixture::kOrder;
+    this->ux_fwd(lDof) = x;
+    this->uy_fwd(lDof) = y;
+    this->ux_adj(lDof) = x;
+    this->uy_adj(lDof) = y;
+    this->ux_dt2(lDof) = 1.0f;
+  }
+
+  auto mesh = makeUnstructMesh1x1x1<TestFixture::kOrder>();
+
+  // Node-based
+  typename TestFixture::DiffNode diffNode;
+  {
+    WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
+    WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
+                                     this->ux_dt2, this->uy_dt2, this->uz_dt2);
+    GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
+    GradientDataElastic data(fwd, bwd, grad);
+    diffNode.compute(mesh, data, 0.001f);
+  }
+  float nodeRho = this->sumGradRho();
+  float nodeLambda = this->sumGradLambda();
+  float nodeMu = this->sumGradMu();
+
+  // Element-based
+  auto gradRhoElem = allocateVector<VECTOR_REAL_VIEW>(1, "gradRhoElem");
+  auto gradLambdaElem =
+      allocateVector<VECTOR_REAL_VIEW>(1, "gradLambdaElem");
+  auto gradMuElem = allocateVector<VECTOR_REAL_VIEW>(1, "gradMuElem");
+  gradRhoElem(0) = 0.0f;
+  gradLambdaElem(0) = 0.0f;
+  gradMuElem(0) = 0.0f;
+
+  typename TestFixture::DiffElem diffElem;
+  {
+    WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
+    WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
+                                     this->ux_dt2, this->uy_dt2, this->uz_dt2);
+    GradientElastic grad(gradRhoElem, gradLambdaElem, gradMuElem);
+    GradientDataElastic data(fwd, bwd, grad);
+    diffElem.compute(mesh, data, 0.001f);
+  }
+
+  EXPECT_NEAR(nodeRho, gradRhoElem(0), 1e-4f);
+  EXPECT_NEAR(nodeLambda, gradLambdaElem(0), 1e-4f);
+  EXPECT_NEAR(nodeMu, gradMuElem(0), 1e-4f);
+}
+
+// --- Polymorphic interface ---
+
+TYPED_TEST(DifferentiatorElasticNodeUnstructTest, PolymorphicInterface)
+{
+  for (int i = 0; i < TestFixture::kNumNodes; ++i)
+  {
+    this->ux_fwd(i) = 1.0f;
+    this->ux_dt2(i) = 1.0f;
+  }
+
+  std::unique_ptr<Differentiator> diff =
+      std::make_unique<typename TestFixture::DiffNode>();
+  auto mesh = makeUnstructMesh1x1x1<TestFixture::kOrder>();
+
+  EXPECT_EQ(diff->getOrder(), TestFixture::kOrder);
+  EXPECT_TRUE(diff->isModelOnNodes());
+
+  WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
+                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
+  GradientDataElastic data(fwd, bwd, grad);
+
+  EXPECT_NO_THROW(diff->compute(mesh, data, 0.001f));
+  EXPECT_GT(this->sumGradRho(), 0.0f);
+}
+
+}  // namespace test
+}  // namespace gradient

--- a/tests/units/gradient/pywrap/test_differentiator_elastic_struct.py
+++ b/tests/units/gradient/pywrap/test_differentiator_elastic_struct.py
@@ -1,0 +1,93 @@
+import pyfuntides.gradient as Gradient
+import pyfuntides.model as Model
+import pyfuntides.solver as Solver
+import pytest
+import gradient_utils as Utils
+
+
+class StructData:
+    def __init__(self, order):
+        self.ex = self.ey = self.ez = 10
+        self.domain_size = 1500
+        self.hx = self.domain_size / self.ex
+        self.hy = self.domain_size / self.ey
+        self.hz = self.domain_size / self.ez
+        self.order = order
+        self.nx = self.ex * self.order + 1
+        self.ny = self.ey * self.order + 1
+        self.nz = self.ez * self.order + 1
+        self.n_dof = self.nx * self.ny * self.nz
+        self.n_elements = self.ex * self.ey * self.ez
+
+
+@pytest.fixture
+def struct(request):
+    order, builder_cls, on_nodes = request.param
+    sd = StructData(order)
+    builder = builder_cls(
+        sd.ex, sd.hx, sd.ey, sd.hy, sd.ez, sd.hz, on_nodes, True
+    )
+    return sd, builder, on_nodes
+
+
+test_cases = [
+    (1, Model.CartesianStructBuilder_f32_i32_O1, True),
+    (1, Model.CartesianStructBuilder_f32_i32_O1, False),
+    (2, Model.CartesianStructBuilder_f32_i32_O2, True),
+    (2, Model.CartesianStructBuilder_f32_i32_O2, False),
+    (3, Model.CartesianStructBuilder_f32_i32_O3, True),
+    (3, Model.CartesianStructBuilder_f32_i32_O3, False),
+]
+
+
+class TestDifferentiatorElasticStruct:
+    @pytest.mark.parametrize("struct", test_cases, indirect=True)
+    @pytest.mark.parametrize("implem", [Solver.ImplemType.MAKUTU])
+    def test_differentiator_compute(self, struct, implem):
+        sd, builder, is_model_on_nodes = struct
+        model = builder.get_model()
+
+        model_location = (
+            Solver.ModelLocationType.ONNODES
+            if is_model_on_nodes
+            else Solver.ModelLocationType.ONELEMENTS
+        )
+
+        differentiator = Gradient.create_differentiator(
+            implem,
+            Solver.MeshType.STRUCT,
+            model_location,
+            Solver.PhysicType.ELASTIC,
+            sd.order,
+        )
+
+        n_nodes = sd.n_dof
+        n_grad = sd.n_dof if is_model_on_nodes else sd.n_elements
+
+        kk_ux_fwd, _ = Utils.allocate_field(n_nodes)
+        kk_uy_fwd, _ = Utils.allocate_field(n_nodes)
+        kk_uz_fwd, _ = Utils.allocate_field(n_nodes)
+        kk_ux_adj, _ = Utils.allocate_field(n_nodes)
+        kk_uy_adj, _ = Utils.allocate_field(n_nodes)
+        kk_uz_adj, _ = Utils.allocate_field(n_nodes)
+        kk_ux_dt2, _ = Utils.allocate_field(n_nodes)
+        kk_uy_dt2, _ = Utils.allocate_field(n_nodes)
+        kk_uz_dt2, _ = Utils.allocate_field(n_nodes)
+        kk_grad_rho, _ = Utils.allocate_field(n_grad)
+        kk_grad_lambda, _ = Utils.allocate_field(n_grad)
+        kk_grad_mu, _ = Utils.allocate_field(n_grad)
+
+        dt = 0.001
+        fwd = Gradient.WavefieldViewForwardElastic(
+            kk_ux_fwd, kk_uy_fwd, kk_uz_fwd
+        )
+        bwd = Gradient.WavefieldViewBackwardElastic(
+            kk_ux_adj, kk_uy_adj, kk_uz_adj,
+            kk_ux_dt2, kk_uy_dt2, kk_uz_dt2,
+        )
+        grad = Gradient.GradientElastic(
+            kk_grad_rho, kk_grad_lambda, kk_grad_mu
+        )
+        data = Gradient.GradientDataElastic(fwd, bwd, grad)
+
+        differentiator.compute(model, data, dt)

--- a/tests/units/gradient/pywrap/test_differentiator_elastic_unstruct.py
+++ b/tests/units/gradient/pywrap/test_differentiator_elastic_unstruct.py
@@ -1,0 +1,94 @@
+import pyfuntides.gradient as Gradient
+import pyfuntides.model as Model
+import pyfuntides.solver as Solver
+import pytest
+import gradient_utils as Utils
+
+
+class UnstructData:
+    def __init__(self, order):
+        self.ex = self.ey = self.ez = 10
+        self.lx = self.ly = self.lz = 1500
+        self.order = order
+        self.nx = self.ex * self.order + 1
+        self.ny = self.ey * self.order + 1
+        self.nz = self.ez * self.order + 1
+        self.n_dof = self.nx * self.ny * self.nz
+        self.n_elements = self.ex * self.ey * self.ez
+
+
+@pytest.fixture
+def unstruct(request):
+    order, param_cls, builder_cls, on_nodes = request.param
+    sd = UnstructData(order)
+    params = param_cls()
+    params.ex, params.ey, params.ez = sd.ex, sd.ey, sd.ez
+    params.lx, params.ly, params.lz = sd.lx, sd.ly, sd.lz
+    params.order = order
+    params.is_model_on_nodes = on_nodes
+    params.is_elastic = True
+    builder = builder_cls(params)
+    return sd, builder, on_nodes
+
+
+test_cases = [
+    (1, Model.CartesianParams_f32_i32, Model.CartesianUnstructBuilder_f32_i32, True),
+    (1, Model.CartesianParams_f32_i32, Model.CartesianUnstructBuilder_f32_i32, False),
+    (2, Model.CartesianParams_f32_i32, Model.CartesianUnstructBuilder_f32_i32, True),
+    (2, Model.CartesianParams_f32_i32, Model.CartesianUnstructBuilder_f32_i32, False),
+    (3, Model.CartesianParams_f32_i32, Model.CartesianUnstructBuilder_f32_i32, True),
+    (3, Model.CartesianParams_f32_i32, Model.CartesianUnstructBuilder_f32_i32, False),
+]
+
+
+class TestDifferentiatorElasticUnstruct:
+    @pytest.mark.parametrize("unstruct", test_cases, indirect=True)
+    @pytest.mark.parametrize("implem", [Solver.ImplemType.MAKUTU])
+    def test_differentiator_compute(self, unstruct, implem):
+        sd, builder, is_model_on_nodes = unstruct
+        model = builder.get_model()
+
+        model_location = (
+            Solver.ModelLocationType.ONNODES
+            if is_model_on_nodes
+            else Solver.ModelLocationType.ONELEMENTS
+        )
+
+        differentiator = Gradient.create_differentiator(
+            implem,
+            Solver.MeshType.UNSTRUCT,
+            model_location,
+            Solver.PhysicType.ELASTIC,
+            sd.order,
+        )
+
+        n_nodes = sd.n_dof
+        n_grad = sd.n_dof if is_model_on_nodes else sd.n_elements
+
+        kk_ux_fwd, _ = Utils.allocate_field(n_nodes)
+        kk_uy_fwd, _ = Utils.allocate_field(n_nodes)
+        kk_uz_fwd, _ = Utils.allocate_field(n_nodes)
+        kk_ux_adj, _ = Utils.allocate_field(n_nodes)
+        kk_uy_adj, _ = Utils.allocate_field(n_nodes)
+        kk_uz_adj, _ = Utils.allocate_field(n_nodes)
+        kk_ux_dt2, _ = Utils.allocate_field(n_nodes)
+        kk_uy_dt2, _ = Utils.allocate_field(n_nodes)
+        kk_uz_dt2, _ = Utils.allocate_field(n_nodes)
+        kk_grad_rho, _ = Utils.allocate_field(n_grad)
+        kk_grad_lambda, _ = Utils.allocate_field(n_grad)
+        kk_grad_mu, _ = Utils.allocate_field(n_grad)
+
+        dt = 0.001
+        fwd = Gradient.WavefieldViewForwardElastic(
+            kk_ux_fwd, kk_uy_fwd, kk_uz_fwd
+        )
+        bwd = Gradient.WavefieldViewBackwardElastic(
+            kk_ux_adj, kk_uy_adj, kk_uz_adj,
+            kk_ux_dt2, kk_uy_dt2, kk_uz_dt2,
+        )
+        grad = Gradient.GradientElastic(
+            kk_grad_rho, kk_grad_lambda, kk_grad_mu
+        )
+        data = Gradient.GradientDataElastic(fwd, bwd, grad)
+
+        differentiator.compute(model, data, dt)


### PR DESCRIPTION
## Summary

Implement the elastic gradient computation in `DifferentiatorElastic` for both isotropic and TTI media.

## Changes

- **`src/gradient/impl/elastic/include/differentiator_elastic.h`**: Full implementation of `compute()` method replacing the previous stub.

## Implementation Details

The elastic gradient computes three sensitivities using a **two-pass approach**:

### Pass 1: Strain interactions (`computeStiffNessTermwithJac`)
Computes physical-space displacement gradients from J⁻¹ and accumulates:
- `strainDiv[q]` = div(u†) · div(u) — for lambda kernel
- `strainEps[q]` = 2·ε(u†):ε(u) — for mu kernel

### Pass 2: Quadrature weighting (`computeMassTerm`)
Weights strain interactions by w·|detJ| and accumulates:
- **gradRho**: ∫ ü† · u dΩ (density kernel via mass term)
- **gradLambda**: ∫ div(u†) · div(u) dΩ (P-wave kernel)
- **gradMu**: ∫ 2·ε(u†):ε(u) dΩ (S-wave kernel)

### Key design decisions
- Uses `computeDisplacementGradient()` helper to avoid code duplication between `computeOnElements` and `computeOnNodes`
- Element-based model: direct accumulation (no atomics)
- Node-based model: uses `ATOMICADD` for shared boundary nodes
- Both isotropic and TTI are handled via Lamé parameter gradients (λ, μ)