### PR TITLE
Shake shake, python is not shaking

### DIFF
--- a/src/solver/fe/impl/acoustic/include/wavefield_acoustic.h
+++ b/src/solver/fe/impl/acoustic/include/wavefield_acoustic.h
@@ -22,7 +22,10 @@ struct WavefieldAcoustic : public Wavefield
 
   WavefieldAcoustic(VECTOR_REAL_VIEW pnGlobalPrev,
                     VECTOR_REAL_VIEW pnGlobalCurr)
-      : m_pnGlobalPrev(pnGlobalPrev), m_pnGlobalCurr(pnGlobalCurr)
+      : m_pnGlobalField0(pnGlobalPrev),
+        m_pnGlobalField1(pnGlobalCurr),
+        m_pnGlobalPrev(&m_pnGlobalField0),
+        m_pnGlobalCurr(&m_pnGlobalField1)
   {
   }
 
@@ -36,35 +39,37 @@ struct WavefieldAcoustic : public Wavefield
   PROXY_HOST_DEVICE
   VECTOR_REAL_VIEW getCurrentField(int i) const override
   {
-    return m_pnGlobalCurr;
+    return *m_pnGlobalCurr;
   }
 
   PROXY_HOST_DEVICE
   VECTOR_REAL_VIEW getPreviousField(int i) const override
   {
-    return m_pnGlobalPrev;
+    return *m_pnGlobalPrev;
   }
 
-  void swap() override { std::swap(m_pnGlobalPrev, m_pnGlobalCurr); }
+  void swap() override { std::swap(*m_pnGlobalPrev, *m_pnGlobalCurr); }
 
   void swapWithRotation(VECTOR_REAL_VIEW& prevPrevBuffer, int i) override
   {
     VECTOR_REAL_VIEW tmp = prevPrevBuffer;
-    prevPrevBuffer       = m_pnGlobalPrev;
-    m_pnGlobalPrev       = m_pnGlobalCurr;
-    m_pnGlobalCurr       = tmp;
+    prevPrevBuffer       = *m_pnGlobalPrev;
+    *m_pnGlobalPrev      = *m_pnGlobalCurr;
+    *m_pnGlobalCurr      = tmp;
   }
 
   void print() const override
   {
-    std::cout << "Pn Global Prev size: " << m_pnGlobalPrev.extent(0)
+    std::cout << "Pn Global Prev size: " << m_pnGlobalPrev->extent(0)
               << std::endl;
-    std::cout << "Pn Global Curr size: " << m_pnGlobalCurr.extent(0)
+    std::cout << "Pn Global Curr size: " << m_pnGlobalCurr->extent(0)
               << std::endl;
   }
 
-  VECTOR_REAL_VIEW m_pnGlobalPrev;  ///< Pressure field at previous time step
-  VECTOR_REAL_VIEW m_pnGlobalCurr;  ///< Pressure field at current time step
+  VECTOR_REAL_VIEW m_pnGlobalField0;        ///< Storage for pressure field 0
+  VECTOR_REAL_VIEW m_pnGlobalField1;        ///< Storage for pressure field 1
+  VECTOR_REAL_VIEW* m_pnGlobalPrev;         ///< Pointer to previous field
+  VECTOR_REAL_VIEW* m_pnGlobalCurr;         ///< Pointer to current field
 };
 }  // namespace fe
 }  // namespace solver

--- a/src/solver/fe/impl/elastic/include/wavefield_elastic.h
+++ b/src/solver/fe/impl/elastic/include/wavefield_elastic.h
@@ -25,12 +25,18 @@ struct WavefieldElastic : public Wavefield
                    VECTOR_REAL_VIEW uynGlobalCurr,
                    VECTOR_REAL_VIEW uznGlobalPrev,
                    VECTOR_REAL_VIEW uznGlobalCurr)
-      : m_uxnGlobalPrev(uxnGlobalPrev),
-        m_uxnGlobalCurr(uxnGlobalCurr),
-        m_uynGlobalPrev(uynGlobalPrev),
-        m_uynGlobalCurr(uynGlobalCurr),
-        m_uznGlobalPrev(uznGlobalPrev),
-        m_uznGlobalCurr(uznGlobalCurr)
+      : m_uxnGlobalField0(uxnGlobalPrev),
+        m_uxnGlobalField1(uxnGlobalCurr),
+        m_uynGlobalField0(uynGlobalPrev),
+        m_uynGlobalField1(uynGlobalCurr),
+        m_uznGlobalField0(uznGlobalPrev),
+        m_uznGlobalField1(uznGlobalCurr),
+        m_uxnGlobalPrev(&m_uxnGlobalField0),
+        m_uxnGlobalCurr(&m_uxnGlobalField1),
+        m_uynGlobalPrev(&m_uynGlobalField0),
+        m_uynGlobalCurr(&m_uynGlobalField1),
+        m_uznGlobalPrev(&m_uznGlobalField0),
+        m_uznGlobalCurr(&m_uznGlobalField1)
   {
   }
 
@@ -48,13 +54,13 @@ struct WavefieldElastic : public Wavefield
     switch (i)
     {
       case 0:
-        return m_uxnGlobalCurr;
+        return *m_uxnGlobalCurr;
       case 1:
-        return m_uynGlobalCurr;
+        return *m_uynGlobalCurr;
       case 2:
-        return m_uznGlobalCurr;
+        return *m_uznGlobalCurr;
       default:
-        return m_uxnGlobalCurr;  // make it cuda happy
+        return *m_uxnGlobalCurr;  // make it cuda happy
     }
   }
 
@@ -65,21 +71,21 @@ struct WavefieldElastic : public Wavefield
     switch (i)
     {
       case 0:
-        return m_uxnGlobalPrev;
+        return *m_uxnGlobalPrev;
       case 1:
-        return m_uynGlobalPrev;
+        return *m_uynGlobalPrev;
       case 2:
-        return m_uznGlobalPrev;
+        return *m_uznGlobalPrev;
       default:
-        return m_uxnGlobalCurr;  // make it cuda happy
+        return *m_uxnGlobalCurr;  // make it cuda happy
     }
   }
 
   void swap() override
   {
-    std::swap(m_uxnGlobalPrev, m_uxnGlobalCurr);
-    std::swap(m_uynGlobalPrev, m_uynGlobalCurr);
-    std::swap(m_uznGlobalPrev, m_uznGlobalCurr);
+    std::swap(*m_uxnGlobalPrev, *m_uxnGlobalCurr);
+    std::swap(*m_uynGlobalPrev, *m_uynGlobalCurr);
+    std::swap(*m_uznGlobalPrev, *m_uznGlobalCurr);
   }
 
   // NOTE: elastic has 3 components — the caller must manage one extra buffer per
