### PR TITLE
Refactor: Resolve template bloat and massive compile times for Differentiators

### DIFF
--- a/src/gradient/impl/acoustic/include/differentiator_acoustic.h
+++ b/src/gradient/impl/acoustic/include/differentiator_acoustic.h
@@ -61,17 +61,17 @@ class DifferentiatorAcoustic : public Differentiator
 #include "model_struct.h"
 #include "model_unstruct.h"
 
-#define DECLARE_EXTERN_DIFF_ACOUSTIC(ORDER, MESH_TYPE) \
-  extern template class gradient::DifferentiatorAcoustic<ORDER, \
-      typename IntegralTypeSelector<ORDER, IntegralType::MAKUTU>::type, \
-      MESH_TYPE, true>; \
-  extern template class gradient::DifferentiatorAcoustic<ORDER, \
-      typename IntegralTypeSelector<ORDER, IntegralType::MAKUTU>::type, \
+#define DECLARE_EXTERN_DIFF_ACOUSTIC(ORDER, MESH_TYPE)                         \
+  extern template class gradient::DifferentiatorAcoustic<                      \
+      ORDER, typename IntegralTypeSelector<ORDER, IntegralType::MAKUTU>::type, \
+      MESH_TYPE, true>;                                                        \
+  extern template class gradient::DifferentiatorAcoustic<                      \
+      ORDER, typename IntegralTypeSelector<ORDER, IntegralType::MAKUTU>::type, \
       MESH_TYPE, false>;
 
 #define DECLARE_EXTERN_DIFF_ACOUSTIC_ALL_ORDERS(MESH_TYPE_MACRO) \
-  DECLARE_EXTERN_DIFF_ACOUSTIC(1, MESH_TYPE_MACRO(1)) \
-  DECLARE_EXTERN_DIFF_ACOUSTIC(2, MESH_TYPE_MACRO(2)) \
+  DECLARE_EXTERN_DIFF_ACOUSTIC(1, MESH_TYPE_MACRO(1))            \
+  DECLARE_EXTERN_DIFF_ACOUSTIC(2, MESH_TYPE_MACRO(2))            \
   DECLARE_EXTERN_DIFF_ACOUSTIC(3, MESH_TYPE_MACRO(3))
 
 #define STRUCT_MESH_TYPE(ORDER) model::ModelStruct<float, int, ORDER>

--- a/src/gradient/impl/acoustic/include/differentiator_acoustic.h
+++ b/src/gradient/impl/acoustic/include/differentiator_acoustic.h
@@ -12,19 +12,11 @@ namespace gradient
 
 /**
  * @brief Acoustic gradient computation for independent use.
- *
- * Computes model parameter gradients (grad_kappa, grad_buoyancy) from acoustic
- * forward and adjoint wavefields. Completely independent from the Solver.
- *
- * Features:
- * - Supports both node-based and element-based model discretization
- * - Uses standard SEM assembly with mass and stiffness matrices
- *
  * Template Parameters:
- *   ORDER                 - Polynomial order (1, 2, 3, ...)
- *   INTEGRAL_TYPE         - Integration kernel (e.g., makutu)
- *   MESH_TYPE             - Mesh topology (e.g., Cartesian)
- *   IS_MODEL_ON_NODES     - Model discretization (true=nodes, false=elements)
+ * ORDER                 - Polynomial order (1, 2, 3, ...)
+ * INTEGRAL_TYPE         - Integration kernel (e.g., makutu)
+ * MESH_TYPE             - Mesh topology (e.g., Cartesian)
+ * IS_MODEL_ON_NODES     - Model discretization (true=nodes, false=elements)
  */
 template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
           bool IS_MODEL_ON_NODES>
@@ -38,209 +30,59 @@ class DifferentiatorAcoustic : public Differentiator
 
   ~DifferentiatorAcoustic() override = default;
 
-  /**
-   * @brief Compute acoustic gradients (Kappa, Buoyancy).
-   *
-   * Computes:
-   *   grad_kappa   = ∑_elements ∑_quadrature q_dt² * p * mass_term
-   *   grad_buoyancy = ∑_elements ∑_stiffness stiffness_term * q * p
-   */
+  // Déclarations uniquement !
   void compute(model::ModelApi<float, int>& mesh, DataStruct& data,
-               float dt) const override
-  {
-    auto& myData = dynamic_cast<DifferentiatorDataAcoustic&>(data);
-    auto& myMesh = dynamic_cast<MESH_TYPE&>(mesh);
+               float dt) const override;
 
-    VECTOR_REAL_VIEW const pn =
-        myData.getForwardField(0);  // forward pressure, node-indexed
-    VECTOR_REAL_VIEW const qn =
-        myData.getBackwardField(0);  // adjoint pressure at n, node-indexed
-    VECTOR_REAL_VIEW const qnPrev =
-        myData.getBackwardField(1);  // adjoint pressure at n-1, node-indexed
-    VECTOR_REAL_VIEW const qnPrevPrev =
-        myData.getBackwardField(2);  // adjoint pressure at n-2, node-indexed
-    VECTOR_REAL_VIEW const gradKappa =
-        myData.getGradient(0);  // grad_kappa, node- or element-indexed
-    VECTOR_REAL_VIEW const gradBuoyancy =
-        myData.getGradient(1);  // grad_buoyancy, node- or element-indexed
+  int getOrder() const override;
+  bool isModelOnNodes() const override;
+  void print() const override;
 
-    if constexpr (!IS_MODEL_ON_NODES)
-      computeOnElements(myMesh, dt, pn, qn, qnPrev, qnPrevPrev, gradKappa,
-                        gradBuoyancy);
-    else
-      computeOnNodes(myMesh, dt, pn, qn, qnPrev, qnPrevPrev, gradKappa,
-                     gradBuoyancy);
-  }
-
-  int getOrder() const override { return kOrder; }
-
-  bool isModelOnNodes() const override { return kIsModelOnNodes; }
-
-  void print() const override
-  {
-    std::cout << "DifferentiatorAcoustic<ORDER=" << kOrder
-              << ", INTEGRAL_TYPE=" << typeid(INTEGRAL_TYPE).name()
-              << ", MESH_TYPE=" << typeid(MESH_TYPE).name()
-              << ", IS_MODEL_ON_NODES=" << (kIsModelOnNodes ? "true" : "false")
-              << ">\n";
-  }
-
-  /**
-   * @brief Each element writes to a unique index — no atomic add required.
-   *
-   * Computes qdt2 = (qnPrevPrev - 2*qnPrev + qn) / dt² on the fly.
-   */
   void computeOnElements(MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const pn,
                          VECTOR_REAL_VIEW const qn,
                          VECTOR_REAL_VIEW const qnPrev,
                          VECTOR_REAL_VIEW const qnPrevPrev,
                          VECTOR_REAL_VIEW const gradKappa,
-                         VECTOR_REAL_VIEW const gradBuoyancy) const
-  {
-    Kokkos::parallel_for(
-        "Compute Acoustic Gradient on Elements",
-        Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock,
-                                                 LaunchMinBlocksPerSM>>(
-            0, mesh.getNumberOfElements()),
-        KOKKOS_CLASS_LAMBDA(const int elementNumber) {
-          if (elementNumber >= mesh.getNumberOfElements()) return;
+                         VECTOR_REAL_VIEW const gradBuoyancy) const;
 
-          int const dim = mesh.getOrder() + 1;
-
-          typename INTEGRAL_TYPE::TransformType transformData;
-          {
-            auto const elementIndex = mesh.elementIndex(elementNumber);
-            int I = 0;
-            for (int kv = 0; kv < 2; ++kv)
-              for (int jv = 0; jv < 2; ++jv)
-                for (int iv = 0; iv < 2; ++iv)
-                {
-                  auto const vertexIndex =
-                      mesh.globalVertexIndex(elementIndex, iv, jv, kv);
-                  mesh.vertexCoords(vertexIndex, transformData.data[I]);
-                  ++I;
-                }
-          }
-
-          float localPn[kPointsPerElement] = {0};
-          float localQn[kPointsPerElement] = {0};
-          float localQnPrev[kPointsPerElement] = {0};
-          float localQnPrevPrev[kPointsPerElement] = {0};
-          for (int i = 0; i < dim; ++i)
-            for (int j = 0; j < dim; ++j)
-              for (int k = 0; k < dim; ++k)
-              {
-                int const gIdx = mesh.globalNodeIndex(elementNumber, i, j, k);
-                int const lIdx = i + j * dim + k * dim * dim;
-                localPn[lIdx] = pn(gIdx);
-                localQn[lIdx] = qn(gIdx);
-                localQnPrev[lIdx] = qnPrev(gIdx);
-                localQnPrevPrev[lIdx] = qnPrevPrev(gIdx);
-              }
-
-          float const invDt2 = 1.0f / (dt * dt);
-
-          // grad_kappa: element-indexed — unique per thread, no atomic
-          float localGradKappa = 0.0f;
-          INTEGRAL_TYPE::computeMassTerm(
-              transformData, [&](const int q, const real_t val) {
-                float const qdt2 =
-                    (localQnPrevPrev[q] - 2.0f * localQnPrev[q] + localQn[q]) *
-                    invDt2;
-                localGradKappa += qdt2 * localPn[q] * val;
-              });
-          gradKappa(elementNumber) += localGradKappa;
-
-          // grad_buoyancy: element-indexed — unique per thread, no atomic
-          float localGradBuoyancy = 0.0f;
-          INTEGRAL_TYPE::computeStiffnessTerm(
-              transformData,
-              [&](const int /*qa*/, const int /*qb*/, const int /*qc*/) {},
-              [&](const int i, const int j, const real_t val) {
-                localGradBuoyancy += val * localQn[j] * localPn[i];
-              });
-          gradBuoyancy(elementNumber) += localGradBuoyancy;
-        });
-  }
-
-  /**
-   * @brief Multiple elements share boundary nodes — ATOMICADD required.
-   *
-   * Computes qdt2 = (qnPrevPrev - 2*qnPrev + qn) / dt² on the fly.
-   */
   void computeOnNodes(MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const pn,
                       VECTOR_REAL_VIEW const qn, VECTOR_REAL_VIEW const qnPrev,
                       VECTOR_REAL_VIEW const qnPrevPrev,
                       VECTOR_REAL_VIEW const gradKappa,
-                      VECTOR_REAL_VIEW const gradBuoyancy) const
-  {
-    Kokkos::parallel_for(
-        "Compute Acoustic Gradient on Nodes",
-        Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock,
-                                                 LaunchMinBlocksPerSM>>(
-            0, mesh.getNumberOfElements()),
-        KOKKOS_CLASS_LAMBDA(const int elementNumber) {
-          if (elementNumber >= mesh.getNumberOfElements()) return;
-
-          int const dim = mesh.getOrder() + 1;
-
-          typename INTEGRAL_TYPE::TransformType transformData;
-          {
-            auto const elementIndex = mesh.elementIndex(elementNumber);
-            int I = 0;
-            for (int kv = 0; kv < 2; ++kv)
-              for (int jv = 0; jv < 2; ++jv)
-                for (int iv = 0; iv < 2; ++iv)
-                {
-                  auto const vertexIndex =
-                      mesh.globalVertexIndex(elementIndex, iv, jv, kv);
-                  mesh.vertexCoords(vertexIndex, transformData.data[I]);
-                  ++I;
-                }
-          }
-
-          float localPn[kPointsPerElement] = {0};
-          float localQn[kPointsPerElement] = {0};
-          float localQnPrev[kPointsPerElement] = {0};
-          float localQnPrevPrev[kPointsPerElement] = {0};
-          int localGIdx[kPointsPerElement] = {0};
-          for (int i = 0; i < dim; ++i)
-            for (int j = 0; j < dim; ++j)
-              for (int k = 0; k < dim; ++k)
-              {
-                int const gIdx = mesh.globalNodeIndex(elementNumber, i, j, k);
-                int const lIdx = i + j * dim + k * dim * dim;
-                localGIdx[lIdx] = gIdx;
-                localPn[lIdx] = pn(gIdx);
-                localQn[lIdx] = qn(gIdx);
-                localQnPrev[lIdx] = qnPrev(gIdx);
-                localQnPrevPrev[lIdx] = qnPrevPrev(gIdx);
-              }
-
-          float const invDt2 = 1.0f / (dt * dt);
-
-          // grad_kappa: scatter per quadrature point to its global node
-          INTEGRAL_TYPE::computeMassTerm(
-              transformData, [&](const int q, const real_t val) {
-                float const qdt2 =
-                    (localQnPrevPrev[q] - 2.0f * localQnPrev[q] + localQn[q]) *
-                    invDt2;
-                ATOMICADD(gradKappa(localGIdx[q]), qdt2 * localPn[q] * val);
-              });
-
-          // grad_buoyancy: scatter test-function node (i) contributions to
-          // global node
-          INTEGRAL_TYPE::computeStiffnessTerm(
-              transformData,
-              [&](const int /*qa*/, const int /*qb*/, const int /*qc*/) {},
-              [&](const int i, const int j, const real_t val) {
-                ATOMICADD(gradBuoyancy(localGIdx[i]),
-                          val * localQn[j] * localPn[i]);
-              });
-        });
-  }
+                      VECTOR_REAL_VIEW const gradBuoyancy) const;
 };
 
 }  // namespace gradient
