### PR TITLE
Add updateFIeldsOnList routine to optimize elastoacoustic solver

### DIFF
--- a/src/main/fe/include/sem_proxy.h
+++ b/src/main/fe/include/sem_proxy.h
@@ -125,7 +125,7 @@ class SEMproxy
   int num_sample_;
   // source parameters
   const int myNumberOfRHS = 1;
-  const float f0 = 10.0f;
+  const float f0 = 5.0f;
   const int sourceOrder = 2;
   int myElementSource = 0;
 

--- a/src/solver/fe/impl/acoustoelastic/include/sem_solver_acoustoelastic.h
+++ b/src/solver/fe/impl/acoustoelastic/include/sem_solver_acoustoelastic.h
@@ -248,6 +248,16 @@ class SEMsolverAcoustoElastic : public Solver
   /// num_elastic_elements_).
   VECTOR_INT_VIEW elastic_elem_list_;
 
+  int num_acoustic_nodes_{0};  ///< Count of acoustic-domain nodes
+  int num_elastic_nodes_{0};   ///< Count of elastic-domain nodes
+
+  /// @brief Compact list of acoustic-domain node indices (pure acoustic +
+  /// interface, size num_acoustic_nodes_).
+  VECTOR_INT_VIEW acoustic_node_list_;
+  /// @brief Compact list of elastic-domain node indices (pure elastic +
+  /// interface, size num_elastic_nodes_).
+  VECTOR_INT_VIEW elastic_node_list_;
+
   /// Shear-modulus threshold below which an element is classified as acoustic.
   static constexpr float kMuTolerance = 1.0e-6f;
 

--- a/src/solver/fe/impl/acoustoelastic/include/sem_solver_acoustoelastic_impl.h
+++ b/src/solver/fe/impl/acoustoelastic/include/sem_solver_acoustoelastic_impl.h
@@ -285,6 +285,30 @@ void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
   }
   FENCE
 
+  // Build compact acoustic and elastic node lists for updateFieldsFromList.
+  // Interface nodes appear in both lists: acoustic solver updates pressure
+  // there, elastic solver updates displacement there.
+  {
+    int n_acou = 0, n_elas = 0;
+    for (int n = 0; n < nNode; ++n)
+    {
+      if (acoustic_count[n] > 0) ++n_acou;
+      if (elastic_count[n] > 0) ++n_elas;
+    }
+    num_acoustic_nodes_ = n_acou;
+    num_elastic_nodes_ = n_elas;
+    acoustic_node_list_ =
+        allocateVector<VECTOR_INT_VIEW>(n_acou, "acousticNodeList");
+    elastic_node_list_ =
+        allocateVector<VECTOR_INT_VIEW>(n_elas, "elasticNodeList");
+    int ia = 0, ie = 0;
+    for (int n = 0; n < nNode; ++n)
+    {
+      if (acoustic_count[n] > 0) acoustic_node_list_[ia++] = n;
+      if (elastic_count[n] > 0) elastic_node_list_[ie++] = n;
+    }
+  }
+
   // Allocate compact nm1 arrays (one entry per interface node).
   m_ux_nm1_iface_ =
       allocateVector<VECTOR_REAL_VIEW>(n_interface_nodes_, "uxNm1Iface");
@@ -577,12 +601,14 @@ void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
 
   SEMsolverData<utils::enums::physicType::kElastic> elastic_data(
       myData.m_wavefield.m_elastic, myData.m_rhs.m_rhs_elastic);
-  m_elastic_solver_.updateFields(dt, elastic_data);
+  m_elastic_solver_.updateFieldsFromList(dt, elastic_data, elastic_node_list_,
+                                         num_elastic_nodes_);
   FENCE
 
   SEMsolverData<utils::enums::physicType::kAcoustic> acoustic_data(
       myData.m_wavefield.m_acoustic, myData.m_rhs.m_rhs_acoustic);
-  m_acoustic_solver_.updateFields(dt, acoustic_data);
+  m_acoustic_solver_.updateFieldsFromList(
+      dt, acoustic_data, acoustic_node_list_, num_acoustic_nodes_);
   FENCE
 }
 
@@ -746,7 +772,8 @@ void SEMsolverAcoustoElastic<
   }
 
   // 3. Elastic Verlet: u^{n+1} written into elastic_data.getPreviousField().
-  m_elastic_solver_.updateFields(dt, elastic_data);
+  m_elastic_solver_.updateFieldsFromList(dt, elastic_data, elastic_node_list_,
+                                         num_elastic_nodes_);
   FENCE
 
   // 4. A→E coupling (GEOS post-Verlet): u^{n+1} += dt²·c·(-p^n)/M_e.
@@ -771,7 +798,8 @@ void SEMsolverAcoustoElastic<
   FENCE
 
   // 8. Acoustic Verlet: p^{n+1} written into acoustic_data.getPreviousField().
-  m_acoustic_solver_.updateFields(dt, acoustic_data);
+  m_acoustic_solver_.updateFieldsFromList(
+      dt, acoustic_data, acoustic_node_list_, num_acoustic_nodes_);
   FENCE
 
   // 9. E→A coupling post-Verlet.


### PR DESCRIPTION
This PR add the possibility to run updateFields routine on a list of nodes instead of going threw all the nodes two times when we use the elastoacoustic solver (all mesh nodes for acoustic + all mesh nodes for elastic) 

On the reference case for elastoacoustic we observe a speedup of x6.