@@ -91,19 +97,19 @@ struct WavefieldElastic : public Wavefield
     switch (i)
     {
       case 0:  // ux component
-        prevPrevBuffer  = m_uxnGlobalPrev;
-        m_uxnGlobalPrev = m_uxnGlobalCurr;
-        m_uxnGlobalCurr = tmp;
+        prevPrevBuffer  = *m_uxnGlobalPrev;
+        *m_uxnGlobalPrev = *m_uxnGlobalCurr;
+        *m_uxnGlobalCurr = tmp;
         break;
       case 1:  // uy component
-        prevPrevBuffer  = m_uynGlobalPrev;
-        m_uynGlobalPrev = m_uynGlobalCurr;
-        m_uynGlobalCurr = tmp;
+        prevPrevBuffer  = *m_uynGlobalPrev;
+        *m_uynGlobalPrev = *m_uynGlobalCurr;
+        *m_uynGlobalCurr = tmp;
         break;
       case 2:  // uz component
-        prevPrevBuffer  = m_uznGlobalPrev;
-        m_uznGlobalPrev = m_uznGlobalCurr;
-        m_uznGlobalCurr = tmp;
+        prevPrevBuffer  = *m_uznGlobalPrev;
+        *m_uznGlobalPrev = *m_uznGlobalCurr;
+        *m_uznGlobalCurr = tmp;
         break;
       default:
         // Invalid field index - no-op to make CUDA happy
@@ -113,32 +119,35 @@ struct WavefieldElastic : public Wavefield
 
   void print() const override
   {
-    std::cout << "Ux Global Prev size: " << m_uxnGlobalPrev.extent(0)
+    std::cout << "Ux Global Prev size: " << m_uxnGlobalPrev->extent(0)
               << std::endl;
-    std::cout << "Ux Global Curr size: " << m_uxnGlobalCurr.extent(0)
+    std::cout << "Ux Global Curr size: " << m_uxnGlobalCurr->extent(0)
               << std::endl;
-    std::cout << "Uy Global Prev size: " << m_uynGlobalPrev.extent(0)
+    std::cout << "Uy Global Prev size: " << m_uynGlobalPrev->extent(0)
               << std::endl;
-    std::cout << "Uy Global Curr size: " << m_uynGlobalCurr.extent(0)
+    std::cout << "Uy Global Curr size: " << m_uynGlobalCurr->extent(0)
               << std::endl;
-    std::cout << "Uz Global Prev size: " << m_uznGlobalPrev.extent(0)
+    std::cout << "Uz Global Prev size: " << m_uznGlobalPrev->extent(0)
               << std::endl;
-    std::cout << "Uz Global Curr size: " << m_uznGlobalCurr.extent(0)
+    std::cout << "Uz Global Curr size: " << m_uznGlobalCurr->extent(0)
               << std::endl;
   }
 
-  VECTOR_REAL_VIEW
-  m_uxnGlobalPrev;  ///< Displacement field in x at previous time step
-  VECTOR_REAL_VIEW
-  m_uxnGlobalCurr;  ///< Displacement field in x at current time step
-  VECTOR_REAL_VIEW
-  m_uynGlobalPrev;  ///< Displacement field in y at previous time step
-  VECTOR_REAL_VIEW
-  m_uynGlobalCurr;  ///< Displacement field in y at current time step
-  VECTOR_REAL_VIEW
-  m_uznGlobalPrev;  ///< Displacement field in z at previous time step
-  VECTOR_REAL_VIEW
-  m_uznGlobalCurr;  ///< Displacement field in z at current time step
+  // Storage for each component
+  VECTOR_REAL_VIEW m_uxnGlobalField0;  ///< Storage for ux field 0
+  VECTOR_REAL_VIEW m_uxnGlobalField1;  ///< Storage for ux field 1
+  VECTOR_REAL_VIEW m_uynGlobalField0;  ///< Storage for uy field 0
+  VECTOR_REAL_VIEW m_uynGlobalField1;  ///< Storage for uy field 1
+  VECTOR_REAL_VIEW m_uznGlobalField0;  ///< Storage for uz field 0
+  VECTOR_REAL_VIEW m_uznGlobalField1;  ///< Storage for uz field 1
+  
+  // Pointers to current/previous fields for each component
+  VECTOR_REAL_VIEW* m_uxnGlobalPrev;  ///< Pointer to ux at previous time step
+  VECTOR_REAL_VIEW* m_uxnGlobalCurr;  ///< Pointer to ux at current time step
+  VECTOR_REAL_VIEW* m_uynGlobalPrev;  ///< Pointer to uy at previous time step
+  VECTOR_REAL_VIEW* m_uynGlobalCurr;  ///< Pointer to uy at current time step
+  VECTOR_REAL_VIEW* m_uznGlobalPrev;  ///< Pointer to uz at previous time step
+  VECTOR_REAL_VIEW* m_uznGlobalCurr;  ///< Pointer to uz at current time step
 };
 }  // namespace fe
 }  // namespace solver

--- a/tests/units/solver/impl/test_wavefield_acoustic.cc
+++ b/tests/units/solver/impl/test_wavefield_acoustic.cc
@@ -51,14 +51,14 @@ TEST_F(WavefieldAcousticTest, Constructor)
 {
   WavefieldAcoustic wavefield(prevField, currField);
 
-  EXPECT_EQ(wavefield.m_pnGlobalPrev.extent(0), size1);
-  EXPECT_EQ(wavefield.m_pnGlobalCurr.extent(0), size1);
+  EXPECT_EQ(wavefield.m_pnGlobalPrev->extent(0), size1);
+  EXPECT_EQ(wavefield.m_pnGlobalCurr->extent(0), size1);
 
   // Verify data is correctly stored
   for (size_t i = 0; i < size1; ++i)
   {
-    EXPECT_FLOAT_EQ(wavefield.m_pnGlobalPrev(i), i);
-    EXPECT_FLOAT_EQ(wavefield.m_pnGlobalCurr(i), i * 2);
+    EXPECT_FLOAT_EQ((*wavefield.m_pnGlobalPrev)(i), i);
+    EXPECT_FLOAT_EQ((*wavefield.m_pnGlobalCurr)(i), i * 2);
   }
 }
 
@@ -68,22 +68,22 @@ TEST_F(WavefieldAcousticTest, CopyConstructor)
   WavefieldAcoustic copy(original);
 
   // Check that copy has the same extent
-  EXPECT_EQ(copy.m_pnGlobalPrev.extent(0), original.m_pnGlobalPrev.extent(0));
-  EXPECT_EQ(copy.m_pnGlobalCurr.extent(0), original.m_pnGlobalCurr.extent(0));
+  EXPECT_EQ(copy.m_pnGlobalPrev->extent(0), original.m_pnGlobalPrev->extent(0));
+  EXPECT_EQ(copy.m_pnGlobalCurr->extent(0), original.m_pnGlobalCurr->extent(0));
 
   // Check that copy has the same data
   for (size_t i = 0; i < size1; ++i)
   {
-    EXPECT_FLOAT_EQ(copy.m_pnGlobalPrev(i), original.m_pnGlobalPrev(i));
-    EXPECT_FLOAT_EQ(copy.m_pnGlobalCurr(i), original.m_pnGlobalCurr(i));
+    EXPECT_FLOAT_EQ((*copy.m_pnGlobalPrev)(i), (*original.m_pnGlobalPrev)(i));
+    EXPECT_FLOAT_EQ((*copy.m_pnGlobalCurr)(i), (*original.m_pnGlobalCurr)(i));
   }
 
   // Modify original data to verify shallow copy behavior (Kokkos views are
   // shallow by default)
-  original.m_pnGlobalPrev(0) = 999.0f;
-  EXPECT_FLOAT_EQ(copy.m_pnGlobalPrev(0), 999.0f);
-  original.m_pnGlobalCurr(0) = 888.0f;
-  EXPECT_FLOAT_EQ(copy.m_pnGlobalCurr(0), 888.0f);
+  (*original.m_pnGlobalPrev)(0) = 999.0f;
+  EXPECT_FLOAT_EQ((*copy.m_pnGlobalPrev)(0), 999.0f);
+  (*original.m_pnGlobalCurr)(0) = 888.0f;
+  EXPECT_FLOAT_EQ((*copy.m_pnGlobalCurr)(0), 888.0f);
 }
 
 TEST_F(WavefieldAcousticTest, CopyAssignmentOperator)
@@ -92,29 +92,29 @@ TEST_F(WavefieldAcousticTest, CopyAssignmentOperator)
   WavefieldAcoustic wavefield2(prevField2, currField2);
 
   // Verify initial state
-  EXPECT_EQ(wavefield2.m_pnGlobalPrev.extent(0), size2);
-  EXPECT_EQ(wavefield2.m_pnGlobalCurr.extent(0), size2);
+  EXPECT_EQ(wavefield2.m_pnGlobalPrev->extent(0), size2);
+  EXPECT_EQ(wavefield2.m_pnGlobalCurr->extent(0), size2);
 
   // Perform assignment
   wavefield2 = wavefield1;
 
   // Check that wavefield2 now has the same extent as wavefield1
-  EXPECT_EQ(wavefield2.m_pnGlobalPrev.extent(0), size1);
-  EXPECT_EQ(wavefield2.m_pnGlobalCurr.extent(0), size1);
+  EXPECT_EQ(wavefield2.m_pnGlobalPrev->extent(0), size1);
+  EXPECT_EQ(wavefield2.m_pnGlobalCurr->extent(0), size1);
 
   // Check that data matches
   for (size_t i = 0; i < size1; ++i)
   {
-    EXPECT_FLOAT_EQ(wavefield2.m_pnGlobalPrev(i), wavefield1.m_pnGlobalPrev(i));
-    EXPECT_FLOAT_EQ(wavefield2.m_pnGlobalCurr(i), wavefield1.m_pnGlobalCurr(i));
+    EXPECT_FLOAT_EQ((*wavefield2.m_pnGlobalPrev)(i), (*wavefield1.m_pnGlobalPrev)(i));
+    EXPECT_FLOAT_EQ((*wavefield2.m_pnGlobalCurr)(i), (*wavefield1.m_pnGlobalCurr)(i));
   }
 
   // Modify original data to verify shallow copy behavior (Kokkos views are
   // shallow by default)
-  wavefield1.m_pnGlobalPrev(0) = 777.0f;
-  EXPECT_FLOAT_EQ(wavefield2.m_pnGlobalPrev(0), 777.0f);
-  wavefield1.m_pnGlobalCurr(0) = 666.0f;
-  EXPECT_FLOAT_EQ(wavefield2.m_pnGlobalCurr(0), 666.0f);
+  (*wavefield1.m_pnGlobalPrev)(0) = 777.0f;
+  EXPECT_FLOAT_EQ((*wavefield2.m_pnGlobalPrev)(0), 777.0f);
+  (*wavefield1.m_pnGlobalCurr)(0) = 666.0f;
+  EXPECT_FLOAT_EQ((*wavefield2.m_pnGlobalCurr)(0), 666.0f);
 }
 
 TEST_F(WavefieldAcousticTest, CopyAssignmentSelfAssignment)
@@ -125,13 +125,13 @@ TEST_F(WavefieldAcousticTest, CopyAssignmentSelfAssignment)
   wavefield = wavefield;
 
   // Verify data is unchanged