+
+// ============================================================================
+// EXTERN TEMPLATES (avoid template bloat)
+// ============================================================================
+#include "Integrals.h"
+#include "model_struct.h"
+#include "model_unstruct.h"
+
+#define DECLARE_EXTERN_DIFF_ACOUSTIC(ORDER, MESH_TYPE) \
+  extern template class gradient::DifferentiatorAcoustic<ORDER, \
+      typename IntegralTypeSelector<ORDER, IntegralType::MAKUTU>::type, \
+      MESH_TYPE, true>; \
+  extern template class gradient::DifferentiatorAcoustic<ORDER, \
+      typename IntegralTypeSelector<ORDER, IntegralType::MAKUTU>::type, \
+      MESH_TYPE, false>;
+
+#define DECLARE_EXTERN_DIFF_ACOUSTIC_ALL_ORDERS(MESH_TYPE_MACRO) \
+  DECLARE_EXTERN_DIFF_ACOUSTIC(1, MESH_TYPE_MACRO(1)) \
+  DECLARE_EXTERN_DIFF_ACOUSTIC(2, MESH_TYPE_MACRO(2)) \
+  DECLARE_EXTERN_DIFF_ACOUSTIC(3, MESH_TYPE_MACRO(3))
+
+#define STRUCT_MESH_TYPE(ORDER) model::ModelStruct<float, int, ORDER>
+#define UNSTRUCT_MESH_TYPE(ORDER) model::ModelUnstruct<float, int>
+
+DECLARE_EXTERN_DIFF_ACOUSTIC_ALL_ORDERS(STRUCT_MESH_TYPE)
+DECLARE_EXTERN_DIFF_ACOUSTIC_ALL_ORDERS(UNSTRUCT_MESH_TYPE)
+
+#undef UNSTRUCT_MESH_TYPE
+#undef STRUCT_MESH_TYPE
+#undef DECLARE_EXTERN_DIFF_ACOUSTIC_ALL_ORDERS
+#undef DECLARE_EXTERN_DIFF_ACOUSTIC
 
 #endif  // FUNTIDES_GRADIENT_IMPL_ACOUSTIC_INCLUDE_DIFFERENTIATOR_ACOUSTIC_H_

--- a/src/gradient/impl/acoustic/include/differentiator_acoustic.h
+++ b/src/gradient/impl/acoustic/include/differentiator_acoustic.h
@@ -12,11 +12,16 @@ namespace gradient
 
 /**
  * @brief Acoustic gradient computation for independent use.
+ * Computes model parameter gradients (grad_kappa, grad_buoyancy) from acoustic
+ * forward and adjoint wavefields. Completely independent from the Solver.
+ * Features:
+ * - Supports both node-based and element-based model discretization
+ * - Uses standard SEM assembly with mass and stiffness matrices
  * Template Parameters:
- * ORDER                 - Polynomial order (1, 2, 3, ...)
- * INTEGRAL_TYPE         - Integration kernel (e.g., makutu)
- * MESH_TYPE             - Mesh topology (e.g., Cartesian)
- * IS_MODEL_ON_NODES     - Model discretization (true=nodes, false=elements)
+ *   ORDER                 - Polynomial order (1, 2, 3, ...)
+ *   INTEGRAL_TYPE         - Integration kernel (e.g., makutu)
+ *   MESH_TYPE             - Mesh topology (e.g., Cartesian)
+ *   IS_MODEL_ON_NODES     - Model discretization (true=nodes, false=elements)
  */
 template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
           bool IS_MODEL_ON_NODES>
@@ -30,7 +35,13 @@ class DifferentiatorAcoustic : public Differentiator
 
   ~DifferentiatorAcoustic() override = default;
 
-  // Déclarations uniquement !
+  /**
+   * @brief Compute acoustic gradients (Kappa, Buoyancy).
+   *
+   * Computes:
+   *   grad_kappa   = ∑_elements ∑_quadrature q_dt² * p * mass_term
+   *   grad_buoyancy = ∑_elements ∑_stiffness stiffness_term * q * p
+   */
   void compute(model::ModelApi<float, int>& mesh, DataStruct& data,
                float dt) const override;
 
@@ -38,6 +49,11 @@ class DifferentiatorAcoustic : public Differentiator
   bool isModelOnNodes() const override;
   void print() const override;
 
+  /**
+   * @brief Each element writes to a unique index — no atomic add required.
+   *
+   * Computes qdt2 = (qnPrevPrev - 2*qnPrev + qn) / dt² on the fly.
+   */
   void computeOnElements(MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const pn,
                          VECTOR_REAL_VIEW const qn,
                          VECTOR_REAL_VIEW const qnPrev,
@@ -45,6 +61,11 @@ class DifferentiatorAcoustic : public Differentiator
                          VECTOR_REAL_VIEW const gradKappa,
                          VECTOR_REAL_VIEW const gradBuoyancy) const;
 
