### PR TITLE
fix GPU build

### DIFF
--- a/src/gradient/impl/acoustic/include/differentiator_acoustic.h
+++ b/src/gradient/impl/acoustic/include/differentiator_acoustic.h
@@ -85,7 +85,6 @@ class DifferentiatorAcoustic : public Differentiator
               << ">\n";
   }
 
- private:
   /**
    * @brief Each element writes to a unique index — no atomic add required.
    *


### PR DESCRIPTION
bug following #278 

nvcc: error: The enclosing parent function ("computeOnElements") for an extended __host__ __device__ lambda cannot have private or protected access within its class                           ( const int elementNumber) {