-  EXPECT_EQ(wavefield.m_pnGlobalPrev.extent(0), size1);
-  EXPECT_EQ(wavefield.m_pnGlobalCurr.extent(0), size1);
+  EXPECT_EQ(wavefield.m_pnGlobalPrev->extent(0), size1);
+  EXPECT_EQ(wavefield.m_pnGlobalCurr->extent(0), size1);
 
   for (size_t i = 0; i < size1; ++i)
   {
-    EXPECT_FLOAT_EQ(wavefield.m_pnGlobalPrev(i), i);
-    EXPECT_FLOAT_EQ(wavefield.m_pnGlobalCurr(i), i * 2);
+    EXPECT_FLOAT_EQ((*wavefield.m_pnGlobalPrev)(i), i);
+    EXPECT_FLOAT_EQ((*wavefield.m_pnGlobalCurr)(i), i * 2);
   }
 }
 
@@ -166,21 +166,21 @@ TEST_F(WavefieldAcousticTest, Swap)
   WavefieldAcoustic wavefield(prevField, currField);
 
   // Store original values
-  float originalPrev0 = wavefield.m_pnGlobalPrev(0);
-  float originalCurr0 = wavefield.m_pnGlobalCurr(0);
+  float originalPrev0 = (*wavefield.m_pnGlobalPrev)(0);
+  float originalCurr0 = (*wavefield.m_pnGlobalCurr)(0);
 
   // Perform swap
   wavefield.swap();
 
   // Verify that prev and curr have been swapped
-  EXPECT_FLOAT_EQ(wavefield.m_pnGlobalPrev(0), originalCurr0);
-  EXPECT_FLOAT_EQ(wavefield.m_pnGlobalCurr(0), originalPrev0);
+  EXPECT_FLOAT_EQ((*wavefield.m_pnGlobalPrev)(0), originalCurr0);
+  EXPECT_FLOAT_EQ((*wavefield.m_pnGlobalCurr)(0), originalPrev0);
 
   // Verify all elements were swapped
   for (size_t i = 0; i < size1; ++i)
   {
-    EXPECT_FLOAT_EQ(wavefield.m_pnGlobalPrev(i), i * 2);
-    EXPECT_FLOAT_EQ(wavefield.m_pnGlobalCurr(i), i);
+    EXPECT_FLOAT_EQ((*wavefield.m_pnGlobalPrev)(i), i * 2);
+    EXPECT_FLOAT_EQ((*wavefield.m_pnGlobalCurr)(i), i);
   }
 }
 
@@ -193,8 +193,8 @@ TEST_F(WavefieldAcousticTest, SwapTwice)
   std::vector<float> originalCurr(size1);
   for (size_t i = 0; i < size1; ++i)
   {
-    originalPrev[i] = wavefield.m_pnGlobalPrev(i);
-    originalCurr[i] = wavefield.m_pnGlobalCurr(i);
+    originalPrev[i] = (*wavefield.m_pnGlobalPrev)(i);
+    originalCurr[i] = (*wavefield.m_pnGlobalCurr)(i);
   }
 
   // Swap twice should restore original state
@@ -204,8 +204,8 @@ TEST_F(WavefieldAcousticTest, SwapTwice)
   // Verify restoration
   for (size_t i = 0; i < size1; ++i)
   {
-    EXPECT_FLOAT_EQ(wavefield.m_pnGlobalPrev(i), originalPrev[i]);
-    EXPECT_FLOAT_EQ(wavefield.m_pnGlobalCurr(i), originalCurr[i]);
+    EXPECT_FLOAT_EQ((*wavefield.m_pnGlobalPrev)(i), originalPrev[i]);
+    EXPECT_FLOAT_EQ((*wavefield.m_pnGlobalCurr)(i), originalCurr[i]);
   }
 }
 
@@ -214,14 +214,14 @@ TEST_F(WavefieldAcousticTest, SwapWithModification)
   WavefieldAcoustic wavefield(prevField, currField);
 
   // Modify current field
-  wavefield.m_pnGlobalCurr(5) = 123.456f;
+  (*wavefield.m_pnGlobalCurr)(5) = 123.456f;
 
   // Swap
   wavefield.swap();
 
   // The modified value should now be in the previous field
-  EXPECT_FLOAT_EQ(wavefield.m_pnGlobalPrev(5), 123.456f);
-  EXPECT_FLOAT_EQ(wavefield.m_pnGlobalCurr(5), 5.0f);
+  EXPECT_FLOAT_EQ((*wavefield.m_pnGlobalPrev)(5), 123.456f);
+  EXPECT_FLOAT_EQ((*wavefield.m_pnGlobalCurr)(5), 5.0f);
 }
 
 TEST_F(WavefieldAcousticTest, CopyConstructorAfterSwap)
@@ -237,8 +237,8 @@ TEST_F(WavefieldAcousticTest, CopyConstructorAfterSwap)
   // Verify copy has the swapped state
   for (size_t i = 0; i < size1; ++i)
   {
-    EXPECT_FLOAT_EQ(copy.m_pnGlobalPrev(i), i * 2);
-    EXPECT_FLOAT_EQ(copy.m_pnGlobalCurr(i), i);
+    EXPECT_FLOAT_EQ((*copy.m_pnGlobalPrev)(i), i * 2);
+    EXPECT_FLOAT_EQ((*copy.m_pnGlobalCurr)(i), i);
   }
 }
 
@@ -249,13 +249,13 @@ TEST_F(WavefieldAcousticTest, EmptyFields)
 
   WavefieldAcoustic wavefield(emptyPrev, emptyCurr);
 
-  EXPECT_EQ(wavefield.m_pnGlobalPrev.extent(0), 0);
-  EXPECT_EQ(wavefield.m_pnGlobalCurr.extent(0), 0);
+  EXPECT_EQ(wavefield.m_pnGlobalPrev->extent(0), 0);
+  EXPECT_EQ(wavefield.m_pnGlobalCurr->extent(0), 0);
 
   // Swap should work with empty fields
   wavefield.swap();
-  EXPECT_EQ(wavefield.m_pnGlobalPrev.extent(0), 0);
-  EXPECT_EQ(wavefield.m_pnGlobalCurr.extent(0), 0);
+  EXPECT_EQ(wavefield.m_pnGlobalPrev->extent(0), 0);
+  EXPECT_EQ(wavefield.m_pnGlobalCurr->extent(0), 0);
 }
 
 TEST_F(WavefieldAcousticTest, CopyInContainerClass)
@@ -277,8 +277,8 @@ TEST_F(WavefieldAcousticTest, CopyInContainerClass)
   std::vector<float> originalCurr(size1);
   for (size_t i = 0; i < size1; ++i)
   {
-    originalPrev[i] = original.m_pnGlobalPrev(i);
-    originalCurr[i] = original.m_pnGlobalCurr(i);
+    originalPrev[i] = (*original.m_pnGlobalPrev)(i);
+    originalCurr[i] = (*original.m_pnGlobalCurr)(i);
   }
 
   // Create container with wavefield copy
@@ -287,44 +287,44 @@ TEST_F(WavefieldAcousticTest, CopyInContainerClass)
   // Verify container has correct initial state
   for (size_t i = 0; i < size1; ++i)
   {
-    EXPECT_FLOAT_EQ(container.wavefield.m_pnGlobalPrev(i), originalPrev[i]);
-    EXPECT_FLOAT_EQ(container.wavefield.m_pnGlobalCurr(i), originalCurr[i]);
+    EXPECT_FLOAT_EQ((*container.wavefield.m_pnGlobalPrev)(i), originalPrev[i]);
+    EXPECT_FLOAT_EQ((*container.wavefield.m_pnGlobalCurr)(i), originalCurr[i]);
   }
 
   // Modify original wavefield
-  original.m_pnGlobalCurr(10) = 999.0f;
-  original.m_pnGlobalPrev(20) = 888.0f;
+  (*original.m_pnGlobalCurr)(10) = 999.0f;
+  (*original.m_pnGlobalPrev)(20) = 888.0f;
 
   // Container should reflect changes (shallow copy via Kokkos views)
-  EXPECT_FLOAT_EQ(container.wavefield.m_pnGlobalCurr(10), 999.0f);
-  EXPECT_FLOAT_EQ(container.wavefield.m_pnGlobalPrev(20), 888.0f);
+  EXPECT_FLOAT_EQ((*container.wavefield.m_pnGlobalCurr)(10), 999.0f);
+  EXPECT_FLOAT_EQ((*container.wavefield.m_pnGlobalPrev)(20), 888.0f);
 
   // Perform multiple swaps on original, checking after each
   container.swap();
   // After first swap
-  EXPECT_FLOAT_EQ(container.wavefield.m_pnGlobalPrev(10), 999.0f);
-  EXPECT_FLOAT_EQ(container.wavefield.m_pnGlobalCurr(20), 888.0f);
+  EXPECT_FLOAT_EQ((*container.wavefield.m_pnGlobalPrev)(10), 999.0f);
+  EXPECT_FLOAT_EQ((*container.wavefield.m_pnGlobalCurr)(20), 888.0f);
 
   container.swap();
   // After second swap (back to original)