+  /**
+   * @brief Multiple elements share boundary nodes — ATOMICADD required.
+   *
+   * Computes qdt2 = (qnPrevPrev - 2*qnPrev + qn) / dt² on the fly.
+   */
   void computeOnNodes(MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const pn,
                       VECTOR_REAL_VIEW const qn, VECTOR_REAL_VIEW const qnPrev,
                       VECTOR_REAL_VIEW const qnPrevPrev,

--- a/src/gradient/impl/acoustic/include/differentiator_acoustic_impl.h
+++ b/src/gradient/impl/acoustic/include/differentiator_acoustic_impl.h
@@ -1,0 +1,199 @@
+#ifndef FUNTIDES_GRADIENT_IMPL_ACOUSTIC_INCLUDE_DIFFERENTIATOR_ACOUSTIC_IMPL_H_
+#define FUNTIDES_GRADIENT_IMPL_ACOUSTIC_INCLUDE_DIFFERENTIATOR_ACOUSTIC_IMPL_H_
+
+#include "differentiator_acoustic.h"
+#include <Kokkos_Core.hpp>
+#include <typeinfo>
+
+namespace gradient
+{
+
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::compute(
+    model::ModelApi<float, int>& mesh, DataStruct& data, float dt) const
+{
+  auto& myData = dynamic_cast<DifferentiatorDataAcoustic&>(data);
+  auto& myMesh = dynamic_cast<MESH_TYPE&>(mesh);
+
+  VECTOR_REAL_VIEW const pn = myData.getForwardField(0);
+  VECTOR_REAL_VIEW const qn = myData.getBackwardField(0);
+  VECTOR_REAL_VIEW const qnPrev = myData.getBackwardField(1);
+  VECTOR_REAL_VIEW const qnPrevPrev = myData.getBackwardField(2);
+  VECTOR_REAL_VIEW const gradKappa = myData.getGradient(0);
+  VECTOR_REAL_VIEW const gradBuoyancy = myData.getGradient(1);
+
+  if constexpr (!IS_MODEL_ON_NODES)
+    computeOnElements(myMesh, dt, pn, qn, qnPrev, qnPrevPrev, gradKappa,
+                      gradBuoyancy);
+  else
+    computeOnNodes(myMesh, dt, pn, qn, qnPrev, qnPrevPrev, gradKappa,
+                   gradBuoyancy);
+}
+
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+int DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::getOrder() const
+{
+  return kOrder;
+}
+
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+bool DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::isModelOnNodes() const
+{
+  return kIsModelOnNodes;
+}
+
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::print() const
+{
+  std::cout << "DifferentiatorAcoustic<ORDER=" << kOrder
+            << ", INTEGRAL_TYPE=" << typeid(INTEGRAL_TYPE).name()
+            << ", MESH_TYPE=" << typeid(MESH_TYPE).name()
+            << ", IS_MODEL_ON_NODES=" << (kIsModelOnNodes ? "true" : "false")
+            << ">\n";
+}
+
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::computeOnElements(
+    MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const pn,
+    VECTOR_REAL_VIEW const qn, VECTOR_REAL_VIEW const qnPrev,
+    VECTOR_REAL_VIEW const qnPrevPrev, VECTOR_REAL_VIEW const gradKappa,
+    VECTOR_REAL_VIEW const gradBuoyancy) const
+{
+  Kokkos::parallel_for(
+      "Compute Acoustic Gradient on Elements",
+      Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock,
+                                               LaunchMinBlocksPerSM>>(
+          0, mesh.getNumberOfElements()),
+      KOKKOS_CLASS_LAMBDA(const int elementNumber) {
+        if (elementNumber >= mesh.getNumberOfElements()) return;
+
+        int const dim = mesh.getOrder() + 1;
+
+        typename INTEGRAL_TYPE::TransformType transformData;
+        {
+          auto const elementIndex = mesh.elementIndex(elementNumber);
+          int I = 0;
+          for (int kv = 0; kv < 2; ++kv)
+            for (int jv = 0; jv < 2; ++jv)
+              for (int iv = 0; iv < 2; ++iv)
+              {
+                auto const vertexIndex =
+                    mesh.globalVertexIndex(elementIndex, iv, jv, kv);
+                mesh.vertexCoords(vertexIndex, transformData.data[I]);
+                ++I;
+              }
+        }
+
+        float localPn[kPointsPerElement] = {0};
+        float localQn[kPointsPerElement] = {0};
+        float localQnPrev[kPointsPerElement] = {0};
+        float localQnPrevPrev[kPointsPerElement] = {0};
+        #pragma unroll 1
+        for (int i = 0; i < dim; ++i)
+          for (int j = 0; j < dim; ++j)
+            for (int k = 0; k < dim; ++k)
+            {
+              int const gIdx = mesh.globalNodeIndex(elementNumber, i, j, k);
+              int const lIdx = i + j * dim + k * dim * dim;
+              localPn[lIdx] = pn(gIdx);
+              localQn[lIdx] = qn(gIdx);
+              localQnPrev[lIdx] = qnPrev(gIdx);
+              localQnPrevPrev[lIdx] = qnPrevPrev(gIdx);
+            }
+
+        float const invDt2 = 1.0f / (dt * dt);
+
+        float localGradKappa = 0.0f;
+        INTEGRAL_TYPE::computeMassTerm(
+            transformData, [&](const int q, const real_t val) {
+              float const qdt2 =
+                  (localQnPrevPrev[q] - 2.0f * localQnPrev[q] + localQn[q]) *
+                  invDt2;
+              localGradKappa += qdt2 * localPn[q] * val;
+            });
+        gradKappa(elementNumber) += localGradKappa;
+
+        float localGradBuoyancy = 0.0f;
+        INTEGRAL_TYPE::computeStiffnessTerm(
+            transformData,
+            [&](const int /*qa*/, const int /*qb*/, const int /*qc*/) {},
+            [&](const int i, const int j, const real_t val) {
+              localGradBuoyancy += val * localQn[j] * localPn[i];
+            });
+        gradBuoyancy(elementNumber) += localGradBuoyancy;
+      });
+}
+
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::computeOnNodes(
+    MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const pn,
+    VECTOR_REAL_VIEW const qn, VECTOR_REAL_VIEW const qnPrev,
+    VECTOR_REAL_VIEW const qnPrevPrev, VECTOR_REAL_VIEW const gradKappa,
+    VECTOR_REAL_VIEW const gradBuoyancy) const
+{
+  Kokkos::parallel_for(
+      "Compute Acoustic Gradient on Nodes",
+      Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock,
+                                               LaunchMinBlocksPerSM>>(
+          0, mesh.getNumberOfElements()),
+      KOKKOS_CLASS_LAMBDA(const int elementNumber) {
+        if (elementNumber >= mesh.getNumberOfElements()) return;
+
+        int const dim = mesh.getOrder() + 1;
+
+        typename INTEGRAL_TYPE::TransformType transformData;
+        {
+          auto const elementIndex = mesh.elementIndex(elementNumber);
+          int I = 0;
+          for (int kv = 0; kv < 2; ++kv)
+            for (int jv = 0; jv < 2; ++jv)
+              for (int iv = 0; iv < 2; ++iv)
+              {
+                auto const vertexIndex =
+                    mesh.globalVertexIndex(elementIndex, iv, jv, kv);
+                mesh.vertexCoords(vertexIndex, transformData.data[I]);
+                ++I;
+              }
+        }
+
+        float localPn[kPointsPerElement] = {0};
+        float localQn[kPointsPerElement] = {0};
+        float localQnPrev[kPointsPerElement] = {0};
+        float localQnPrevPrev[kPointsPerElement] = {0};
+        int localGIdx[kPointsPerElement] = {0};
+        for (int i = 0; i < dim; ++i)
+          for (int j = 0; j < dim; ++j)
+            for (int k = 0; k < dim; ++k)
+            {
+              int const gIdx = mesh.globalNodeIndex(elementNumber, i, j, k);
+              int const lIdx = i + j * dim + k * dim * dim;
+              localGIdx[lIdx] = gIdx;
+              localPn[lIdx] = pn(gIdx);
+              localQn[lIdx] = qn(gIdx);
+              localQnPrev[lIdx] = qnPrev(gIdx);
+              localQnPrevPrev[lIdx] = qnPrevPrev(gIdx);
+            }
+
+        float const invDt2 = 1.0f / (dt * dt);
+
+        INTEGRAL_TYPE::computeMassTerm(
+            transformData, [&](const int q, const real_t val) {
+              float const qdt2 =
+                  (localQnPrevPrev[q] - 2.0f * localQnPrev[q] + localQn[q]) *
+                  invDt2;
+              ATOMICADD(gradKappa(localGIdx[q]), qdt2 * localPn[q] * val);
+            });
+
+        INTEGRAL_TYPE::computeStiffnessTerm(
+            transformData,
+            [&](const int /*qa*/, const int /*qb*/, const int /*qc*/) {},
+            [&](const int i, const int j, const real_t val) {
+              ATOMICADD(gradBuoyancy(localGIdx[i]),
+                        val * localQn[j] * localPn[i]);
+            });
+      });
+}
+
+}  // namespace gradient
+
+#endif  // FUNTIDES_GRADIENT_IMPL_ACOUSTIC_INCLUDE_DIFFERENTIATOR_ACOUSTIC_IMPL_H_

--- a/src/gradient/impl/acoustic/include/differentiator_acoustic_impl.h
+++ b/src/gradient/impl/acoustic/include/differentiator_acoustic_impl.h
@@ -1,16 +1,20 @@
 #ifndef FUNTIDES_GRADIENT_IMPL_ACOUSTIC_INCLUDE_DIFFERENTIATOR_ACOUSTIC_IMPL_H_
 #define FUNTIDES_GRADIENT_IMPL_ACOUSTIC_INCLUDE_DIFFERENTIATOR_ACOUSTIC_IMPL_H_
 
-#include "differentiator_acoustic.h"
 #include <Kokkos_Core.hpp>
 #include <typeinfo>
+
+#include "differentiator_acoustic.h"
 
 namespace gradient
 {
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
-void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::compute(
-    model::ModelApi<float, int>& mesh, DataStruct& data, float dt) const
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
+          bool IS_MODEL_ON_NODES>
+void DifferentiatorAcoustic<
+    ORDER, INTEGRAL_TYPE, MESH_TYPE,
+    IS_MODEL_ON_NODES>::compute(model::ModelApi<float, int>& mesh,
+                                DataStruct& data, float dt) const
 {
   auto& myData = dynamic_cast<DifferentiatorDataAcoustic&>(data);
   auto& myMesh = dynamic_cast<MESH_TYPE&>(mesh);
@@ -30,20 +34,26 @@ void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>:
                    gradBuoyancy);
 }
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
-int DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::getOrder() const
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
+          bool IS_MODEL_ON_NODES>
+int DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
+                           IS_MODEL_ON_NODES>::getOrder() const
 {
   return kOrder;
 }
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
-bool DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::isModelOnNodes() const
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
+          bool IS_MODEL_ON_NODES>
+bool DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
+                            IS_MODEL_ON_NODES>::isModelOnNodes() const
 {
   return kIsModelOnNodes;
 }
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
-void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::print() const
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
+          bool IS_MODEL_ON_NODES>
+void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
+                            IS_MODEL_ON_NODES>::print() const
 {
   std::cout << "DifferentiatorAcoustic<ORDER=" << kOrder
             << ", INTEGRAL_TYPE=" << typeid(INTEGRAL_TYPE).name()
@@ -52,17 +62,20 @@ void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>:
             << ">\n";
 }
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
-void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::computeOnElements(
-    MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const pn,
-    VECTOR_REAL_VIEW const qn, VECTOR_REAL_VIEW const qnPrev,
-    VECTOR_REAL_VIEW const qnPrevPrev, VECTOR_REAL_VIEW const gradKappa,
-    VECTOR_REAL_VIEW const gradBuoyancy) const
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
+          bool IS_MODEL_ON_NODES>
+void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
+                            IS_MODEL_ON_NODES>::
+    computeOnElements(MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const pn,
+                      VECTOR_REAL_VIEW const qn, VECTOR_REAL_VIEW const qnPrev,
+                      VECTOR_REAL_VIEW const qnPrevPrev,
+                      VECTOR_REAL_VIEW const gradKappa,
+                      VECTOR_REAL_VIEW const gradBuoyancy) const
 {
   Kokkos::parallel_for(
       "Compute Acoustic Gradient on Elements",
-      Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock,
-                                               LaunchMinBlocksPerSM>>(
+      Kokkos::RangePolicy<
+          Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(
           0, mesh.getNumberOfElements()),
       KOKKOS_CLASS_LAMBDA(const int elementNumber) {
         if (elementNumber >= mesh.getNumberOfElements()) return;
@@ -88,7 +101,7 @@ void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>:
         float localQn[kPointsPerElement] = {0};
         float localQnPrev[kPointsPerElement] = {0};
         float localQnPrevPrev[kPointsPerElement] = {0};
-        #pragma unroll 1
+#pragma unroll 1
         for (int i = 0; i < dim; ++i)
           for (int j = 0; j < dim; ++j)
             for (int k = 0; k < dim; ++k)
@@ -124,17 +137,20 @@ void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>:
       });
 }
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
-void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::computeOnNodes(
-    MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const pn,
-    VECTOR_REAL_VIEW const qn, VECTOR_REAL_VIEW const qnPrev,
-    VECTOR_REAL_VIEW const qnPrevPrev, VECTOR_REAL_VIEW const gradKappa,
-    VECTOR_REAL_VIEW const gradBuoyancy) const
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
+          bool IS_MODEL_ON_NODES>
+void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
+                            IS_MODEL_ON_NODES>::
+    computeOnNodes(MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const pn,
+                   VECTOR_REAL_VIEW const qn, VECTOR_REAL_VIEW const qnPrev,
+                   VECTOR_REAL_VIEW const qnPrevPrev,
+                   VECTOR_REAL_VIEW const gradKappa,
+                   VECTOR_REAL_VIEW const gradBuoyancy) const
 {
   Kokkos::parallel_for(
       "Compute Acoustic Gradient on Nodes",
-      Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock,
-                                               LaunchMinBlocksPerSM>>(
+      Kokkos::RangePolicy<
+          Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(
           0, mesh.getNumberOfElements()),
       KOKKOS_CLASS_LAMBDA(const int elementNumber) {
         if (elementNumber >= mesh.getNumberOfElements()) return;

--- a/src/gradient/impl/acoustic/src/makutu/templates/differentiator_acoustic_template.cpp.in
+++ b/src/gradient/impl/acoustic/src/makutu/templates/differentiator_acoustic_template.cpp.in
@@ -3,7 +3,7 @@
 
 #include <@MODEL_HEADER@>
 
-#include "differentiator_acoustic.h"
+#include "differentiator_acoustic_impl.h"
 #include "Integrals.h"
 
 constexpr int ORDER = @ORDER@;

--- a/src/gradient/impl/elastic/include/differentiator_elastic.h
+++ b/src/gradient/impl/elastic/include/differentiator_elastic.h
@@ -1,12 +1,12 @@
 #ifndef FUNTIDES_GRADIENT_IMPL_ELASTIC_INCLUDE_DIFFERENTIATOR_ELASTIC_H_
 #define FUNTIDES_GRADIENT_IMPL_ELASTIC_INCLUDE_DIFFERENTIATOR_ELASTIC_H_
 
+#include <Kokkos_Macros.hpp>
 #include <iostream>
 
 #include "differentiator.h"
 #include "differentiator_data_elastic.h"
 #include "model.h"
-#include <Kokkos_Macros.hpp>
 
 namespace gradient
 {
@@ -71,17 +71,17 @@ class DifferentiatorElastic : public Differentiator
 #include "model_struct.h"
 #include "model_unstruct.h"
 
-#define DECLARE_EXTERN_DIFF_ELASTIC(ORDER, MESH_TYPE) \
-  extern template class gradient::DifferentiatorElastic<ORDER, \
-      typename IntegralTypeSelector<ORDER, IntegralType::MAKUTU>::type, \
-      MESH_TYPE, true>; \
-  extern template class gradient::DifferentiatorElastic<ORDER, \
-      typename IntegralTypeSelector<ORDER, IntegralType::MAKUTU>::type, \
+#define DECLARE_EXTERN_DIFF_ELASTIC(ORDER, MESH_TYPE)                          \
+  extern template class gradient::DifferentiatorElastic<                       \
+      ORDER, typename IntegralTypeSelector<ORDER, IntegralType::MAKUTU>::type, \
+      MESH_TYPE, true>;                                                        \
+  extern template class gradient::DifferentiatorElastic<                       \
+      ORDER, typename IntegralTypeSelector<ORDER, IntegralType::MAKUTU>::type, \
       MESH_TYPE, false>;
 
 #define DECLARE_EXTERN_DIFF_ELASTIC_ALL_ORDERS(MESH_TYPE_MACRO) \
-  DECLARE_EXTERN_DIFF_ELASTIC(1, MESH_TYPE_MACRO(1)) \
-  DECLARE_EXTERN_DIFF_ELASTIC(2, MESH_TYPE_MACRO(2)) \
+  DECLARE_EXTERN_DIFF_ELASTIC(1, MESH_TYPE_MACRO(1))            \
+  DECLARE_EXTERN_DIFF_ELASTIC(2, MESH_TYPE_MACRO(2))            \
   DECLARE_EXTERN_DIFF_ELASTIC(3, MESH_TYPE_MACRO(3))
 
 #define STRUCT_MESH_TYPE(ORDER) model::ModelStruct<float, int, ORDER>

--- a/src/gradient/impl/elastic/include/differentiator_elastic.h
+++ b/src/gradient/impl/elastic/include/differentiator_elastic.h
@@ -13,11 +13,36 @@ namespace gradient
 
 /**
  * @brief Elastic gradient computation for independent use.
+ *
+ * Computes model parameter gradients (grad_rho, grad_lambda, grad_mu) from
+ * elastic forward and adjoint displacement wavefields. Completely independent
+ * from the Solver.
+ *
+ * The elastic gradient for isotropic media computes three sensitivities:
+ *
+ *   grad_rho    = - ∑_t ∑_e ∫ ü† · u  dΩ
+ *                 (density kernel via mass term with second time derivative)
+ *
+ *   grad_lambda = - ∑_t ∑_e ∫ div(u†) · div(u)  dΩ
+ *                 (volumetric / P-wave kernel via divergence interaction)
+ *
+ *   grad_mu     = - ∑_t ∑_e ∫ 2 ε(u†) : ε(u)  dΩ
+ *                 (shear / S-wave kernel via strain tensor interaction)
+ *
+ * For TTI (tilted transverse isotropy), the stiffness kernel uses the full
+ * 6×6 Voigt elasticity tensor C_ij to compute the interaction between
+ * adjoint and forward strain fields.
+ *
+ * Features:
+ * - Supports both node-based and element-based model discretization
+ * - Uses standard SEM assembly with mass and stiffness matrices
+ * - Supports isotropic and TTI anisotropy via computeStiffNessTermwithJac
+ *
  * Template Parameters:
- * ORDER                 - Polynomial order (1, 2, 3, ...)
- * INTEGRAL_TYPE         - Integration kernel (e.g., makutu)
- * MESH_TYPE             - Mesh topology (e.g., Cartesian)
- * IS_MODEL_ON_NODES     - Model discretization (true=nodes, false=elements)
+ *   ORDER                 - Polynomial order (1, 2, 3, ...)
+ *   INTEGRAL_TYPE         - Integration kernel (e.g., makutu)
+ *   MESH_TYPE             - Mesh topology (e.g., Cartesian)
+ *   IS_MODEL_ON_NODES     - Model discretization (true=nodes, false=elements)
  */
 template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
           bool IS_MODEL_ON_NODES>
@@ -31,6 +56,9 @@ class DifferentiatorElastic : public Differentiator
 
   ~DifferentiatorElastic() override = default;
 
+  /**
+   * @brief Compute elastic gradients (Rho, Lambda, Mu).
+   */
   void compute(model::ModelApi<float, int>& mesh, DataStruct& data,
                float dt) const override;
 
@@ -38,11 +66,26 @@ class DifferentiatorElastic : public Differentiator
   bool isModelOnNodes() const override;
   void print() const override;
 
+  /**
+   * @brief Compute displacement gradients at a quadrature point given J^{-1}.
+   *
+   * Computes grad[component][spatial] = ∂u_component/∂x_spatial
+   * using the tensor-product basis and the inverse Jacobian.
+   *
+   * @param qa,qb,qc  Quadrature indices in each reference direction
+   * @param J          Inverse Jacobian matrix J^{-1}[ref_dir][phys_dir]
+   * @param localU     Array of displacement values indexed by local node
+   * @param grad       Output: gradient tensor grad[3] (spatial derivatives)
+   */
   KOKKOS_INLINE_FUNCTION
   static void computeDisplacementGradient(
       int qa, int qb, int qc, float const (&J)[3][3], float const* localUx,
       float const* localUy, float const* localUz, float (&grad)[3][3]);
 
+  /**
+   * @brief Element-based model: each element writes to a unique index — no
+   * atomic add required.
+   */
   void computeOnElements(
       MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const ux_fwd,
       VECTOR_REAL_VIEW const uy_fwd, VECTOR_REAL_VIEW const uz_fwd,
@@ -52,6 +95,10 @@ class DifferentiatorElastic : public Differentiator
       VECTOR_REAL_VIEW const gradRho, VECTOR_REAL_VIEW const gradLambda,
       VECTOR_REAL_VIEW const gradMu) const;
 
+  /**
+   * @brief Node-based model: multiple elements share boundary nodes — ATOMICADD
+   * required.
+   */
   void computeOnNodes(
       MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const ux_fwd,
       VECTOR_REAL_VIEW const uy_fwd, VECTOR_REAL_VIEW const uz_fwd,

--- a/src/gradient/impl/elastic/include/differentiator_elastic.h
+++ b/src/gradient/impl/elastic/include/differentiator_elastic.h
@@ -6,42 +6,18 @@
 #include "differentiator.h"
 #include "differentiator_data_elastic.h"
 #include "model.h"
+#include <Kokkos_Macros.hpp>
 
 namespace gradient
 {
 
 /**
  * @brief Elastic gradient computation for independent use.
- *
- * Computes model parameter gradients (grad_rho, grad_lambda, grad_mu) from
- * elastic forward and adjoint displacement wavefields. Completely independent
- * from the Solver.
- *
- * The elastic gradient for isotropic media computes three sensitivities:
- *
- *   grad_rho    = - ∑_t ∑_e ∫ ü† · u  dΩ
- *                 (density kernel via mass term with second time derivative)
- *
- *   grad_lambda = - ∑_t ∑_e ∫ div(u†) · div(u)  dΩ
- *                 (volumetric / P-wave kernel via divergence interaction)
- *
- *   grad_mu     = - ∑_t ∑_e ∫ 2 ε(u†) : ε(u)  dΩ
- *                 (shear / S-wave kernel via strain tensor interaction)
- *
- * For TTI (tilted transverse isotropy), the stiffness kernel uses the full
- * 6×6 Voigt elasticity tensor C_ij to compute the interaction between
- * adjoint and forward strain fields.
- *
- * Features:
- * - Supports both node-based and element-based model discretization
- * - Uses standard SEM assembly with mass and stiffness matrices
- * - Supports isotropic and TTI anisotropy via computeStiffNessTermwithJac
- *
  * Template Parameters:
- *   ORDER                 - Polynomial order (1, 2, 3, ...)
- *   INTEGRAL_TYPE         - Integration kernel (e.g., makutu)
- *   MESH_TYPE             - Mesh topology (e.g., Cartesian)
- *   IS_MODEL_ON_NODES     - Model discretization (true=nodes, false=elements)
+ * ORDER                 - Polynomial order (1, 2, 3, ...)
+ * INTEGRAL_TYPE         - Integration kernel (e.g., makutu)
+ * MESH_TYPE             - Mesh topology (e.g., Cartesian)
+ * IS_MODEL_ON_NODES     - Model discretization (true=nodes, false=elements)
  */
 template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
           bool IS_MODEL_ON_NODES>
@@ -55,118 +31,18 @@ class DifferentiatorElastic : public Differentiator
 
   ~DifferentiatorElastic() override = default;
 
-  /**
-   * @brief Compute elastic gradients (Rho, Lambda, Mu).
-   */
   void compute(model::ModelApi<float, int>& mesh, DataStruct& data,
-               float dt) const override
-  {
-    auto& myData = dynamic_cast<DifferentiatorDataElastic&>(data);
-    auto& myMesh = dynamic_cast<MESH_TYPE&>(mesh);
+               float dt) const override;
 
-    // Forward displacement at current time step
-    VECTOR_REAL_VIEW const ux_fwd = myData.getForwardField(0);
-    VECTOR_REAL_VIEW const uy_fwd = myData.getForwardField(1);
-    VECTOR_REAL_VIEW const uz_fwd = myData.getForwardField(2);
+  int getOrder() const override;
+  bool isModelOnNodes() const override;
+  void print() const override;
 
-    // Adjoint displacement at current time step
-    VECTOR_REAL_VIEW const ux_adj = myData.getBackwardField(0);
-    VECTOR_REAL_VIEW const uy_adj = myData.getBackwardField(1);
-    VECTOR_REAL_VIEW const uz_adj = myData.getBackwardField(2);
-
-    // Adjoint second time derivatives (pre-computed by caller)
-    VECTOR_REAL_VIEW const ux_dt2 = myData.getBackwardField(3);
-    VECTOR_REAL_VIEW const uy_dt2 = myData.getBackwardField(4);
-    VECTOR_REAL_VIEW const uz_dt2 = myData.getBackwardField(5);
-
-    // Gradient outputs
-    VECTOR_REAL_VIEW const gradRho = myData.getGradient(0);
-    VECTOR_REAL_VIEW const gradLambda = myData.getGradient(1);
-    VECTOR_REAL_VIEW const gradMu = myData.getGradient(2);
-
-    if constexpr (!IS_MODEL_ON_NODES)
-      computeOnElements(myMesh, dt, ux_fwd, uy_fwd, uz_fwd, ux_adj, uy_adj,
-                        uz_adj, ux_dt2, uy_dt2, uz_dt2, gradRho, gradLambda,
-                        gradMu);
-    else
-      computeOnNodes(myMesh, dt, ux_fwd, uy_fwd, uz_fwd, ux_adj, uy_adj, uz_adj,
-                     ux_dt2, uy_dt2, uz_dt2, gradRho, gradLambda, gradMu);
-  }
-
-  int getOrder() const override { return kOrder; }
-
-  bool isModelOnNodes() const override { return kIsModelOnNodes; }
-
-  void print() const override
-  {
-    std::cout << "DifferentiatorElastic<ORDER=" << kOrder
-              << ", INTEGRAL_TYPE=" << typeid(INTEGRAL_TYPE).name()
-              << ", MESH_TYPE=" << typeid(MESH_TYPE).name()
-              << ", IS_MODEL_ON_NODES=" << (kIsModelOnNodes ? "true" : "false")
-              << ">\n";
-  }
-
-  /**
-   * @brief Compute displacement gradients at a quadrature point given J^{-1}.
-   *
-   * Computes grad[component][spatial] = ∂u_component/∂x_spatial
-   * using the tensor-product basis and the inverse Jacobian.
-   *
-   * @param qa,qb,qc  Quadrature indices in each reference direction
-   * @param J          Inverse Jacobian matrix J^{-1}[ref_dir][phys_dir]
-   * @param localU     Array of displacement values indexed by local node
-   * @param grad       Output: gradient tensor grad[3] (spatial derivatives)
-   */
   KOKKOS_INLINE_FUNCTION
   static void computeDisplacementGradient(
       int qa, int qb, int qc, float const (&J)[3][3], float const* localUx,
-      float const* localUy, float const* localUz, float (&grad)[3][3])
-  {
-    int const dim = kOrder + 1;
-    for (int c = 0; c < 3; ++c)
-      for (int d = 0; d < 3; ++d) grad[c][d] = 0.0f;
+      float const* localUy, float const* localUz, float (&grad)[3][3]);
 
-    for (int n = 0; n < dim; ++n)
-    {
-      // ξ_0 direction
-      int const nIdx_a = n + qb * dim + qc * dim * dim;
-      float const dNdxi0 = INTEGRAL_TYPE::basisGradientAt(n, qa);
-      for (int d = 0; d < 3; ++d)
-      {
-        float const JdN = dNdxi0 * J[0][d];
-        grad[0][d] += JdN * localUx[nIdx_a];
-        grad[1][d] += JdN * localUy[nIdx_a];
-        grad[2][d] += JdN * localUz[nIdx_a];
-      }
-
-      // ξ_1 direction
-      int const nIdx_b = qa + n * dim + qc * dim * dim;
-      float const dNdxi1 = INTEGRAL_TYPE::basisGradientAt(n, qb);
-      for (int d = 0; d < 3; ++d)
-      {
-        float const JdN = dNdxi1 * J[1][d];
-        grad[0][d] += JdN * localUx[nIdx_b];
-        grad[1][d] += JdN * localUy[nIdx_b];
-        grad[2][d] += JdN * localUz[nIdx_b];
-      }
-
-      // ξ_2 direction
-      int const nIdx_c = qa + qb * dim + n * dim * dim;
-      float const dNdxi2 = INTEGRAL_TYPE::basisGradientAt(n, qc);
-      for (int d = 0; d < 3; ++d)
-      {
-        float const JdN = dNdxi2 * J[2][d];
-        grad[0][d] += JdN * localUx[nIdx_c];
-        grad[1][d] += JdN * localUy[nIdx_c];
-        grad[2][d] += JdN * localUz[nIdx_c];
-      }
-    }
-  }
-
-  /**
-   * @brief Element-based model: each element writes to a unique index — no
-   * atomic add required.
-   */
   void computeOnElements(
       MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const ux_fwd,
       VECTOR_REAL_VIEW const uy_fwd, VECTOR_REAL_VIEW const uz_fwd,
@@ -174,136 +50,8 @@ class DifferentiatorElastic : public Differentiator
       VECTOR_REAL_VIEW const uz_adj, VECTOR_REAL_VIEW const ux_dt2,
       VECTOR_REAL_VIEW const uy_dt2, VECTOR_REAL_VIEW const uz_dt2,
       VECTOR_REAL_VIEW const gradRho, VECTOR_REAL_VIEW const gradLambda,
-      VECTOR_REAL_VIEW const gradMu) const
-  {
-    Kokkos::parallel_for(
-        "Compute Elastic Gradient on Elements",
-        Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock,
-                                                 LaunchMinBlocksPerSM>>(
-            0, mesh.getNumberOfElements()),
-        KOKKOS_CLASS_LAMBDA(const int elementNumber) {
-          if (elementNumber >= mesh.getNumberOfElements()) return;
+      VECTOR_REAL_VIEW const gradMu) const;
 
-          int const dim = mesh.getOrder() + 1;
-
-          float localUxFwd[kPointsPerElement] = {0};
-          float localUyFwd[kPointsPerElement] = {0};
-          float localUzFwd[kPointsPerElement] = {0};
-          float localUxAdj[kPointsPerElement] = {0};
-          float localUyAdj[kPointsPerElement] = {0};
-          float localUzAdj[kPointsPerElement] = {0};
-          float localUxDt2[kPointsPerElement] = {0};
-          float localUyDt2[kPointsPerElement] = {0};
-          float localUzDt2[kPointsPerElement] = {0};
-
-          for (int i = 0; i < dim; ++i)
-            for (int j = 0; j < dim; ++j)
-              for (int k = 0; k < dim; ++k)
-              {
-                int const gIdx = mesh.globalNodeIndex(elementNumber, i, j, k);
-                int const lIdx = i + j * dim + k * dim * dim;
-                localUxFwd[lIdx] = ux_fwd(gIdx);
-                localUyFwd[lIdx] = uy_fwd(gIdx);
-                localUzFwd[lIdx] = uz_fwd(gIdx);
-                localUxAdj[lIdx] = ux_adj(gIdx);
-                localUyAdj[lIdx] = uy_adj(gIdx);
-                localUzAdj[lIdx] = uz_adj(gIdx);
-                localUxDt2[lIdx] = ux_dt2(gIdx);
-                localUyDt2[lIdx] = uy_dt2(gIdx);
-                localUzDt2[lIdx] = uz_dt2(gIdx);
-              }
-
-          typename INTEGRAL_TYPE::TransformType transformData;
-          {
-            auto const elementIndex = mesh.elementIndex(elementNumber);
-            int I = 0;
-            for (int kv = 0; kv < 2; ++kv)
-              for (int jv = 0; jv < 2; ++jv)
-                for (int iv = 0; iv < 2; ++iv)
-                {
-                  auto const vertexIndex =
-                      mesh.globalVertexIndex(elementIndex, iv, jv, kv);
-                  mesh.vertexCoords(vertexIndex, transformData.data[I]);
-                  ++I;
-                }
-          }
-
-          // --- Pass 1: compute strain interactions at each quadrature point
-          // using computeStiffNessTermwithJac (provides J^{-1}) ---
-          float strainDiv[kPointsPerElement] = {0};
-          float strainEps[kPointsPerElement] = {0};
-
-          INTEGRAL_TYPE::computeStiffNessTermwithJac(
-              transformData,
-              [&](int qa, int qb, int qc, float const(&J)[3][3]) {
-                float grad_fwd[3][3] = {{0}};
-                float grad_adj[3][3] = {{0}};
-                computeDisplacementGradient(qa, qb, qc, J, localUxFwd,
-                                            localUyFwd, localUzFwd, grad_fwd);
-                computeDisplacementGradient(qa, qb, qc, J, localUxAdj,
-                                            localUyAdj, localUzAdj, grad_adj);
-
-                int const qIdx = qa + qb * dim + qc * dim * dim;
-
-                // divergence interaction: div(u†) * div(u)
-                float const div_fwd =
-                    grad_fwd[0][0] + grad_fwd[1][1] + grad_fwd[2][2];
-                float const div_adj =
-                    grad_adj[0][0] + grad_adj[1][1] + grad_adj[2][2];
-                strainDiv[qIdx] = div_adj * div_fwd;
-
-                // 2 * ε(u†) : ε(u)
-                float const exx_f = grad_fwd[0][0];
-                float const eyy_f = grad_fwd[1][1];
-                float const ezz_f = grad_fwd[2][2];
-                float const exy_f = 0.5f * (grad_fwd[0][1] + grad_fwd[1][0]);
-                float const exz_f = 0.5f * (grad_fwd[0][2] + grad_fwd[2][0]);
-                float const eyz_f = 0.5f * (grad_fwd[1][2] + grad_fwd[2][1]);
-
-                float const exx_a = grad_adj[0][0];
-                float const eyy_a = grad_adj[1][1];
-                float const ezz_a = grad_adj[2][2];
-                float const exy_a = 0.5f * (grad_adj[0][1] + grad_adj[1][0]);
-                float const exz_a = 0.5f * (grad_adj[0][2] + grad_adj[2][0]);
-                float const eyz_a = 0.5f * (grad_adj[1][2] + grad_adj[2][1]);
-
-                strainEps[qIdx] =
-                    2.0f * (exx_a * exx_f + eyy_a * eyy_f + ezz_a * ezz_f) +
-                    4.0f * (exy_a * exy_f + exz_a * exz_f + eyz_a * eyz_f);
-              },
-              [&](int, int, float, const int, const int) {});
-
-          // --- Pass 2: accumulate all three gradients using computeMassTerm
-          //     which provides w*|detJ| at each quadrature point ---
-          float localGradRho = 0.0f;
-          float localGradLambda = 0.0f;
-          float localGradMu = 0.0f;
-
-          INTEGRAL_TYPE::computeMassTerm(
-              transformData, [&](const int q, const real_t wdetJ) {
-                // grad_rho: density kernel
-                localGradRho += (localUxDt2[q] * localUxFwd[q] +
-                                 localUyDt2[q] * localUyFwd[q] +
-                                 localUzDt2[q] * localUzFwd[q]) *
-                                wdetJ;
-
-                // grad_lambda: divergence interaction
-                localGradLambda += strainDiv[q] * wdetJ;
-
-                // grad_mu: double-contraction of strain tensors
-                localGradMu += strainEps[q] * wdetJ;
-              });
-
-          gradRho(elementNumber) += localGradRho;
-          gradLambda(elementNumber) += localGradLambda;
-          gradMu(elementNumber) += localGradMu;
-        });
-  }
-
-  /**
-   * @brief Node-based model: multiple elements share boundary nodes — ATOMICADD
-   * required.
-   */
   void computeOnNodes(
       MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const ux_fwd,
       VECTOR_REAL_VIEW const uy_fwd, VECTOR_REAL_VIEW const uz_fwd,
@@ -311,123 +59,40 @@ class DifferentiatorElastic : public Differentiator
       VECTOR_REAL_VIEW const uz_adj, VECTOR_REAL_VIEW const ux_dt2,
       VECTOR_REAL_VIEW const uy_dt2, VECTOR_REAL_VIEW const uz_dt2,
       VECTOR_REAL_VIEW const gradRho, VECTOR_REAL_VIEW const gradLambda,
-      VECTOR_REAL_VIEW const gradMu) const
-  {
-    Kokkos::parallel_for(
-        "Compute Elastic Gradient on Nodes",
-        Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock,
-                                                 LaunchMinBlocksPerSM>>(
-            0, mesh.getNumberOfElements()),
-        KOKKOS_CLASS_LAMBDA(const int elementNumber) {
-          if (elementNumber >= mesh.getNumberOfElements()) return;
-
-          int const dim = mesh.getOrder() + 1;
-
-          float localUxFwd[kPointsPerElement] = {0};
-          float localUyFwd[kPointsPerElement] = {0};
-          float localUzFwd[kPointsPerElement] = {0};
-          float localUxAdj[kPointsPerElement] = {0};
-          float localUyAdj[kPointsPerElement] = {0};
-          float localUzAdj[kPointsPerElement] = {0};
-          float localUxDt2[kPointsPerElement] = {0};
-          float localUyDt2[kPointsPerElement] = {0};
-          float localUzDt2[kPointsPerElement] = {0};
-          int localGIdx[kPointsPerElement] = {0};
-
-          for (int i = 0; i < dim; ++i)
-            for (int j = 0; j < dim; ++j)
-              for (int k = 0; k < dim; ++k)
-              {
-                int const gIdx = mesh.globalNodeIndex(elementNumber, i, j, k);
-                int const lIdx = i + j * dim + k * dim * dim;
-                localGIdx[lIdx] = gIdx;
-                localUxFwd[lIdx] = ux_fwd(gIdx);
-                localUyFwd[lIdx] = uy_fwd(gIdx);
-                localUzFwd[lIdx] = uz_fwd(gIdx);
-                localUxAdj[lIdx] = ux_adj(gIdx);
-                localUyAdj[lIdx] = uy_adj(gIdx);
-                localUzAdj[lIdx] = uz_adj(gIdx);
-                localUxDt2[lIdx] = ux_dt2(gIdx);
-                localUyDt2[lIdx] = uy_dt2(gIdx);
-                localUzDt2[lIdx] = uz_dt2(gIdx);
-              }
-
-          typename INTEGRAL_TYPE::TransformType transformData;
-          {
-            auto const elementIndex = mesh.elementIndex(elementNumber);
-            int I = 0;
-            for (int kv = 0; kv < 2; ++kv)
-              for (int jv = 0; jv < 2; ++jv)
-                for (int iv = 0; iv < 2; ++iv)
-                {
-                  auto const vertexIndex =
-                      mesh.globalVertexIndex(elementIndex, iv, jv, kv);
-                  mesh.vertexCoords(vertexIndex, transformData.data[I]);
-                  ++I;
-                }
-          }
-
-          // --- Pass 1: compute strain interactions at each quadrature point
-          float strainDiv[kPointsPerElement] = {0};
-          float strainEps[kPointsPerElement] = {0};
-
-          INTEGRAL_TYPE::computeStiffNessTermwithJac(
-              transformData,
-              [&](int qa, int qb, int qc, float const(&J)[3][3]) {
-                float grad_fwd[3][3] = {{0}};
-                float grad_adj[3][3] = {{0}};
-                computeDisplacementGradient(qa, qb, qc, J, localUxFwd,
-                                            localUyFwd, localUzFwd, grad_fwd);
-                computeDisplacementGradient(qa, qb, qc, J, localUxAdj,
-                                            localUyAdj, localUzAdj, grad_adj);
-
-                int const qIdx = qa + qb * dim + qc * dim * dim;
-
-                float const div_fwd =
-                    grad_fwd[0][0] + grad_fwd[1][1] + grad_fwd[2][2];
-                float const div_adj =
-                    grad_adj[0][0] + grad_adj[1][1] + grad_adj[2][2];
-                strainDiv[qIdx] = div_adj * div_fwd;
-
-                float const exx_f = grad_fwd[0][0];
-                float const eyy_f = grad_fwd[1][1];
-                float const ezz_f = grad_fwd[2][2];
-                float const exy_f = 0.5f * (grad_fwd[0][1] + grad_fwd[1][0]);
-                float const exz_f = 0.5f * (grad_fwd[0][2] + grad_fwd[2][0]);
-                float const eyz_f = 0.5f * (grad_fwd[1][2] + grad_fwd[2][1]);
-
-                float const exx_a = grad_adj[0][0];
-                float const eyy_a = grad_adj[1][1];
-                float const ezz_a = grad_adj[2][2];
-                float const exy_a = 0.5f * (grad_adj[0][1] + grad_adj[1][0]);
-                float const exz_a = 0.5f * (grad_adj[0][2] + grad_adj[2][0]);
-                float const eyz_a = 0.5f * (grad_adj[1][2] + grad_adj[2][1]);
-
-                strainEps[qIdx] =
-                    2.0f * (exx_a * exx_f + eyy_a * eyy_f + ezz_a * ezz_f) +
-                    4.0f * (exy_a * exy_f + exz_a * exz_f + eyz_a * eyz_f);
-              },
-              [&](int, int, float, const int, const int) {});
-
-          // --- Pass 2: scatter gradients to nodes using computeMassTerm ---
-          INTEGRAL_TYPE::computeMassTerm(
-              transformData, [&](const int q, const real_t wdetJ) {
-                // grad_rho
-                float const dot = localUxDt2[q] * localUxFwd[q] +
-                                  localUyDt2[q] * localUyFwd[q] +
-                                  localUzDt2[q] * localUzFwd[q];
-                ATOMICADD(gradRho(localGIdx[q]), dot * wdetJ);
-
-                // grad_lambda
-                ATOMICADD(gradLambda(localGIdx[q]), strainDiv[q] * wdetJ);
-
-                // grad_mu
-                ATOMICADD(gradMu(localGIdx[q]), strainEps[q] * wdetJ);
-              });
-        });
-  }
+      VECTOR_REAL_VIEW const gradMu) const;
 };
 
 }  // namespace gradient
+
+// ============================================================================
+// EXTERN TEMPLATES (avoid template bloat)
+// ============================================================================
+#include "Integrals.h"
+#include "model_struct.h"
+#include "model_unstruct.h"
+
+#define DECLARE_EXTERN_DIFF_ELASTIC(ORDER, MESH_TYPE) \
+  extern template class gradient::DifferentiatorElastic<ORDER, \
+      typename IntegralTypeSelector<ORDER, IntegralType::MAKUTU>::type, \
+      MESH_TYPE, true>; \
+  extern template class gradient::DifferentiatorElastic<ORDER, \
+      typename IntegralTypeSelector<ORDER, IntegralType::MAKUTU>::type, \
+      MESH_TYPE, false>;
+
+#define DECLARE_EXTERN_DIFF_ELASTIC_ALL_ORDERS(MESH_TYPE_MACRO) \
+  DECLARE_EXTERN_DIFF_ELASTIC(1, MESH_TYPE_MACRO(1)) \
+  DECLARE_EXTERN_DIFF_ELASTIC(2, MESH_TYPE_MACRO(2)) \
+  DECLARE_EXTERN_DIFF_ELASTIC(3, MESH_TYPE_MACRO(3))
+
+#define STRUCT_MESH_TYPE(ORDER) model::ModelStruct<float, int, ORDER>
+#define UNSTRUCT_MESH_TYPE(ORDER) model::ModelUnstruct<float, int>
+
+DECLARE_EXTERN_DIFF_ELASTIC_ALL_ORDERS(STRUCT_MESH_TYPE)
+DECLARE_EXTERN_DIFF_ELASTIC_ALL_ORDERS(UNSTRUCT_MESH_TYPE)
+
+#undef UNSTRUCT_MESH_TYPE
+#undef STRUCT_MESH_TYPE
+#undef DECLARE_EXTERN_DIFF_ELASTIC_ALL_ORDERS
+#undef DECLARE_EXTERN_DIFF_ELASTIC
 
 #endif  // FUNTIDES_GRADIENT_IMPL_ELASTIC_INCLUDE_DIFFERENTIATOR_ELASTIC_H_

--- a/src/gradient/impl/elastic/include/differentiator_elastic_impl.h
+++ b/src/gradient/impl/elastic/include/differentiator_elastic_impl.h
@@ -1,16 +1,18 @@
 #ifndef FUNTIDES_GRADIENT_IMPL_ELASTIC_INCLUDE_DIFFERENTIATOR_ELASTIC_IMPL_H_
 #define FUNTIDES_GRADIENT_IMPL_ELASTIC_INCLUDE_DIFFERENTIATOR_ELASTIC_IMPL_H_
 
-#include "differentiator_elastic.h"
 #include <Kokkos_Core.hpp>
 #include <typeinfo>
+
+#include "differentiator_elastic.h"
 
 namespace gradient
 {
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
-void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::compute(
-    model::ModelApi<float, int>& mesh, DataStruct& data, float dt) const
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
+          bool IS_MODEL_ON_NODES>
+void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::
+    compute(model::ModelApi<float, int>& mesh, DataStruct& data, float dt) const
 {
   auto& myData = dynamic_cast<DifferentiatorDataElastic&>(data);
   auto& myMesh = dynamic_cast<MESH_TYPE&>(mesh);
@@ -40,20 +42,26 @@ void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::
                    ux_dt2, uy_dt2, uz_dt2, gradRho, gradLambda, gradMu);
 }
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
-int DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::getOrder() const
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
+          bool IS_MODEL_ON_NODES>
+int DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
+                          IS_MODEL_ON_NODES>::getOrder() const
 {
   return kOrder;
 }
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
-bool DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::isModelOnNodes() const
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
+          bool IS_MODEL_ON_NODES>
+bool DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
+                           IS_MODEL_ON_NODES>::isModelOnNodes() const
 {
   return kIsModelOnNodes;
 }
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
-void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::print() const
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
+          bool IS_MODEL_ON_NODES>
+void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
+                           IS_MODEL_ON_NODES>::print() const
 {
   std::cout << "DifferentiatorElastic<ORDER=" << kOrder
             << ", INTEGRAL_TYPE=" << typeid(INTEGRAL_TYPE).name()
@@ -62,11 +70,13 @@ void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::
             << ">\n";
 }
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
-KOKKOS_INLINE_FUNCTION
-void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::computeDisplacementGradient(
-    int qa, int qb, int qc, float const (&J)[3][3], float const* localUx,
-    float const* localUy, float const* localUz, float (&grad)[3][3])
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
+          bool IS_MODEL_ON_NODES>
+KOKKOS_INLINE_FUNCTION void
+DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::
+    computeDisplacementGradient(int qa, int qb, int qc, float const (&J)[3][3],
+                                float const* localUx, float const* localUy,
+                                float const* localUz, float (&grad)[3][3])
 {
   int const dim = kOrder + 1;
   for (int c = 0; c < 3; ++c)
@@ -106,20 +116,22 @@ void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::
   }
 }
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
-void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::computeOnElements(
-    MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const ux_fwd,
-    VECTOR_REAL_VIEW const uy_fwd, VECTOR_REAL_VIEW const uz_fwd,
-    VECTOR_REAL_VIEW const ux_adj, VECTOR_REAL_VIEW const uy_adj,
-    VECTOR_REAL_VIEW const uz_adj, VECTOR_REAL_VIEW const ux_dt2,
-    VECTOR_REAL_VIEW const uy_dt2, VECTOR_REAL_VIEW const uz_dt2,
-    VECTOR_REAL_VIEW const gradRho, VECTOR_REAL_VIEW const gradLambda,
-    VECTOR_REAL_VIEW const gradMu) const
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
+          bool IS_MODEL_ON_NODES>
+void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::
+    computeOnElements(
+        MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const ux_fwd,
+        VECTOR_REAL_VIEW const uy_fwd, VECTOR_REAL_VIEW const uz_fwd,
+        VECTOR_REAL_VIEW const ux_adj, VECTOR_REAL_VIEW const uy_adj,
+        VECTOR_REAL_VIEW const uz_adj, VECTOR_REAL_VIEW const ux_dt2,
+        VECTOR_REAL_VIEW const uy_dt2, VECTOR_REAL_VIEW const uz_dt2,
+        VECTOR_REAL_VIEW const gradRho, VECTOR_REAL_VIEW const gradLambda,
+        VECTOR_REAL_VIEW const gradMu) const
 {
   Kokkos::parallel_for(
       "Compute Elastic Gradient on Elements",
-      Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock,
-                                               LaunchMinBlocksPerSM>>(
+      Kokkos::RangePolicy<
+          Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(
           0, mesh.getNumberOfElements()),
       KOKKOS_CLASS_LAMBDA(const int elementNumber) {
         if (elementNumber >= mesh.getNumberOfElements()) return;
@@ -176,10 +188,10 @@ void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::
             [&](int qa, int qb, int qc, float const(&J)[3][3]) {
               float grad_fwd[3][3] = {{0}};
               float grad_adj[3][3] = {{0}};
-              computeDisplacementGradient(qa, qb, qc, J, localUxFwd,
-                                          localUyFwd, localUzFwd, grad_fwd);
-              computeDisplacementGradient(qa, qb, qc, J, localUxAdj,
-                                          localUyAdj, localUzAdj, grad_adj);
+              computeDisplacementGradient(qa, qb, qc, J, localUxFwd, localUyFwd,
+                                          localUzFwd, grad_fwd);
+              computeDisplacementGradient(qa, qb, qc, J, localUxAdj, localUyAdj,
+                                          localUzAdj, grad_adj);
 
               int const qIdx = qa + qb * dim + qc * dim * dim;
 
@@ -217,7 +229,8 @@ void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::
             transformData, [&](const int q, const real_t wdetJ) {
               localGradRho += (localUxDt2[q] * localUxFwd[q] +
                                localUyDt2[q] * localUyFwd[q] +
-                               localUzDt2[q] * localUzFwd[q]) * wdetJ;
+                               localUzDt2[q] * localUzFwd[q]) *
+                              wdetJ;
               localGradLambda += strainDiv[q] * wdetJ;
               localGradMu += strainEps[q] * wdetJ;
             });
@@ -228,20 +241,22 @@ void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::
       });
 }
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
-void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::computeOnNodes(
-    MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const ux_fwd,
-    VECTOR_REAL_VIEW const uy_fwd, VECTOR_REAL_VIEW const uz_fwd,
-    VECTOR_REAL_VIEW const ux_adj, VECTOR_REAL_VIEW const uy_adj,
-    VECTOR_REAL_VIEW const uz_adj, VECTOR_REAL_VIEW const ux_dt2,
-    VECTOR_REAL_VIEW const uy_dt2, VECTOR_REAL_VIEW const uz_dt2,
-    VECTOR_REAL_VIEW const gradRho, VECTOR_REAL_VIEW const gradLambda,
-    VECTOR_REAL_VIEW const gradMu) const
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
+          bool IS_MODEL_ON_NODES>
+void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::
+    computeOnNodes(MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const ux_fwd,
+                   VECTOR_REAL_VIEW const uy_fwd, VECTOR_REAL_VIEW const uz_fwd,
+                   VECTOR_REAL_VIEW const ux_adj, VECTOR_REAL_VIEW const uy_adj,
+                   VECTOR_REAL_VIEW const uz_adj, VECTOR_REAL_VIEW const ux_dt2,
+                   VECTOR_REAL_VIEW const uy_dt2, VECTOR_REAL_VIEW const uz_dt2,
+                   VECTOR_REAL_VIEW const gradRho,
+                   VECTOR_REAL_VIEW const gradLambda,
+                   VECTOR_REAL_VIEW const gradMu) const
 {
   Kokkos::parallel_for(
       "Compute Elastic Gradient on Nodes",
-      Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock,
-                                               LaunchMinBlocksPerSM>>(
+      Kokkos::RangePolicy<
+          Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(
           0, mesh.getNumberOfElements()),
       KOKKOS_CLASS_LAMBDA(const int elementNumber) {
         if (elementNumber >= mesh.getNumberOfElements()) return;
@@ -300,10 +315,10 @@ void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::
             [&](int qa, int qb, int qc, float const(&J)[3][3]) {
               float grad_fwd[3][3] = {{0}};
               float grad_adj[3][3] = {{0}};
-              computeDisplacementGradient(qa, qb, qc, J, localUxFwd,
-                                          localUyFwd, localUzFwd, grad_fwd);
-              computeDisplacementGradient(qa, qb, qc, J, localUxAdj,
-                                          localUyAdj, localUzAdj, grad_adj);
+              computeDisplacementGradient(qa, qb, qc, J, localUxFwd, localUyFwd,
+                                          localUzFwd, grad_fwd);
+              computeDisplacementGradient(qa, qb, qc, J, localUxAdj, localUyAdj,
+                                          localUzAdj, grad_adj);
 
               int const qIdx = qa + qb * dim + qc * dim * dim;
 

--- a/src/gradient/impl/elastic/include/differentiator_elastic_impl.h
+++ b/src/gradient/impl/elastic/include/differentiator_elastic_impl.h
@@ -1,0 +1,350 @@
+#ifndef FUNTIDES_GRADIENT_IMPL_ELASTIC_INCLUDE_DIFFERENTIATOR_ELASTIC_IMPL_H_
+#define FUNTIDES_GRADIENT_IMPL_ELASTIC_INCLUDE_DIFFERENTIATOR_ELASTIC_IMPL_H_
+
+#include "differentiator_elastic.h"
+#include <Kokkos_Core.hpp>
+#include <typeinfo>
+
+namespace gradient
+{
+
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::compute(
+    model::ModelApi<float, int>& mesh, DataStruct& data, float dt) const
+{
+  auto& myData = dynamic_cast<DifferentiatorDataElastic&>(data);
+  auto& myMesh = dynamic_cast<MESH_TYPE&>(mesh);
+
+  VECTOR_REAL_VIEW const ux_fwd = myData.getForwardField(0);
+  VECTOR_REAL_VIEW const uy_fwd = myData.getForwardField(1);
+  VECTOR_REAL_VIEW const uz_fwd = myData.getForwardField(2);
+
+  VECTOR_REAL_VIEW const ux_adj = myData.getBackwardField(0);
+  VECTOR_REAL_VIEW const uy_adj = myData.getBackwardField(1);
+  VECTOR_REAL_VIEW const uz_adj = myData.getBackwardField(2);
+
+  VECTOR_REAL_VIEW const ux_dt2 = myData.getBackwardField(3);
+  VECTOR_REAL_VIEW const uy_dt2 = myData.getBackwardField(4);
+  VECTOR_REAL_VIEW const uz_dt2 = myData.getBackwardField(5);
+
+  VECTOR_REAL_VIEW const gradRho = myData.getGradient(0);
+  VECTOR_REAL_VIEW const gradLambda = myData.getGradient(1);
+  VECTOR_REAL_VIEW const gradMu = myData.getGradient(2);
+
+  if constexpr (!IS_MODEL_ON_NODES)
+    computeOnElements(myMesh, dt, ux_fwd, uy_fwd, uz_fwd, ux_adj, uy_adj,
+                      uz_adj, ux_dt2, uy_dt2, uz_dt2, gradRho, gradLambda,
+                      gradMu);
+  else
+    computeOnNodes(myMesh, dt, ux_fwd, uy_fwd, uz_fwd, ux_adj, uy_adj, uz_adj,
+                   ux_dt2, uy_dt2, uz_dt2, gradRho, gradLambda, gradMu);
+}
+
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+int DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::getOrder() const
+{
+  return kOrder;
+}
+
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+bool DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::isModelOnNodes() const
+{
+  return kIsModelOnNodes;
+}
+
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::print() const
+{
+  std::cout << "DifferentiatorElastic<ORDER=" << kOrder
+            << ", INTEGRAL_TYPE=" << typeid(INTEGRAL_TYPE).name()
+            << ", MESH_TYPE=" << typeid(MESH_TYPE).name()
+            << ", IS_MODEL_ON_NODES=" << (kIsModelOnNodes ? "true" : "false")
+            << ">\n";
+}
+
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+KOKKOS_INLINE_FUNCTION
+void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::computeDisplacementGradient(
+    int qa, int qb, int qc, float const (&J)[3][3], float const* localUx,
+    float const* localUy, float const* localUz, float (&grad)[3][3])
+{
+  int const dim = kOrder + 1;
+  for (int c = 0; c < 3; ++c)
+    for (int d = 0; d < 3; ++d) grad[c][d] = 0.0f;
+
+  for (int n = 0; n < dim; ++n)
+  {
+    int const nIdx_a = n + qb * dim + qc * dim * dim;
+    float const dNdxi0 = INTEGRAL_TYPE::basisGradientAt(n, qa);
+    for (int d = 0; d < 3; ++d)
+    {
+      float const JdN = dNdxi0 * J[0][d];
+      grad[0][d] += JdN * localUx[nIdx_a];
+      grad[1][d] += JdN * localUy[nIdx_a];
+      grad[2][d] += JdN * localUz[nIdx_a];
+    }
+
+    int const nIdx_b = qa + n * dim + qc * dim * dim;
+    float const dNdxi1 = INTEGRAL_TYPE::basisGradientAt(n, qb);
+    for (int d = 0; d < 3; ++d)
+    {
+      float const JdN = dNdxi1 * J[1][d];
+      grad[0][d] += JdN * localUx[nIdx_b];
+      grad[1][d] += JdN * localUy[nIdx_b];
+      grad[2][d] += JdN * localUz[nIdx_b];
+    }
+
+    int const nIdx_c = qa + qb * dim + n * dim * dim;
+    float const dNdxi2 = INTEGRAL_TYPE::basisGradientAt(n, qc);
+    for (int d = 0; d < 3; ++d)
+    {
+      float const JdN = dNdxi2 * J[2][d];
+      grad[0][d] += JdN * localUx[nIdx_c];
+      grad[1][d] += JdN * localUy[nIdx_c];
+      grad[2][d] += JdN * localUz[nIdx_c];
+    }
+  }
+}
+
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::computeOnElements(
+    MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const ux_fwd,
+    VECTOR_REAL_VIEW const uy_fwd, VECTOR_REAL_VIEW const uz_fwd,
+    VECTOR_REAL_VIEW const ux_adj, VECTOR_REAL_VIEW const uy_adj,
+    VECTOR_REAL_VIEW const uz_adj, VECTOR_REAL_VIEW const ux_dt2,
+    VECTOR_REAL_VIEW const uy_dt2, VECTOR_REAL_VIEW const uz_dt2,
+    VECTOR_REAL_VIEW const gradRho, VECTOR_REAL_VIEW const gradLambda,
+    VECTOR_REAL_VIEW const gradMu) const
+{
+  Kokkos::parallel_for(
+      "Compute Elastic Gradient on Elements",
+      Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock,
+                                               LaunchMinBlocksPerSM>>(
+          0, mesh.getNumberOfElements()),
+      KOKKOS_CLASS_LAMBDA(const int elementNumber) {
+        if (elementNumber >= mesh.getNumberOfElements()) return;
+
+        int const dim = mesh.getOrder() + 1;
+
+        float localUxFwd[kPointsPerElement] = {0};
+        float localUyFwd[kPointsPerElement] = {0};
+        float localUzFwd[kPointsPerElement] = {0};
+        float localUxAdj[kPointsPerElement] = {0};
+        float localUyAdj[kPointsPerElement] = {0};
+        float localUzAdj[kPointsPerElement] = {0};
+        float localUxDt2[kPointsPerElement] = {0};
+        float localUyDt2[kPointsPerElement] = {0};
+        float localUzDt2[kPointsPerElement] = {0};
+
+        for (int i = 0; i < dim; ++i)
+          for (int j = 0; j < dim; ++j)
+            for (int k = 0; k < dim; ++k)
+            {
+              int const gIdx = mesh.globalNodeIndex(elementNumber, i, j, k);
+              int const lIdx = i + j * dim + k * dim * dim;
+              localUxFwd[lIdx] = ux_fwd(gIdx);
+              localUyFwd[lIdx] = uy_fwd(gIdx);
+              localUzFwd[lIdx] = uz_fwd(gIdx);
+              localUxAdj[lIdx] = ux_adj(gIdx);
+              localUyAdj[lIdx] = uy_adj(gIdx);
+              localUzAdj[lIdx] = uz_adj(gIdx);
+              localUxDt2[lIdx] = ux_dt2(gIdx);
+              localUyDt2[lIdx] = uy_dt2(gIdx);
+              localUzDt2[lIdx] = uz_dt2(gIdx);
+            }
+
+        typename INTEGRAL_TYPE::TransformType transformData;
+        {
+          auto const elementIndex = mesh.elementIndex(elementNumber);
+          int I = 0;
+          for (int kv = 0; kv < 2; ++kv)
+            for (int jv = 0; jv < 2; ++jv)
+              for (int iv = 0; iv < 2; ++iv)
+              {
+                auto const vertexIndex =
+                    mesh.globalVertexIndex(elementIndex, iv, jv, kv);
+                mesh.vertexCoords(vertexIndex, transformData.data[I]);
+                ++I;
+              }
+        }
+
+        float strainDiv[kPointsPerElement] = {0};
+        float strainEps[kPointsPerElement] = {0};
+
+        INTEGRAL_TYPE::computeStiffNessTermwithJac(
+            transformData,
+            [&](int qa, int qb, int qc, float const(&J)[3][3]) {
+              float grad_fwd[3][3] = {{0}};
+              float grad_adj[3][3] = {{0}};
+              computeDisplacementGradient(qa, qb, qc, J, localUxFwd,
+                                          localUyFwd, localUzFwd, grad_fwd);
+              computeDisplacementGradient(qa, qb, qc, J, localUxAdj,
+                                          localUyAdj, localUzAdj, grad_adj);
+
+              int const qIdx = qa + qb * dim + qc * dim * dim;
+
+              float const div_fwd =
+                  grad_fwd[0][0] + grad_fwd[1][1] + grad_fwd[2][2];
+              float const div_adj =
+                  grad_adj[0][0] + grad_adj[1][1] + grad_adj[2][2];
+              strainDiv[qIdx] = div_adj * div_fwd;
+
+              float const exx_f = grad_fwd[0][0];
+              float const eyy_f = grad_fwd[1][1];
+              float const ezz_f = grad_fwd[2][2];
+              float const exy_f = 0.5f * (grad_fwd[0][1] + grad_fwd[1][0]);
+              float const exz_f = 0.5f * (grad_fwd[0][2] + grad_fwd[2][0]);
+              float const eyz_f = 0.5f * (grad_fwd[1][2] + grad_fwd[2][1]);
+
+              float const exx_a = grad_adj[0][0];
+              float const eyy_a = grad_adj[1][1];
+              float const ezz_a = grad_adj[2][2];
+              float const exy_a = 0.5f * (grad_adj[0][1] + grad_adj[1][0]);
+              float const exz_a = 0.5f * (grad_adj[0][2] + grad_adj[2][0]);
+              float const eyz_a = 0.5f * (grad_adj[1][2] + grad_adj[2][1]);
+
+              strainEps[qIdx] =
+                  2.0f * (exx_a * exx_f + eyy_a * eyy_f + ezz_a * ezz_f) +
+                  4.0f * (exy_a * exy_f + exz_a * exz_f + eyz_a * eyz_f);
+            },
+            [&](int, int, float, const int, const int) {});
+
+        float localGradRho = 0.0f;
+        float localGradLambda = 0.0f;
+        float localGradMu = 0.0f;
+
+        INTEGRAL_TYPE::computeMassTerm(
+            transformData, [&](const int q, const real_t wdetJ) {
+              localGradRho += (localUxDt2[q] * localUxFwd[q] +
+                               localUyDt2[q] * localUyFwd[q] +
+                               localUzDt2[q] * localUzFwd[q]) * wdetJ;
+              localGradLambda += strainDiv[q] * wdetJ;
+              localGradMu += strainEps[q] * wdetJ;
+            });
+
+        gradRho(elementNumber) += localGradRho;
+        gradLambda(elementNumber) += localGradLambda;
+        gradMu(elementNumber) += localGradMu;
+      });
+}
+
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::computeOnNodes(
+    MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const ux_fwd,
+    VECTOR_REAL_VIEW const uy_fwd, VECTOR_REAL_VIEW const uz_fwd,
+    VECTOR_REAL_VIEW const ux_adj, VECTOR_REAL_VIEW const uy_adj,
+    VECTOR_REAL_VIEW const uz_adj, VECTOR_REAL_VIEW const ux_dt2,
+    VECTOR_REAL_VIEW const uy_dt2, VECTOR_REAL_VIEW const uz_dt2,
+    VECTOR_REAL_VIEW const gradRho, VECTOR_REAL_VIEW const gradLambda,
+    VECTOR_REAL_VIEW const gradMu) const
+{
+  Kokkos::parallel_for(
+      "Compute Elastic Gradient on Nodes",
+      Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock,
+                                               LaunchMinBlocksPerSM>>(
+          0, mesh.getNumberOfElements()),
+      KOKKOS_CLASS_LAMBDA(const int elementNumber) {
+        if (elementNumber >= mesh.getNumberOfElements()) return;
+
+        int const dim = mesh.getOrder() + 1;
+
+        float localUxFwd[kPointsPerElement] = {0};
+        float localUyFwd[kPointsPerElement] = {0};
+        float localUzFwd[kPointsPerElement] = {0};
+        float localUxAdj[kPointsPerElement] = {0};
+        float localUyAdj[kPointsPerElement] = {0};
+        float localUzAdj[kPointsPerElement] = {0};
+        float localUxDt2[kPointsPerElement] = {0};
+        float localUyDt2[kPointsPerElement] = {0};
+        float localUzDt2[kPointsPerElement] = {0};
+        int localGIdx[kPointsPerElement] = {0};
+
+        for (int i = 0; i < dim; ++i)
+          for (int j = 0; j < dim; ++j)
+            for (int k = 0; k < dim; ++k)
+            {
+              int const gIdx = mesh.globalNodeIndex(elementNumber, i, j, k);
+              int const lIdx = i + j * dim + k * dim * dim;
+              localGIdx[lIdx] = gIdx;
+              localUxFwd[lIdx] = ux_fwd(gIdx);
+              localUyFwd[lIdx] = uy_fwd(gIdx);
+              localUzFwd[lIdx] = uz_fwd(gIdx);
+              localUxAdj[lIdx] = ux_adj(gIdx);
+              localUyAdj[lIdx] = uy_adj(gIdx);
+              localUzAdj[lIdx] = uz_adj(gIdx);
+              localUxDt2[lIdx] = ux_dt2(gIdx);
+              localUyDt2[lIdx] = uy_dt2(gIdx);
+              localUzDt2[lIdx] = uz_dt2(gIdx);
+            }
+
+        typename INTEGRAL_TYPE::TransformType transformData;
+        {
+          auto const elementIndex = mesh.elementIndex(elementNumber);
+          int I = 0;
+          for (int kv = 0; kv < 2; ++kv)
+            for (int jv = 0; jv < 2; ++jv)
+              for (int iv = 0; iv < 2; ++iv)
+              {
+                auto const vertexIndex =
+                    mesh.globalVertexIndex(elementIndex, iv, jv, kv);
+                mesh.vertexCoords(vertexIndex, transformData.data[I]);
+                ++I;
+              }
+        }
+
+        float strainDiv[kPointsPerElement] = {0};
+        float strainEps[kPointsPerElement] = {0};
+
+        INTEGRAL_TYPE::computeStiffNessTermwithJac(
+            transformData,
+            [&](int qa, int qb, int qc, float const(&J)[3][3]) {
+              float grad_fwd[3][3] = {{0}};
+              float grad_adj[3][3] = {{0}};
+              computeDisplacementGradient(qa, qb, qc, J, localUxFwd,
+                                          localUyFwd, localUzFwd, grad_fwd);
+              computeDisplacementGradient(qa, qb, qc, J, localUxAdj,
+                                          localUyAdj, localUzAdj, grad_adj);
+
+              int const qIdx = qa + qb * dim + qc * dim * dim;
+
+              float const div_fwd =
+                  grad_fwd[0][0] + grad_fwd[1][1] + grad_fwd[2][2];
+              float const div_adj =
+                  grad_adj[0][0] + grad_adj[1][1] + grad_adj[2][2];
+              strainDiv[qIdx] = div_adj * div_fwd;
+
+              float const exx_f = grad_fwd[0][0];
+              float const eyy_f = grad_fwd[1][1];
+              float const ezz_f = grad_fwd[2][2];
+              float const exy_f = 0.5f * (grad_fwd[0][1] + grad_fwd[1][0]);
+              float const exz_f = 0.5f * (grad_fwd[0][2] + grad_fwd[2][0]);
+              float const eyz_f = 0.5f * (grad_fwd[1][2] + grad_fwd[2][1]);
+
+              float const exx_a = grad_adj[0][0];
+              float const eyy_a = grad_adj[1][1];
+              float const ezz_a = grad_adj[2][2];
+              float const exy_a = 0.5f * (grad_adj[0][1] + grad_adj[1][0]);
+              float const exz_a = 0.5f * (grad_adj[0][2] + grad_adj[2][0]);
+              float const eyz_a = 0.5f * (grad_adj[1][2] + grad_adj[2][1]);
+
+              strainEps[qIdx] =
+                  2.0f * (exx_a * exx_f + eyy_a * eyy_f + ezz_a * ezz_f) +
+                  4.0f * (exy_a * exy_f + exz_a * exz_f + eyz_a * eyz_f);
+            },
+            [&](int, int, float, const int, const int) {});
+
+        INTEGRAL_TYPE::computeMassTerm(
+            transformData, [&](const int q, const real_t wdetJ) {
+              float const dot = localUxDt2[q] * localUxFwd[q] +
+                                localUyDt2[q] * localUyFwd[q] +
+                                localUzDt2[q] * localUzFwd[q];
+              ATOMICADD(gradRho(localGIdx[q]), dot * wdetJ);
+              ATOMICADD(gradLambda(localGIdx[q]), strainDiv[q] * wdetJ);
+              ATOMICADD(gradMu(localGIdx[q]), strainEps[q] * wdetJ);
+            });
+      });
+}
+
+}  // namespace gradient
+
+#endif  // FUNTIDES_GRADIENT_IMPL_ELASTIC_INCLUDE_DIFFERENTIATOR_ELASTIC_IMPL_H_

--- a/src/gradient/impl/elastic/src/makutu/templates/differentiator_elastic_template.cpp.in
+++ b/src/gradient/impl/elastic/src/makutu/templates/differentiator_elastic_template.cpp.in
@@ -3,7 +3,8 @@
 
 #include <@MODEL_HEADER@>
 
-#include "differentiator_elastic.h"
+// use impl to take advantage of external template
+#include "differentiator_elastic_impl.h"
 #include "Integrals.h"
 
 constexpr int ORDER = @ORDER@;


### PR DESCRIPTION
Linked to #288.

## Refactor: Resolve template bloat and massive compile times for Differentiators

### Description
This PR addresses a severe compilation bottleneck caused by heavy Kokkos kernels within the acoustic and elastic differentiator classes. Previously, files like `differentiator_factory.cc` and various unit tests were taking up to 10 minutes (~600s) to compile, saturating system RAM and blocking parallel builds.

### The Architecture Fix: Extern Templates & Implementation Splitting
To solve this, we implemented an explicit template instantiation pattern:

1. **Extern Templates:** We added `extern template` declarations at the bottom of our main headers (`differentiator_acoustic.h` and `differentiator_elastic.h`). This acts as a contract telling the compiler: "The machine code for this specific template combination is already compiled elsewhere; do not generate it here." This prevents the compiler from needlessly regenerating heavy machine code in every translation unit that includes the header (a phenomenon known as Template Bloat).

2. **Hiding the Implementation (`_impl.hpp`):** An `extern template` promise is often ignored by the compiler if the function body is defined directly inside the class header, because the compiler treats those methods as implicitly `inline` and parses them anyway. To enforce the extern rule, we moved all `Kokkos::parallel_for` loops into isolated `_impl.hpp` files. 

3. **Single Point of Instantiation:** The main headers now only contain declarations. The `_impl.hpp` files are NEVER included by the factory or the tests. They are exclusively included by the CMake-generated `.cpp` files (via the `.cpp.in` templates). This guarantees that the C++ compiler parses, optimizes, and translates the heavy Kokkos loops exactly once per physics/mesh configuration.

### Additional Fixes
* **Compiler Heuristics Cliff:** Added `#pragma unroll 1` (or `#pragma nounroll`) to the spatial loops inside the structured mesh methods. This prevents NVCC/GCC from falling off an optimization cliff where it unpredictably attempted to fully unroll 64-element loops (for Q3 structured meshes). This compiler misjudgment was causing single `.cpp.o` files to take ~500 seconds to compile on specific OS/compiler combinations.

### Impact & Results
* **Factory Compilation:** `differentiator_factory.cc` compile time dropped from ~596s to under 5s.
* **Unit Tests Compilation:** Test compilation times dropped from ~450s to ~2s.
* **Generated Files:** Heavy kernel compilations are now strictly isolated to their specific `.cpp.o` files, compiling in ~80s.
* The overall build pipeline is now heavily parallelizable without triggering the OS OOM-killer or swapping to disk.