-  EXPECT_FLOAT_EQ(container.wavefield.m_pnGlobalCurr(10), 999.0f);
-  EXPECT_FLOAT_EQ(container.wavefield.m_pnGlobalPrev(20), 888.0f);
+  EXPECT_FLOAT_EQ((*container.wavefield.m_pnGlobalCurr)(10), 999.0f);
+  EXPECT_FLOAT_EQ((*container.wavefield.m_pnGlobalPrev)(20), 888.0f);
 
   container.swap();
   // After third swap
-  EXPECT_FLOAT_EQ(container.wavefield.m_pnGlobalPrev(10), 999.0f);
-  EXPECT_FLOAT_EQ(container.wavefield.m_pnGlobalCurr(20), 888.0f);
+  EXPECT_FLOAT_EQ((*container.wavefield.m_pnGlobalPrev)(10), 999.0f);
+  EXPECT_FLOAT_EQ((*container.wavefield.m_pnGlobalCurr)(20), 888.0f);
 
   // Swap container's wavefield independently
   container.swap();
 
   // Now container should be back to original order
-  EXPECT_FLOAT_EQ(container.wavefield.m_pnGlobalCurr(10), 999.0f);
-  EXPECT_FLOAT_EQ(container.wavefield.m_pnGlobalPrev(20), 888.0f);
+  EXPECT_FLOAT_EQ((*container.wavefield.m_pnGlobalCurr)(10), 999.0f);
+  EXPECT_FLOAT_EQ((*container.wavefield.m_pnGlobalPrev)(20), 888.0f);
 
   // Verify they still share the same underlying data
-  container.wavefield.m_pnGlobalCurr(30) = 777.0f;
-  EXPECT_FLOAT_EQ(original.m_pnGlobalCurr(30), 777.0f);
+  (*container.wavefield.m_pnGlobalCurr)(30) = 777.0f;
+  EXPECT_FLOAT_EQ((*original.m_pnGlobalCurr)(30), 777.0f);
 }
 
 TEST_F(WavefieldAcousticTest, SwapWithRotationRotatesThreeBuffers)
@@ -342,8 +342,8 @@ TEST_F(WavefieldAcousticTest, SwapWithRotationRotatesThreeBuffers)
   //   prevPrev  ← old prev      (value = i)
   for (size_t i = 0; i < size1; ++i)
   {
-    EXPECT_FLOAT_EQ(wavefield.m_pnGlobalCurr(i), 10.0f);
-    EXPECT_FLOAT_EQ(wavefield.m_pnGlobalPrev(i), i * 2);
+    EXPECT_FLOAT_EQ((*wavefield.m_pnGlobalCurr)(i), 10.0f);
+    EXPECT_FLOAT_EQ((*wavefield.m_pnGlobalPrev)(i), i * 2);
     EXPECT_FLOAT_EQ(prevPrev(i), static_cast<float>(i));
   }
 }
@@ -365,8 +365,8 @@ TEST_F(WavefieldAcousticTest, SwapWithRotationThreeTimesRestoresState)
   wavefield.swapWithRotation(prevPrev, 0);
   wavefield.swapWithRotation(prevPrev, 0);
 
-  EXPECT_FLOAT_EQ(wavefield.m_pnGlobalPrev(0), initialPrev0);
-  EXPECT_FLOAT_EQ(wavefield.m_pnGlobalCurr(0), initialCurr0);
+  EXPECT_FLOAT_EQ((*wavefield.m_pnGlobalPrev)(0), initialPrev0);
+  EXPECT_FLOAT_EQ((*wavefield.m_pnGlobalCurr)(0), initialCurr0);
   EXPECT_FLOAT_EQ(prevPrev(0), initialPrevPrev0);
 }
 

--- a/tests/units/solver/impl/test_wavefield_elastic.cc
+++ b/tests/units/solver/impl/test_wavefield_elastic.cc
@@ -71,22 +71,22 @@ TEST_F(WavefieldElasticTest, Constructor)
   WavefieldElastic wavefield(uxPrevField, uxCurrField, uyPrevField, uyCurrField,
                              uzPrevField, uzCurrField);
 
-  EXPECT_EQ(wavefield.m_uxnGlobalPrev.extent(0), size1);
-  EXPECT_EQ(wavefield.m_uxnGlobalCurr.extent(0), size1);
-  EXPECT_EQ(wavefield.m_uynGlobalPrev.extent(0), size1);
-  EXPECT_EQ(wavefield.m_uynGlobalCurr.extent(0), size1);
-  EXPECT_EQ(wavefield.m_uznGlobalPrev.extent(0), size1);
-  EXPECT_EQ(wavefield.m_uznGlobalCurr.extent(0), size1);
+  EXPECT_EQ(wavefield.m_uxnGlobalPrev->extent(0), size1);
+  EXPECT_EQ(wavefield.m_uxnGlobalCurr->extent(0), size1);
+  EXPECT_EQ(wavefield.m_uynGlobalPrev->extent(0), size1);
+  EXPECT_EQ(wavefield.m_uynGlobalCurr->extent(0), size1);
+  EXPECT_EQ(wavefield.m_uznGlobalPrev->extent(0), size1);
+  EXPECT_EQ(wavefield.m_uznGlobalCurr->extent(0), size1);
 
   // Verify data is correctly stored
   for (size_t i = 0; i < size1; ++i)
   {
-    EXPECT_FLOAT_EQ(wavefield.m_uxnGlobalPrev(i), i);
-    EXPECT_FLOAT_EQ(wavefield.m_uxnGlobalCurr(i), i * 2);
-    EXPECT_FLOAT_EQ(wavefield.m_uynGlobalPrev(i), i * 3);
-    EXPECT_FLOAT_EQ(wavefield.m_uynGlobalCurr(i), i * 4);
-    EXPECT_FLOAT_EQ(wavefield.m_uznGlobalPrev(i), i * 5);
-    EXPECT_FLOAT_EQ(wavefield.m_uznGlobalCurr(i), i * 6);
+    EXPECT_FLOAT_EQ((*wavefield.m_uxnGlobalPrev)(i), i);
+    EXPECT_FLOAT_EQ((*wavefield.m_uxnGlobalCurr)(i), i * 2);
+    EXPECT_FLOAT_EQ((*wavefield.m_uynGlobalPrev)(i), i * 3);
+    EXPECT_FLOAT_EQ((*wavefield.m_uynGlobalCurr)(i), i * 4);
+    EXPECT_FLOAT_EQ((*wavefield.m_uznGlobalPrev)(i), i * 5);
+    EXPECT_FLOAT_EQ((*wavefield.m_uznGlobalCurr)(i), i * 6);
   }
 }
 
@@ -97,38 +97,38 @@ TEST_F(WavefieldElasticTest, CopyConstructor)
   WavefieldElastic copy(original);
 
   // Check that copy has the same extent
-  EXPECT_EQ(copy.m_uxnGlobalPrev.extent(0), original.m_uxnGlobalPrev.extent(0));
-  EXPECT_EQ(copy.m_uxnGlobalCurr.extent(0), original.m_uxnGlobalCurr.extent(0));
-  EXPECT_EQ(copy.m_uynGlobalPrev.extent(0), original.m_uynGlobalPrev.extent(0));
-  EXPECT_EQ(copy.m_uynGlobalCurr.extent(0), original.m_uynGlobalCurr.extent(0));
-  EXPECT_EQ(copy.m_uznGlobalPrev.extent(0), original.m_uznGlobalPrev.extent(0));
-  EXPECT_EQ(copy.m_uznGlobalCurr.extent(0), original.m_uznGlobalCurr.extent(0));
+  EXPECT_EQ(copy.m_uxnGlobalPrev->extent(0), original.m_uxnGlobalPrev->extent(0));
+  EXPECT_EQ(copy.m_uxnGlobalCurr->extent(0), original.m_uxnGlobalCurr->extent(0));
+  EXPECT_EQ(copy.m_uynGlobalPrev->extent(0), original.m_uynGlobalPrev->extent(0));
+  EXPECT_EQ(copy.m_uynGlobalCurr->extent(0), original.m_uynGlobalCurr->extent(0));
+  EXPECT_EQ(copy.m_uznGlobalPrev->extent(0), original.m_uznGlobalPrev->extent(0));
+  EXPECT_EQ(copy.m_uznGlobalCurr->extent(0), original.m_uznGlobalCurr->extent(0));
 
   // Check that copy has the same data
   for (size_t i = 0; i < size1; ++i)
   {
-    EXPECT_FLOAT_EQ(copy.m_uxnGlobalPrev(i), original.m_uxnGlobalPrev(i));
-    EXPECT_FLOAT_EQ(copy.m_uxnGlobalCurr(i), original.m_uxnGlobalCurr(i));
-    EXPECT_FLOAT_EQ(copy.m_uynGlobalPrev(i), original.m_uynGlobalPrev(i));
-    EXPECT_FLOAT_EQ(copy.m_uynGlobalCurr(i), original.m_uynGlobalCurr(i));
-    EXPECT_FLOAT_EQ(copy.m_uznGlobalPrev(i), original.m_uznGlobalPrev(i));
-    EXPECT_FLOAT_EQ(copy.m_uznGlobalCurr(i), original.m_uznGlobalCurr(i));
+    EXPECT_FLOAT_EQ((*copy.m_uxnGlobalPrev)(i), (*original.m_uxnGlobalPrev)(i));
+    EXPECT_FLOAT_EQ((*copy.m_uxnGlobalCurr)(i), (*original.m_uxnGlobalCurr)(i));
+    EXPECT_FLOAT_EQ((*copy.m_uynGlobalPrev)(i), (*original.m_uynGlobalPrev)(i));
+    EXPECT_FLOAT_EQ((*copy.m_uynGlobalCurr)(i), (*original.m_uynGlobalCurr)(i));
+    EXPECT_FLOAT_EQ((*copy.m_uznGlobalPrev)(i), (*original.m_uznGlobalPrev)(i));
+    EXPECT_FLOAT_EQ((*copy.m_uznGlobalCurr)(i), (*original.m_uznGlobalCurr)(i));
   }
 
   // Modify original data to verify shallow copy behavior (Kokkos views are
   // shallow by default)
-  original.m_uxnGlobalPrev(0) = 999.0f;
-  EXPECT_FLOAT_EQ(copy.m_uxnGlobalPrev(0), 999.0f);
-  original.m_uxnGlobalCurr(0) = 888.0f;
-  EXPECT_FLOAT_EQ(copy.m_uxnGlobalCurr(0), 888.0f);
-  original.m_uynGlobalPrev(0) = 777.0f;
-  EXPECT_FLOAT_EQ(copy.m_uynGlobalPrev(0), 777.0f);
-  original.m_uynGlobalCurr(0) = 666.0f;
-  EXPECT_FLOAT_EQ(copy.m_uynGlobalCurr(0), 666.0f);
-  original.m_uznGlobalPrev(0) = 555.0f;
-  EXPECT_FLOAT_EQ(copy.m_uznGlobalPrev(0), 555.0f);
-  original.m_uznGlobalCurr(0) = 444.0f;
-  EXPECT_FLOAT_EQ(copy.m_uznGlobalCurr(0), 444.0f);
+  (*original.m_uxnGlobalPrev)(0) = 999.0f;
+  EXPECT_FLOAT_EQ((*copy.m_uxnGlobalPrev)(0), 999.0f);
+  (*original.m_uxnGlobalCurr)(0) = 888.0f;
+  EXPECT_FLOAT_EQ((*copy.m_uxnGlobalCurr)(0), 888.0f);
+  (*original.m_uynGlobalPrev)(0) = 777.0f;
+  EXPECT_FLOAT_EQ((*copy.m_uynGlobalPrev)(0), 777.0f);
+  (*original.m_uynGlobalCurr)(0) = 666.0f;
+  EXPECT_FLOAT_EQ((*copy.m_uynGlobalCurr)(0), 666.0f);
+  (*original.m_uznGlobalPrev)(0) = 555.0f;
+  EXPECT_FLOAT_EQ((*copy.m_uznGlobalPrev)(0), 555.0f);
+  (*original.m_uznGlobalCurr)(0) = 444.0f;
+  EXPECT_FLOAT_EQ((*copy.m_uznGlobalCurr)(0), 444.0f);
 }
 
 TEST_F(WavefieldElasticTest, CopyAssignmentOperator)
@@ -139,43 +139,43 @@ TEST_F(WavefieldElasticTest, CopyAssignmentOperator)
                               uyCurrField2, uzPrevField2, uzCurrField2);
 
   // Verify initial state
-  EXPECT_EQ(wavefield2.m_uxnGlobalPrev.extent(0), size2);
-  EXPECT_EQ(wavefield2.m_uxnGlobalCurr.extent(0), size2);
+  EXPECT_EQ(wavefield2.m_uxnGlobalPrev->extent(0), size2);
+  EXPECT_EQ(wavefield2.m_uxnGlobalCurr->extent(0), size2);
 
   // Perform assignment
   wavefield2 = wavefield1;
 
   // Check that wavefield2 now has the same extent as wavefield1
-  EXPECT_EQ(wavefield2.m_uxnGlobalPrev.extent(0), size1);
-  EXPECT_EQ(wavefield2.m_uxnGlobalCurr.extent(0), size1);
-  EXPECT_EQ(wavefield2.m_uynGlobalPrev.extent(0), size1);
-  EXPECT_EQ(wavefield2.m_uynGlobalCurr.extent(0), size1);
-  EXPECT_EQ(wavefield2.m_uznGlobalPrev.extent(0), size1);
-  EXPECT_EQ(wavefield2.m_uznGlobalCurr.extent(0), size1);
+  EXPECT_EQ(wavefield2.m_uxnGlobalPrev->extent(0), size1);
+  EXPECT_EQ(wavefield2.m_uxnGlobalCurr->extent(0), size1);
+  EXPECT_EQ(wavefield2.m_uynGlobalPrev->extent(0), size1);
+  EXPECT_EQ(wavefield2.m_uynGlobalCurr->extent(0), size1);
+  EXPECT_EQ(wavefield2.m_uznGlobalPrev->extent(0), size1);
+  EXPECT_EQ(wavefield2.m_uznGlobalCurr->extent(0), size1);
 
   // Check that data matches
   for (size_t i = 0; i < size1; ++i)
   {
-    EXPECT_FLOAT_EQ(wavefield2.m_uxnGlobalPrev(i),
-                    wavefield1.m_uxnGlobalPrev(i));
-    EXPECT_FLOAT_EQ(wavefield2.m_uxnGlobalCurr(i),
-                    wavefield1.m_uxnGlobalCurr(i));
-    EXPECT_FLOAT_EQ(wavefield2.m_uynGlobalPrev(i),
-                    wavefield1.m_uynGlobalPrev(i));
-    EXPECT_FLOAT_EQ(wavefield2.m_uynGlobalCurr(i),
-                    wavefield1.m_uynGlobalCurr(i));
-    EXPECT_FLOAT_EQ(wavefield2.m_uznGlobalPrev(i),
-                    wavefield1.m_uznGlobalPrev(i));
-    EXPECT_FLOAT_EQ(wavefield2.m_uznGlobalCurr(i),
-                    wavefield1.m_uznGlobalCurr(i));
+    EXPECT_FLOAT_EQ((*wavefield2.m_uxnGlobalPrev)(i),
+                    (*wavefield1.m_uxnGlobalPrev)(i));
+    EXPECT_FLOAT_EQ((*wavefield2.m_uxnGlobalCurr)(i),
+                    (*wavefield1.m_uxnGlobalCurr)(i));
+    EXPECT_FLOAT_EQ((*wavefield2.m_uynGlobalPrev)(i),
+                    (*wavefield1.m_uynGlobalPrev)(i));
+    EXPECT_FLOAT_EQ((*wavefield2.m_uynGlobalCurr)(i),
+                    (*wavefield1.m_uynGlobalCurr)(i));
+    EXPECT_FLOAT_EQ((*wavefield2.m_uznGlobalPrev)(i),
+                    (*wavefield1.m_uznGlobalPrev)(i));
+    EXPECT_FLOAT_EQ((*wavefield2.m_uznGlobalCurr)(i),
+                    (*wavefield1.m_uznGlobalCurr)(i));
   }
 
   // Modify original data to verify shallow copy behavior (Kokkos views are
   // shallow by default)
-  wavefield1.m_uxnGlobalPrev(0) = 777.0f;
-  EXPECT_FLOAT_EQ(wavefield2.m_uxnGlobalPrev(0), 777.0f);
-  wavefield1.m_uxnGlobalCurr(0) = 666.0f;
-  EXPECT_FLOAT_EQ(wavefield2.m_uxnGlobalCurr(0), 666.0f);
+  (*wavefield1.m_uxnGlobalPrev)(0) = 777.0f;
+  EXPECT_FLOAT_EQ((*wavefield2.m_uxnGlobalPrev)(0), 777.0f);
+  (*wavefield1.m_uxnGlobalCurr)(0) = 666.0f;
+  EXPECT_FLOAT_EQ((*wavefield2.m_uxnGlobalCurr)(0), 666.0f);
 }
 
 TEST_F(WavefieldElasticTest, CopyAssignmentSelfAssignment)
@@ -187,21 +187,21 @@ TEST_F(WavefieldElasticTest, CopyAssignmentSelfAssignment)
   wavefield = wavefield;
 
   // Verify data is unchanged
-  EXPECT_EQ(wavefield.m_uxnGlobalPrev.extent(0), size1);
-  EXPECT_EQ(wavefield.m_uxnGlobalCurr.extent(0), size1);
-  EXPECT_EQ(wavefield.m_uynGlobalPrev.extent(0), size1);
-  EXPECT_EQ(wavefield.m_uynGlobalCurr.extent(0), size1);
-  EXPECT_EQ(wavefield.m_uznGlobalPrev.extent(0), size1);
-  EXPECT_EQ(wavefield.m_uznGlobalCurr.extent(0), size1);
+  EXPECT_EQ(wavefield.m_uxnGlobalPrev->extent(0), size1);
+  EXPECT_EQ(wavefield.m_uxnGlobalCurr->extent(0), size1);
+  EXPECT_EQ(wavefield.m_uynGlobalPrev->extent(0), size1);
+  EXPECT_EQ(wavefield.m_uynGlobalCurr->extent(0), size1);
+  EXPECT_EQ(wavefield.m_uznGlobalPrev->extent(0), size1);
+  EXPECT_EQ(wavefield.m_uznGlobalCurr->extent(0), size1);
 
   for (size_t i = 0; i < size1; ++i)
   {
-    EXPECT_FLOAT_EQ(wavefield.m_uxnGlobalPrev(i), i);
-    EXPECT_FLOAT_EQ(wavefield.m_uxnGlobalCurr(i), i * 2);
-    EXPECT_FLOAT_EQ(wavefield.m_uynGlobalPrev(i), i * 3);
-    EXPECT_FLOAT_EQ(wavefield.m_uynGlobalCurr(i), i * 4);
-    EXPECT_FLOAT_EQ(wavefield.m_uznGlobalPrev(i), i * 5);
-    EXPECT_FLOAT_EQ(wavefield.m_uznGlobalCurr(i), i * 6);
+    EXPECT_FLOAT_EQ((*wavefield.m_uxnGlobalPrev)(i), i);
+    EXPECT_FLOAT_EQ((*wavefield.m_uxnGlobalCurr)(i), i * 2);
+    EXPECT_FLOAT_EQ((*wavefield.m_uynGlobalPrev)(i), i * 3);
+    EXPECT_FLOAT_EQ((*wavefield.m_uynGlobalCurr)(i), i * 4);
+    EXPECT_FLOAT_EQ((*wavefield.m_uznGlobalPrev)(i), i * 5);
+    EXPECT_FLOAT_EQ((*wavefield.m_uznGlobalCurr)(i), i * 6);
   }
 }
 
@@ -253,33 +253,33 @@ TEST_F(WavefieldElasticTest, Swap)
                              uzPrevField, uzCurrField);
 
   // Store original values
-  float originalUxPrev0 = wavefield.m_uxnGlobalPrev(0);
-  float originalUxCurr0 = wavefield.m_uxnGlobalCurr(0);
-  float originalUyPrev0 = wavefield.m_uynGlobalPrev(0);
-  float originalUyCurr0 = wavefield.m_uynGlobalCurr(0);
-  float originalUzPrev0 = wavefield.m_uznGlobalPrev(0);
-  float originalUzCurr0 = wavefield.m_uznGlobalCurr(0);
+  float originalUxPrev0 = (*wavefield.m_uxnGlobalPrev)(0);
+  float originalUxCurr0 = (*wavefield.m_uxnGlobalCurr)(0);
+  float originalUyPrev0 = (*wavefield.m_uynGlobalPrev)(0);
+  float originalUyCurr0 = (*wavefield.m_uynGlobalCurr)(0);
+  float originalUzPrev0 = (*wavefield.m_uznGlobalPrev)(0);
+  float originalUzCurr0 = (*wavefield.m_uznGlobalCurr)(0);
 
   // Perform swap
   wavefield.swap();
 
   // Verify that prev and curr have been swapped
-  EXPECT_FLOAT_EQ(wavefield.m_uxnGlobalPrev(0), originalUxCurr0);
-  EXPECT_FLOAT_EQ(wavefield.m_uxnGlobalCurr(0), originalUxPrev0);
-  EXPECT_FLOAT_EQ(wavefield.m_uynGlobalPrev(0), originalUyCurr0);
-  EXPECT_FLOAT_EQ(wavefield.m_uynGlobalCurr(0), originalUyPrev0);
-  EXPECT_FLOAT_EQ(wavefield.m_uznGlobalPrev(0), originalUzCurr0);
-  EXPECT_FLOAT_EQ(wavefield.m_uznGlobalCurr(0), originalUzPrev0);
+  EXPECT_FLOAT_EQ((*wavefield.m_uxnGlobalPrev)(0), originalUxCurr0);
+  EXPECT_FLOAT_EQ((*wavefield.m_uxnGlobalCurr)(0), originalUxPrev0);
+  EXPECT_FLOAT_EQ((*wavefield.m_uynGlobalPrev)(0), originalUyCurr0);
+  EXPECT_FLOAT_EQ((*wavefield.m_uynGlobalCurr)(0), originalUyPrev0);
+  EXPECT_FLOAT_EQ((*wavefield.m_uznGlobalPrev)(0), originalUzCurr0);
+  EXPECT_FLOAT_EQ((*wavefield.m_uznGlobalCurr)(0), originalUzPrev0);
 
   // Verify all elements were swapped
   for (size_t i = 0; i < size1; ++i)
   {
-    EXPECT_FLOAT_EQ(wavefield.m_uxnGlobalPrev(i), i * 2);
-    EXPECT_FLOAT_EQ(wavefield.m_uxnGlobalCurr(i), i);
-    EXPECT_FLOAT_EQ(wavefield.m_uynGlobalPrev(i), i * 4);
-    EXPECT_FLOAT_EQ(wavefield.m_uynGlobalCurr(i), i * 3);
-    EXPECT_FLOAT_EQ(wavefield.m_uznGlobalPrev(i), i * 6);
-    EXPECT_FLOAT_EQ(wavefield.m_uznGlobalCurr(i), i * 5);
+    EXPECT_FLOAT_EQ((*wavefield.m_uxnGlobalPrev)(i), i * 2);
+    EXPECT_FLOAT_EQ((*wavefield.m_uxnGlobalCurr)(i), i);
+    EXPECT_FLOAT_EQ((*wavefield.m_uynGlobalPrev)(i), i * 4);
+    EXPECT_FLOAT_EQ((*wavefield.m_uynGlobalCurr)(i), i * 3);
+    EXPECT_FLOAT_EQ((*wavefield.m_uznGlobalPrev)(i), i * 6);
+    EXPECT_FLOAT_EQ((*wavefield.m_uznGlobalCurr)(i), i * 5);
   }
 }
 
@@ -295,12 +295,12 @@ TEST_F(WavefieldElasticTest, SwapTwice)
 
   for (size_t i = 0; i < size1; ++i)
   {
-    originalUxPrev[i] = wavefield.m_uxnGlobalPrev(i);
-    originalUxCurr[i] = wavefield.m_uxnGlobalCurr(i);
-    originalUyPrev[i] = wavefield.m_uynGlobalPrev(i);
-    originalUyCurr[i] = wavefield.m_uynGlobalCurr(i);
-    originalUzPrev[i] = wavefield.m_uznGlobalPrev(i);
-    originalUzCurr[i] = wavefield.m_uznGlobalCurr(i);
+    originalUxPrev[i] = (*wavefield.m_uxnGlobalPrev)(i);
+    originalUxCurr[i] = (*wavefield.m_uxnGlobalCurr)(i);
+    originalUyPrev[i] = (*wavefield.m_uynGlobalPrev)(i);
+    originalUyCurr[i] = (*wavefield.m_uynGlobalCurr)(i);
+    originalUzPrev[i] = (*wavefield.m_uznGlobalPrev)(i);
+    originalUzCurr[i] = (*wavefield.m_uznGlobalCurr)(i);
   }
 
   // Swap twice should restore original state
@@ -310,12 +310,12 @@ TEST_F(WavefieldElasticTest, SwapTwice)
   // Verify restoration
   for (size_t i = 0; i < size1; ++i)
   {
-    EXPECT_FLOAT_EQ(wavefield.m_uxnGlobalPrev(i), originalUxPrev[i]);
-    EXPECT_FLOAT_EQ(wavefield.m_uxnGlobalCurr(i), originalUxCurr[i]);
-    EXPECT_FLOAT_EQ(wavefield.m_uynGlobalPrev(i), originalUyPrev[i]);
-    EXPECT_FLOAT_EQ(wavefield.m_uynGlobalCurr(i), originalUyCurr[i]);
-    EXPECT_FLOAT_EQ(wavefield.m_uznGlobalPrev(i), originalUzPrev[i]);
-    EXPECT_FLOAT_EQ(wavefield.m_uznGlobalCurr(i), originalUzCurr[i]);
+    EXPECT_FLOAT_EQ((*wavefield.m_uxnGlobalPrev)(i), originalUxPrev[i]);
+    EXPECT_FLOAT_EQ((*wavefield.m_uxnGlobalCurr)(i), originalUxCurr[i]);
+    EXPECT_FLOAT_EQ((*wavefield.m_uynGlobalPrev)(i), originalUyPrev[i]);
+    EXPECT_FLOAT_EQ((*wavefield.m_uynGlobalCurr)(i), originalUyCurr[i]);
+    EXPECT_FLOAT_EQ((*wavefield.m_uznGlobalPrev)(i), originalUzPrev[i]);
+    EXPECT_FLOAT_EQ((*wavefield.m_uznGlobalCurr)(i), originalUzCurr[i]);
   }
 }
 
@@ -325,20 +325,20 @@ TEST_F(WavefieldElasticTest, SwapWithModification)
                              uzPrevField, uzCurrField);
 
   // Modify current fields
-  wavefield.m_uxnGlobalCurr(5) = 123.456f;
-  wavefield.m_uynGlobalCurr(7) = 234.567f;
-  wavefield.m_uznGlobalCurr(9) = 345.678f;
+  (*wavefield.m_uxnGlobalCurr)(5) = 123.456f;
+  (*wavefield.m_uynGlobalCurr)(7) = 234.567f;
+  (*wavefield.m_uznGlobalCurr)(9) = 345.678f;
 
   // Swap
   wavefield.swap();
 
   // The modified values should now be in the previous fields
-  EXPECT_FLOAT_EQ(wavefield.m_uxnGlobalPrev(5), 123.456f);
-  EXPECT_FLOAT_EQ(wavefield.m_uxnGlobalCurr(5), 5.0f);
-  EXPECT_FLOAT_EQ(wavefield.m_uynGlobalPrev(7), 234.567f);
-  EXPECT_FLOAT_EQ(wavefield.m_uynGlobalCurr(7), 21.0f);
-  EXPECT_FLOAT_EQ(wavefield.m_uznGlobalPrev(9), 345.678f);
-  EXPECT_FLOAT_EQ(wavefield.m_uznGlobalCurr(9), 45.0f);
+  EXPECT_FLOAT_EQ((*wavefield.m_uxnGlobalPrev)(5), 123.456f);
+  EXPECT_FLOAT_EQ((*wavefield.m_uxnGlobalCurr)(5), 5.0f);
+  EXPECT_FLOAT_EQ((*wavefield.m_uynGlobalPrev)(7), 234.567f);
+  EXPECT_FLOAT_EQ((*wavefield.m_uynGlobalCurr)(7), 21.0f);
+  EXPECT_FLOAT_EQ((*wavefield.m_uznGlobalPrev)(9), 345.678f);
+  EXPECT_FLOAT_EQ((*wavefield.m_uznGlobalCurr)(9), 45.0f);
 }
 
 TEST_F(WavefieldElasticTest, CopyConstructorAfterSwap)
@@ -355,12 +355,12 @@ TEST_F(WavefieldElasticTest, CopyConstructorAfterSwap)
   // Verify copy has the swapped state
   for (size_t i = 0; i < size1; ++i)
   {
-    EXPECT_FLOAT_EQ(copy.m_uxnGlobalPrev(i), i * 2);
-    EXPECT_FLOAT_EQ(copy.m_uxnGlobalCurr(i), i);
-    EXPECT_FLOAT_EQ(copy.m_uynGlobalPrev(i), i * 4);
-    EXPECT_FLOAT_EQ(copy.m_uynGlobalCurr(i), i * 3);
-    EXPECT_FLOAT_EQ(copy.m_uznGlobalPrev(i), i * 6);
-    EXPECT_FLOAT_EQ(copy.m_uznGlobalCurr(i), i * 5);
+    EXPECT_FLOAT_EQ((*copy.m_uxnGlobalPrev)(i), i * 2);
+    EXPECT_FLOAT_EQ((*copy.m_uxnGlobalCurr)(i), i);
+    EXPECT_FLOAT_EQ((*copy.m_uynGlobalPrev)(i), i * 4);
+    EXPECT_FLOAT_EQ((*copy.m_uynGlobalCurr)(i), i * 3);
+    EXPECT_FLOAT_EQ((*copy.m_uznGlobalPrev)(i), i * 6);
+    EXPECT_FLOAT_EQ((*copy.m_uznGlobalCurr)(i), i * 5);
   }
 }
 
@@ -376,21 +376,21 @@ TEST_F(WavefieldElasticTest, EmptyFields)
   WavefieldElastic wavefield(emptyUxPrev, emptyUxCurr, emptyUyPrev, emptyUyCurr,
                              emptyUzPrev, emptyUzCurr);
 
-  EXPECT_EQ(wavefield.m_uxnGlobalPrev.extent(0), 0);
-  EXPECT_EQ(wavefield.m_uxnGlobalCurr.extent(0), 0);
-  EXPECT_EQ(wavefield.m_uynGlobalPrev.extent(0), 0);
-  EXPECT_EQ(wavefield.m_uynGlobalCurr.extent(0), 0);
-  EXPECT_EQ(wavefield.m_uznGlobalPrev.extent(0), 0);
-  EXPECT_EQ(wavefield.m_uznGlobalCurr.extent(0), 0);
+  EXPECT_EQ(wavefield.m_uxnGlobalPrev->extent(0), 0);
+  EXPECT_EQ(wavefield.m_uxnGlobalCurr->extent(0), 0);
+  EXPECT_EQ(wavefield.m_uynGlobalPrev->extent(0), 0);
+  EXPECT_EQ(wavefield.m_uynGlobalCurr->extent(0), 0);
+  EXPECT_EQ(wavefield.m_uznGlobalPrev->extent(0), 0);
+  EXPECT_EQ(wavefield.m_uznGlobalCurr->extent(0), 0);
 
   // Swap should work with empty fields
   wavefield.swap();
-  EXPECT_EQ(wavefield.m_uxnGlobalPrev.extent(0), 0);
-  EXPECT_EQ(wavefield.m_uxnGlobalCurr.extent(0), 0);
-  EXPECT_EQ(wavefield.m_uynGlobalPrev.extent(0), 0);
-  EXPECT_EQ(wavefield.m_uynGlobalCurr.extent(0), 0);
-  EXPECT_EQ(wavefield.m_uznGlobalPrev.extent(0), 0);
-  EXPECT_EQ(wavefield.m_uznGlobalCurr.extent(0), 0);
+  EXPECT_EQ(wavefield.m_uxnGlobalPrev->extent(0), 0);
+  EXPECT_EQ(wavefield.m_uxnGlobalCurr->extent(0), 0);
+  EXPECT_EQ(wavefield.m_uynGlobalPrev->extent(0), 0);
+  EXPECT_EQ(wavefield.m_uynGlobalCurr->extent(0), 0);
+  EXPECT_EQ(wavefield.m_uznGlobalPrev->extent(0), 0);
+  EXPECT_EQ(wavefield.m_uznGlobalCurr->extent(0), 0);
 }
 
 TEST_F(WavefieldElasticTest, CopyInContainerClass)
@@ -415,12 +415,12 @@ TEST_F(WavefieldElasticTest, CopyInContainerClass)
 
   for (size_t i = 0; i < size1; ++i)
   {
-    originalUxPrev[i] = original.m_uxnGlobalPrev(i);
-    originalUxCurr[i] = original.m_uxnGlobalCurr(i);
-    originalUyPrev[i] = original.m_uynGlobalPrev(i);
-    originalUyCurr[i] = original.m_uynGlobalCurr(i);
-    originalUzPrev[i] = original.m_uznGlobalPrev(i);
-    originalUzCurr[i] = original.m_uznGlobalCurr(i);
+    originalUxPrev[i] = (*original.m_uxnGlobalPrev)(i);
+    originalUxCurr[i] = (*original.m_uxnGlobalCurr)(i);
+    originalUyPrev[i] = (*original.m_uynGlobalPrev)(i);
+    originalUyCurr[i] = (*original.m_uynGlobalCurr)(i);
+    originalUzPrev[i] = (*original.m_uznGlobalPrev)(i);
+    originalUzCurr[i] = (*original.m_uznGlobalCurr)(i);
   }
 
   // Create container with wavefield copy
@@ -429,54 +429,54 @@ TEST_F(WavefieldElasticTest, CopyInContainerClass)
   // Verify container has correct initial state
   for (size_t i = 0; i < size1; ++i)
   {
-    EXPECT_FLOAT_EQ(container.wavefield.m_uxnGlobalPrev(i), originalUxPrev[i]);
-    EXPECT_FLOAT_EQ(container.wavefield.m_uxnGlobalCurr(i), originalUxCurr[i]);
-    EXPECT_FLOAT_EQ(container.wavefield.m_uynGlobalPrev(i), originalUyPrev[i]);
-    EXPECT_FLOAT_EQ(container.wavefield.m_uynGlobalCurr(i), originalUyCurr[i]);
-    EXPECT_FLOAT_EQ(container.wavefield.m_uznGlobalPrev(i), originalUzPrev[i]);
-    EXPECT_FLOAT_EQ(container.wavefield.m_uznGlobalCurr(i), originalUzCurr[i]);
+    EXPECT_FLOAT_EQ((*container.wavefield.m_uxnGlobalPrev)(i), originalUxPrev[i]);
+    EXPECT_FLOAT_EQ((*container.wavefield.m_uxnGlobalCurr)(i), originalUxCurr[i]);
+    EXPECT_FLOAT_EQ((*container.wavefield.m_uynGlobalPrev)(i), originalUyPrev[i]);
+    EXPECT_FLOAT_EQ((*container.wavefield.m_uynGlobalCurr)(i), originalUyCurr[i]);
+    EXPECT_FLOAT_EQ((*container.wavefield.m_uznGlobalPrev)(i), originalUzPrev[i]);
+    EXPECT_FLOAT_EQ((*container.wavefield.m_uznGlobalCurr)(i), originalUzCurr[i]);
   }
 
   // Modify original wavefield
-  original.m_uxnGlobalCurr(10) = 999.0f;
-  original.m_uxnGlobalPrev(20) = 888.0f;
-  original.m_uynGlobalCurr(15) = 777.0f;
+  (*original.m_uxnGlobalCurr)(10) = 999.0f;
+  (*original.m_uxnGlobalPrev)(20) = 888.0f;
+  (*original.m_uynGlobalCurr)(15) = 777.0f;
 
   // Container should reflect changes (shallow copy via Kokkos views)
-  EXPECT_FLOAT_EQ(container.wavefield.m_uxnGlobalCurr(10), 999.0f);
-  EXPECT_FLOAT_EQ(container.wavefield.m_uxnGlobalPrev(20), 888.0f);
-  EXPECT_FLOAT_EQ(container.wavefield.m_uynGlobalCurr(15), 777.0f);
+  EXPECT_FLOAT_EQ((*container.wavefield.m_uxnGlobalCurr)(10), 999.0f);
+  EXPECT_FLOAT_EQ((*container.wavefield.m_uxnGlobalPrev)(20), 888.0f);
+  EXPECT_FLOAT_EQ((*container.wavefield.m_uynGlobalCurr)(15), 777.0f);
 
   // Perform multiple swaps on container, checking after each
   container.swap();
   // After first swap
-  EXPECT_FLOAT_EQ(container.wavefield.m_uxnGlobalPrev(10), 999.0f);
-  EXPECT_FLOAT_EQ(container.wavefield.m_uxnGlobalCurr(20), 888.0f);
-  EXPECT_FLOAT_EQ(container.wavefield.m_uynGlobalPrev(15), 777.0f);
+  EXPECT_FLOAT_EQ((*container.wavefield.m_uxnGlobalPrev)(10), 999.0f);
+  EXPECT_FLOAT_EQ((*container.wavefield.m_uxnGlobalCurr)(20), 888.0f);
+  EXPECT_FLOAT_EQ((*container.wavefield.m_uynGlobalPrev)(15), 777.0f);
 
   container.swap();
   // After second swap (back to original)
-  EXPECT_FLOAT_EQ(container.wavefield.m_uxnGlobalCurr(10), 999.0f);
-  EXPECT_FLOAT_EQ(container.wavefield.m_uxnGlobalPrev(20), 888.0f);
-  EXPECT_FLOAT_EQ(container.wavefield.m_uynGlobalCurr(15), 777.0f);
+  EXPECT_FLOAT_EQ((*container.wavefield.m_uxnGlobalCurr)(10), 999.0f);
+  EXPECT_FLOAT_EQ((*container.wavefield.m_uxnGlobalPrev)(20), 888.0f);
+  EXPECT_FLOAT_EQ((*container.wavefield.m_uynGlobalCurr)(15), 777.0f);
 
   container.swap();
   // After third swap
-  EXPECT_FLOAT_EQ(container.wavefield.m_uxnGlobalPrev(10), 999.0f);
-  EXPECT_FLOAT_EQ(container.wavefield.m_uxnGlobalCurr(20), 888.0f);
-  EXPECT_FLOAT_EQ(container.wavefield.m_uynGlobalPrev(15), 777.0f);
+  EXPECT_FLOAT_EQ((*container.wavefield.m_uxnGlobalPrev)(10), 999.0f);
+  EXPECT_FLOAT_EQ((*container.wavefield.m_uxnGlobalCurr)(20), 888.0f);
+  EXPECT_FLOAT_EQ((*container.wavefield.m_uynGlobalPrev)(15), 777.0f);
 
   // Swap container's wavefield independently
   container.swap();
 
   // Now container should be back to original order
-  EXPECT_FLOAT_EQ(container.wavefield.m_uxnGlobalCurr(10), 999.0f);
-  EXPECT_FLOAT_EQ(container.wavefield.m_uxnGlobalPrev(20), 888.0f);
-  EXPECT_FLOAT_EQ(container.wavefield.m_uynGlobalCurr(15), 777.0f);
+  EXPECT_FLOAT_EQ((*container.wavefield.m_uxnGlobalCurr)(10), 999.0f);
+  EXPECT_FLOAT_EQ((*container.wavefield.m_uxnGlobalPrev)(20), 888.0f);
+  EXPECT_FLOAT_EQ((*container.wavefield.m_uynGlobalCurr)(15), 777.0f);
 
   // Verify they still share the same underlying data
-  container.wavefield.m_uznGlobalCurr(30) = 666.0f;
-  EXPECT_FLOAT_EQ(original.m_uznGlobalCurr(30), 666.0f);
+  (*container.wavefield.m_uznGlobalCurr)(30) = 666.0f;
+  EXPECT_FLOAT_EQ((*original.m_uznGlobalCurr)(30), 666.0f);
 }
 
 TEST_F(WavefieldElasticTest, SwapWithRotationRotatesThreeBuffers)
@@ -504,13 +504,13 @@ TEST_F(WavefieldElasticTest, SwapWithRotationRotatesThreeBuffers)
   //   prevPrev  ← old prev      (ux=i,   uy=i*3, uz=i*5)
   for (size_t i = 0; i < size1; ++i)
   {
-    EXPECT_FLOAT_EQ(wavefield.m_uxnGlobalCurr(i), 10.0f);
-    EXPECT_FLOAT_EQ(wavefield.m_uynGlobalCurr(i), 20.0f);
-    EXPECT_FLOAT_EQ(wavefield.m_uznGlobalCurr(i), 30.0f);
+    EXPECT_FLOAT_EQ((*wavefield.m_uxnGlobalCurr)(i), 10.0f);
+    EXPECT_FLOAT_EQ((*wavefield.m_uynGlobalCurr)(i), 20.0f);
+    EXPECT_FLOAT_EQ((*wavefield.m_uznGlobalCurr)(i), 30.0f);
 
-    EXPECT_FLOAT_EQ(wavefield.m_uxnGlobalPrev(i), i * 2);
-    EXPECT_FLOAT_EQ(wavefield.m_uynGlobalPrev(i), i * 4);
-    EXPECT_FLOAT_EQ(wavefield.m_uznGlobalPrev(i), i * 6);
+    EXPECT_FLOAT_EQ((*wavefield.m_uxnGlobalPrev)(i), i * 2);
+    EXPECT_FLOAT_EQ((*wavefield.m_uynGlobalPrev)(i), i * 4);
+    EXPECT_FLOAT_EQ((*wavefield.m_uznGlobalPrev)(i), i * 6);
 
     EXPECT_FLOAT_EQ(uxPrevPrev(i), static_cast<float>(i));
     EXPECT_FLOAT_EQ(uyPrevPrev(i), static_cast<float>(i) * 3);
@@ -547,8 +547,8 @@ TEST_F(WavefieldElasticTest, SwapWithRotationThreeTimesRestoresState)
   wavefield.swapWithRotation(uyPrevPrev, 1);
   wavefield.swapWithRotation(uzPrevPrev, 2);
 
-  EXPECT_FLOAT_EQ(wavefield.m_uxnGlobalPrev(0), initialUxPrev0);
-  EXPECT_FLOAT_EQ(wavefield.m_uxnGlobalCurr(0), initialUxCurr0);
+  EXPECT_FLOAT_EQ((*wavefield.m_uxnGlobalPrev)(0), initialUxPrev0);
+  EXPECT_FLOAT_EQ((*wavefield.m_uxnGlobalCurr)(0), initialUxCurr0);
   EXPECT_FLOAT_EQ(uxPrevPrev(0), initialUxPP0);
 }
 


### PR DESCRIPTION
Swap wavefields do not work on the python side. This is true for forward and adjoint methods. 

When we call `data_adj.swap_wavefields()` in python, it swaps on the C++ side but the kokkos arrays are not changed on the python side. 

The table below illustrates such behaviour, and shows what we expect to get.

| iter num      |  Current behaviour         |  Expected behaviour |
|------------------|------------------------------------|-------------------------------|
| iter = 0         | pPrev = 0                           | pPrev = 0                    |
|                      | pCurr = 1                            | pCurr = 1                   |
|------------------|------------------------------------|-------------------------------|
| iter = 1         | pPrev = 1                           | pPrev = 1                    |
|                      | pCurr = 1                            | pCurr = 2                   |
|------------------|------------------------------------|-------------------------------|
| iter = 2         | pPrev = 2                           | pPrev = 2                    |
|                      | pCurr = 3                            | pCurr = 3                   |
|------------------|------------------------------------|-------------------------------|
| iter = 3         | pPrev = 3                           | pPrev = 3                    |
|                      | pCurr = 3                            | pCurr = 4                   |
|------------------|------------------------------------|-------------------------------|


This problem is pretty dangerous if we are using the kokkos arrays on the python side to compute residuals for example, or to output snapshots. 

Turns out the problem is related to bad pointer and wrong memory references.

I've slightly modified `wavefield_acoustic.h` and `wavefield_elastic.h` to correct this behaviour. So far it does the job and fixes this issue.