### PR TITLE
Add input file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ mpirun -n 4 python3 examples/fe/solver_cartesian_mpi.py --ex 200 --snap_interval
 If you want to easily modify the cli option to launch the (eg: modify the number of elements by directions, 
 the spacial order etc)
 
-You can also use `run_funtides.py` script inside`python`folder, to run the executable using a yaml 
-input file where you have defined all the options
+You can also use `run_funtides.py` script inside`python` folder, to run the executable using a yaml 
+input file where you can define all the options for your simulation
 ```sh
 
 # Run python script with input file

--- a/README.md
+++ b/README.md
@@ -126,11 +126,7 @@ mpirun -n 4 python3 examples/fe/solver_cartesian_mpi.py --ex 200 --snap_interval
 
 ```
 
-If you want to easily modify the cli option to launch the (eg: modify the number of elements by directions, 
-the spacial order etc)
-
-You can also use `run_funtides.py` script inside`python` folder, to run the executable using a yaml 
-input file where you can define all the options for your simulation
+If you want to easily modify the cli option when you launch the code (eg: modify the number of elements by directions, the spacial order etc), you can also use `run_funtides.py` script inside `python` folder, to run the executable using a yaml input file where you can define all the options for your simulation
 ```sh
 
 # Run python script with input file

--- a/README.md
+++ b/README.md
@@ -123,7 +123,23 @@ python3 examples/fe/solver_cartesian.py --ex 100 --ey 100 --ez 100 --order 2
 
 # Run an MPI-distributed Python cartesian solver (requires MPI)
 mpirun -n 4 python3 examples/fe/solver_cartesian_mpi.py --ex 200 --snap_interval 20
+
 ```
+
+If you want to easily modify the cli option to launch the (eg: modify the number of elements by directions, 
+the spacial order etc)
+
+You can also use `run_funtides.py` script inside`python`folder, to run the executable using a yaml 
+input file where you have defined all the options
+```sh
+
+# Run python script with input file
+python3 python run_funtides.py examples/example_config.yaml
+```
+
+The `example_config.yaml` file inside the examples folder, gives an example of a possible yaml file to use.
+> **Note**: The script can also handle mpi simulation with or without a scheduler with dedicated option inside the yaml
+
 
 > **Note**: A dedicated python env can be made via TPLs.
 

--- a/examples/example_config.yaml
+++ b/examples/example_config.yaml
@@ -36,6 +36,13 @@ mesh:   cartesian  # Mesh type option are : cartesian or ucartesian (unstructure
 implem: makutu     # Method of implementation for basis function and matrices assembly (only makutu for now)
 method: sem        # Numerical method: sem (spectral element method)
 
+#--------------------------------------------------------------------------------
+# General source parameters
+#--------------------------------------------------------------------------------
+f0: 10.0          # dominant frequency of the source (Hz)
+tpeak: 0.1       # time shift of the source wavelet (seconds)
+ricker-order: 2   # order of the ricker wavelet (2 = classic Ricker)
+
 # -------------------------------------------------------------------------------------------
 # Source and receiver positions (meters) NB: For now only one source/receiver is supported
 # -------------------------------------------------------------------------------------------

--- a/examples/example_config.yaml
+++ b/examples/example_config.yaml
@@ -1,0 +1,96 @@
+# funtides-sem configuration file
+# All keys correspond to the CLI flags of funtides-sem.
+# Dashes and underscores are interchangeable (e.g. is-elastic or is_elastic).
+# Boolean false values can simply be omitted — the binary defaults apply.
+
+# ---------------------------------------------------------------------------
+# MPI (optional)
+#
+# mpi-np:       number of MPI processes (omit or set to 1 for serial)
+# mpi-launcher: mpirun | mpiexec | srun | jsrun
+#               Auto-detected when inside SLURM (→ srun) or LSF (→ mpirun).
+#               Under SLURM + srun, omitting mpi-np lets srun inherit
+#               --ntasks directly from the batch script header.
+#
+# Environment overrides: FUNTIDES_MPI_NP, FUNTIDES_MPI_LAUNCHER
+# ---------------------------------------------------------------------------
+# mpi-np: 4
+# mpi-launcher: srun
+
+# ---------------------------------------------------------------------------
+# Spatial discretization
+# ---------------------------------------------------------------------------
+order: 2          # Order of discretization
+ex: 50            # number of elements along X-axis
+ey: 50            # number of elements along Y-axis
+ez: 50            # number of elements along Z-axis
+
+lx: 2000.0        # domain size along X-axis (meters)
+ly: 2000.0        # domain size along Y-axis (meters)
+lz: 2000.0        # domain size along Z-axis (meters)
+
+# ---------------------------------------------------------------------------
+# Mesh and implementation
+# ---------------------------------------------------------------------------
+mesh:   cartesian  # Mesh type option are : cartesian or ucartesian (unstructured cartesian)
+implem: makutu     # Method of implementation for basis function and matrices assembly (only makutu for now)
+method: sem        # Numerical method: sem (spectral element method)
+
+# -------------------------------------------------------------------------------------------
+# Source and receiver positions (meters) NB: For now only one source/receiver is supported
+# -------------------------------------------------------------------------------------------
+srcx: 1010.0 # X coordinate of source
+srcy: 1010.0 # Y coordinate of source
+srcz: 1010.0 # Z coordinate of source
+
+rcvx: 1310.0 # X coordinate of receiver
+rcvy: 1310.0 # Y coordinate of receiver
+rcvz: 1310.0 # Z coordinate of receiver
+
+# ---------------------------------------------------------------------------
+# Time parameters
+# ---------------------------------------------------------------------------
+dt:      0.006    # time step (seconds)
+timemax: 0.7      # simulation duration (seconds)
+auto-dt: false    # set to true to let the code pick dt via CFL (override the dt value)
+
+# ---------------------------------------------------------------------------
+# Physics
+# ---------------------------------------------------------------------------
+is-elastic:       false  # true: pure elastic simulation
+is-acousto-elastic: false  # true; coupled acoustic-elastic simulation
+# acousto-elastic-boundary-z: 1000.0  # Z coordinate of fluid-solid interface (meters)
+
+anisotropy:        iso   # Anisotropy of the middle (elastic only). Three supported argument iso | vti | tti
+is-model-on-nodes: false # true: material properties defined on nodes
+free-surface:      false # true: free surface on top boundary (Z+)
+
+# ---------------------------------------------------------------------------
+# Attenuation (SLS model) — omit or leave empty to disable
+# ---------------------------------------------------------------------------
+qp: -1.0   # quality factor for P-waves  (<0 = no attenuation)
+qs: -1.0   # quality factor for S-waves  (<0 = no attenuation)
+# sls-reference-angular-frequencies: [10.0, 50.0, 200.0]  # rad/s
+# sls-anelasticity-coefficients:     [0.1,  0.2,  0.05]
+
+# ----------------------------------------------------------------------------------------------
+# Absorbing boundaries (sponge) leave disabled by default, or set boundaries-size > 0 to enable
+# ----------------------------------------------------------------------------------------------
+boundaries-size: 0.0    # thickness of absorbing layer (meters, 0 = disabled)
+sponge-surface:  false  # include the top surface in the sponge
+taper-delta:     0.015  # taper decay rate
+
+# ---------------------------------------------------------------------------
+# Snapshots
+# ---------------------------------------------------------------------------
+snapshots:     false  # true: save wavefield snapshots
+snap-interval: 20     # number of time steps between snapshots
+
+# ---------------------------------------------------------------------------
+# DAS (Distributed Acoustic Sensing) receiver — omit or set das-type: none
+# ---------------------------------------------------------------------------
+das-type:         none  # none | dipole | strain
+das-dip:          0.0   # fiber dip angle (degrees)
+das-azimuth:      0.0   # fiber azimuth angle (degrees)
+das-gauge-length: 1.0   # gauge length (meters)
+das-samples:      5     # number of integration points along fiber

--- a/examples/example_config.yaml
+++ b/examples/example_config.yaml
@@ -1,103 +1,93 @@
 # funtides-sem configuration file
-# All keys correspond to the CLI flags of funtides-sem.
-# Dashes and underscores are interchangeable (e.g. is-elastic or is_elastic).
-# Boolean false values can simply be omitted — the binary defaults apply.
+# Section names are for readability only — all leaf keys map directly to
+# funtides-sem CLI flags. Dashes and underscores are interchangeable.
+# Boolean false values can be omitted (binary defaults apply).
 
 # ---------------------------------------------------------------------------
-# MPI (optional)
+# Launcher — script-level keys, not forwarded to the binary
 #
-# mpi-np:       number of MPI processes (omit or set to 1 for serial)
+# mpi-np:       number of MPI processes (omit or 1 = serial launch)
 # mpi-launcher: mpirun | mpiexec | srun | jsrun
-#               Auto-detected when inside SLURM (→ srun) or LSF (→ mpirun).
+#               Auto-detected when inside a job allocation:
+#                 SLURM → srun  |  LSF → mpirun
 #               Under SLURM + srun, omitting mpi-np lets srun inherit
-#               --ntasks directly from the batch script header.
-#
+#               --ntasks from the batch script header.
 # Environment overrides: FUNTIDES_MPI_NP, FUNTIDES_MPI_LAUNCHER
 # ---------------------------------------------------------------------------
-# mpi-np: 4
-# mpi-launcher: srun
+launcher:
+  # mpi-np: 4
+  # mpi-launcher: srun
 
 # ---------------------------------------------------------------------------
-# Spatial discretization
+# Domain — computational domain, mesh and numerical method
 # ---------------------------------------------------------------------------
-order: 2          # Order of discretization
-ex: 50            # number of elements along X-axis
-ey: 50            # number of elements along Y-axis
-ez: 50            # number of elements along Z-axis
-
-lx: 2000.0        # domain size along X-axis (meters)
-ly: 2000.0        # domain size along Y-axis (meters)
-lz: 2000.0        # domain size along Z-axis (meters)
+domain:
+  order: 2       # polynomial order of approximation
+  ex: 50         # number of elements along X
+  ey: 50         # number of elements along Y
+  ez: 50         # number of elements along Z
+  lx: 2000.0     # domain size along X (meters)
+  ly: 2000.0     # domain size along Y (meters)
+  lz: 2000.0     # domain size along Z (meters)
+  mesh:   cartesian  # cartesian | ucartesian (unstructured cartesian)
+  implem: makutu     # implementation backend (only makutu for now)
+  method: sem        # numerical method: sem (spectral element method)
 
 # ---------------------------------------------------------------------------
-# Mesh and implementation
+# Acquisition — source and receivers
+# NB: only one source/receiver supported for now
 # ---------------------------------------------------------------------------
-mesh:   cartesian  # Mesh type option are : cartesian or ucartesian (unstructured cartesian)
-implem: makutu     # Method of implementation for basis function and matrices assembly (only makutu for now)
-method: sem        # Numerical method: sem (spectral element method)
+acquisition:
+  source:
+    srcx: 1010.0  # X coordinate (meters)
+    srcy: 1010.0  # Y coordinate (meters)
+    srcz: 1010.0  # Z coordinate (meters)
 
-#--------------------------------------------------------------------------------
-# General source parameters
-#--------------------------------------------------------------------------------
-f0: 10.0          # dominant frequency of the source (Hz)
-tpeak: 0.1       # time shift of the source wavelet (seconds)
-ricker-order: 2   # order of the ricker wavelet (2 = classic Ricker)
+  receiver:
+    rcvx: 1310.0  # X coordinate (meters)
+    rcvy: 1310.0  # Y coordinate (meters)
+    rcvz: 1310.0  # Z coordinate (meters)
 
-# -------------------------------------------------------------------------------------------
-# Source and receiver positions (meters) NB: For now only one source/receiver is supported
-# -------------------------------------------------------------------------------------------
-srcx: 1010.0 # X coordinate of source
-srcy: 1010.0 # Y coordinate of source
-srcz: 1010.0 # Z coordinate of source
-
-rcvx: 1310.0 # X coordinate of receiver
-rcvy: 1310.0 # Y coordinate of receiver
-rcvz: 1310.0 # Z coordinate of receiver
+  das:  # Distributed Acoustic Sensing — set das-type: none to disable
+    das-type:         none  # none | dipole | strain
+    das-dip:          0.0   # fiber dip angle (degrees)
+    das-azimuth:      0.0   # fiber azimuth angle (degrees)
+    das-gauge-length: 1.0   # gauge length (meters)
+    das-samples:      5     # number of integration points along fiber
 
 # ---------------------------------------------------------------------------
 # Time parameters
 # ---------------------------------------------------------------------------
-dt:      0.006    # time step (seconds)
-timemax: 0.7      # simulation duration (seconds)
-auto-dt: false    # set to true to let the code pick dt via CFL (override the dt value)
+time:
+  dt:      0.006  # time step (seconds)
+  timemax: 0.7    # simulation duration (seconds)
+  auto-dt: false  # true: override dt with CFL-optimal value
 
 # ---------------------------------------------------------------------------
 # Physics
 # ---------------------------------------------------------------------------
-is-elastic:       false  # true: pure elastic simulation
-is-acousto-elastic: false  # true; coupled acoustic-elastic simulation
-# acousto-elastic-boundary-z: 1000.0  # Z coordinate of fluid-solid interface (meters)
+physics:
+  is-elastic:         false  # true: pure elastic simulation
+  is-acousto-elastic: false  # true: coupled acoustic-elastic simulation
+  # acousto-elastic-boundary-z: 1000.0  # Z of fluid-solid interface (meters)
+  anisotropy:         iso    # iso | vti | tti  (elastic only)
+  is-model-on-nodes:  false  # true: material properties on nodes (false: on elements)
+  free-surface:       false  # true: free surface on top boundary (Z+)
 
-anisotropy:        iso   # Anisotropy of the middle (elastic only). Three supported argument iso | vti | tti
-is-model-on-nodes: false # true: material properties defined on nodes
-free-surface:      false # true: free surface on top boundary (Z+)
+  attenuation:  # SLS model — comment out to disable
+    qp: -1.0  # quality factor for P-waves (<0 = no attenuation)
+    qs: -1.0  # quality factor for S-waves (<0 = no attenuation)
+    # sls-reference-angular-frequencies: [10.0, 50.0, 200.0]  # rad/s
+    # sls-anelasticity-coefficients:     [0.1,  0.2,  0.05]
 
-# ---------------------------------------------------------------------------
-# Attenuation (SLS model) — omit or leave empty to disable
-# ---------------------------------------------------------------------------
-qp: -1.0   # quality factor for P-waves  (<0 = no attenuation)
-qs: -1.0   # quality factor for S-waves  (<0 = no attenuation)
-# sls-reference-angular-frequencies: [10.0, 50.0, 200.0]  # rad/s
-# sls-anelasticity-coefficients:     [0.1,  0.2,  0.05]
-
-# ----------------------------------------------------------------------------------------------
-# Absorbing boundaries (sponge) leave disabled by default, or set boundaries-size > 0 to enable
-# ----------------------------------------------------------------------------------------------
-boundaries-size: 0.0    # thickness of absorbing layer (meters, 0 = disabled)
-sponge-surface:  false  # include the top surface in the sponge
-taper-delta:     0.015  # taper decay rate
+  boundaries:  # absorbing sponge — set boundaries-size > 0 to enable
+    boundaries-size: 0.0    # absorbing layer thickness (meters, 0 = disabled)
+    sponge-surface:  false  # include the top surface in the sponge
+    taper-delta:     0.015  # taper decay rate
 
 # ---------------------------------------------------------------------------
-# Snapshots
+# Output
 # ---------------------------------------------------------------------------
-snapshots:     false  # true: save wavefield snapshots
-snap-interval: 20     # number of time steps between snapshots
-
-# ---------------------------------------------------------------------------
-# DAS (Distributed Acoustic Sensing) receiver — omit or set das-type: none
-# ---------------------------------------------------------------------------
-das-type:         none  # none | dipole | strain
-das-dip:          0.0   # fiber dip angle (degrees)
-das-azimuth:      0.0   # fiber azimuth angle (degrees)
-das-gauge-length: 1.0   # gauge length (meters)
-das-samples:      5     # number of integration points along fiber
+output:
+  snapshots:     false  # true: save wavefield snapshots
+  snap-interval: 20     # time steps between snapshots

--- a/examples/example_config.yaml
+++ b/examples/example_config.yaml
@@ -42,6 +42,9 @@ acquisition:
     srcx: 1010.0  # X coordinate (meters)
     srcy: 1010.0  # Y coordinate (meters)
     srcz: 1010.0  # Z coordinate (meters)
+    f0:   5.0     # dominant frequency of the Ricker wavelet (Hz)
+    tpeak: 0.2    # peak time of the Ricker wavelet (seconds)
+    ricker-order: 2  # order of the Ricker wavelet (1 or 2)
 
   receiver:
     rcvx: 1310.0  # X coordinate (meters)
@@ -60,7 +63,7 @@ acquisition:
 # ---------------------------------------------------------------------------
 time:
   dt:      0.006  # time step (seconds)
-  timemax: 0.7    # simulation duration (seconds)
+  timemax: 1.5    # simulation duration (seconds)
   auto-dt: false  # true: override dt with CFL-optimal value
 
 # ---------------------------------------------------------------------------

--- a/python/run_funtides.py
+++ b/python/run_funtides.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""
+run_funtides.py — Wrapper script to launch funtides-sem from a YAML config file.
+
+Usage:
+    python run_funtides.py config.yaml [extra CLI args passed to the binary]
+    python run_funtides.py --help
+
+YAML keys map 1-to-1 to the CLI flags of funtides-sem (dashes and underscores
+are treated identically). CLI arguments provided after the config file override
+the corresponding YAML values.
+
+The reserved key ``mpi-np`` (integer) is not passed to the binary — it controls
+whether the launch is prefixed with ``mpirun -np <mpi-np>``.
+
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Executable auto-detection
+# ---------------------------------------------------------------------------
+
+BINARY_NAME = "funtides-sem"
+
+# The script lives in <project_root>/python/, so go one level up.
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def find_executable(root: Path) -> Path:
+    """Search for funtides-sem in build*/bin/ directories under *root*.
+
+    If several copies are found, returns the most recently modified one.
+
+    Args:
+        root: Project root directory.
+
+    Returns:
+        Path to the funtides-sem binary.
+
+    Raises:
+        FileNotFoundError: If no binary is found.
+    """
+    candidates = sorted(
+        root.glob(f"build*/bin/{BINARY_NAME}"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    if not candidates:
+        raise FileNotFoundError(
+            f"No '{BINARY_NAME}' found in any build*/bin/ directory under {root}.\n"
+            "Build the project first (cmake + make)."
+        )
+    if len(candidates) > 1:
+        print(
+            f"[run_funtides] Multiple binaries found, using the most recent:\n"
+            f"  {candidates[0]}\n"
+            f"  (others: {', '.join(str(c) for c in candidates[1:])})\n"
+        )
+    return candidates[0]
+
+
+# ---------------------------------------------------------------------------
+# MPI launch prefix
+# ---------------------------------------------------------------------------
+
+# Keys consumed by this script — never forwarded to the binary.
+_SCRIPT_KEYS = {"mpi-np", "mpi-launcher"}
+
+# Flag used by each supported launcher to set the number of processes.
+_NP_FLAG: dict[str, str] = {
+    "mpirun":  "-np",
+    "mpiexec": "-n",
+    "srun":    "-n",
+    "jsrun":   "-n",
+}
+
+
+def _detect_scheduler() -> str | None:
+    """Return the scheduler name if running inside a known job allocation."""
+    if "SLURM_JOB_ID" in os.environ:
+        return "slurm"
+    if "LSB_JOBID" in os.environ:
+        return "lsf"
+    return None
+
+
+def build_mpi_prefix(config: dict) -> list[str]:
+    """Return the MPI launcher prefix to prepend to the command.
+
+    Resolution order for the launcher:
+    1. ``FUNTIDES_MPI_LAUNCHER`` environment variable
+    2. ``mpi-launcher`` YAML key
+    3. Auto-detected from the scheduler (SLURM → ``srun``, LSF → ``mpirun``)
+    4. ``mpirun`` (default for direct launches)
+
+    Resolution order for the number of processes:
+    1. ``FUNTIDES_MPI_NP`` environment variable
+    2. ``mpi-np`` YAML key (default: 1)
+
+    When running under SLURM with ``srun`` and no explicit ``mpi-np``, the
+    number of tasks is omitted so that srun inherits the allocation
+    (``#SBATCH --ntasks``).
+
+    Args:
+        config: Parsed YAML configuration dictionary.
+
+    Returns:
+        Launcher prefix as a list of strings, or ``[]`` for a direct launch.
+    """
+    # Resolve number of processes
+    env_np = os.environ.get("FUNTIDES_MPI_NP")
+    np = int(env_np) if env_np is not None else int(config.get("mpi-np", 1))
+
+    # Resolve launcher
+    launcher = (
+        os.environ.get("FUNTIDES_MPI_LAUNCHER")
+        or config.get("mpi-launcher")
+    )
+    if launcher is None:
+        scheduler = _detect_scheduler()
+        if scheduler == "slurm":
+            launcher = "srun"
+        elif scheduler == "lsf":
+            launcher = "mpirun"
+        elif np > 1:
+            launcher = "mpirun"
+        else:
+            return []  # single-process direct launch
+
+    launcher = str(launcher)
+    np_flag = _NP_FLAG.get(launcher, "-np")
+
+    # Under srun inside a SLURM allocation with no explicit np,
+    # omit -n and let srun inherit --ntasks from the batch header.
+    if launcher == "srun" and np <= 1 and _detect_scheduler() == "slurm":
+        return ["srun"]
+
+    # Warn if mpi-np conflicts with the scheduler allocation size.
+    if np > 1:
+        scheduler = _detect_scheduler()
+        allocated_str = None
+        scheduler_label = ""
+        if scheduler == "slurm":
+            allocated_str = os.environ.get("SLURM_NTASKS")
+            scheduler_label = "SLURM (SLURM_NTASKS)"
+        elif scheduler == "lsf":
+            allocated_str = os.environ.get("LSB_DJOB_NUMPROC")
+            scheduler_label = "LSF (LSB_DJOB_NUMPROC)"
+
+        if allocated_str is not None and int(allocated_str) != np:
+            allocated = int(allocated_str)
+            print(
+                f"[run_funtides] WARNING: mpi-np={np} differs from the "
+                f"{scheduler_label} allocation ({allocated}).",
+                file=sys.stderr,
+            )
+            if np > allocated:
+                print(
+                    f"[run_funtides] ERROR: requesting more tasks ({np}) than "
+                    f"allocated ({allocated}). The scheduler will reject this.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            else:
+                print(
+                    f"[run_funtides] WARNING: only {np}/{allocated} allocated "
+                    "tasks will be used.",
+                    file=sys.stderr,
+                )
+
+    if np > 1:
+        return [launcher, np_flag, str(np)]
+    return [launcher]
+
+
+def _normalize_key(key: str) -> str:
+    """Convert underscores to dashes so both styles are accepted in YAML."""
+    return key.replace("_", "-")
+
+
+def yaml_to_cli_args(config: dict) -> list[str]:
+    """Convert a YAML config dict to a list of CLI arguments.
+
+    Mapping rules:
+    - bool True  → ``--key``
+    - bool False → omitted (leaves binary default unchanged)
+    - list       → ``--key val1,val2,val3``
+    - empty list → omitted
+    - other      → ``--key value``
+
+    Args:
+        config: Parsed YAML configuration dictionary.
+
+    Returns:
+        List of CLI argument strings.
+    """
+    args: list[str] = []
+    for raw_key, value in config.items():
+        key = _normalize_key(raw_key)
+        if key in _SCRIPT_KEYS:
+            continue
+        if isinstance(value, bool):
+            if value:
+                args.append(f"--{key}")
+        elif isinstance(value, list):
+            if value:
+                args.extend([f"--{key}", ",".join(str(v) for v in value)])
+        else:
+            args.extend([f"--{key}", str(value)])
+    return args
+
+
+# ---------------------------------------------------------------------------
+# Help
+# ---------------------------------------------------------------------------
+
+HELP_TEXT = f"""\
+Usage:
+  python run_funtides.py <config.yaml> [extra args ...]
+  python run_funtides.py --help
+
+Arguments:
+  config.yaml   Path to a YAML configuration file. Keys match the CLI flags
+                of {BINARY_NAME} (dashes and underscores interchangeable).
+  extra args    Any additional arguments are appended as-is to the command
+                line, overriding the YAML values where applicable.
+
+Binary selection:
+  If the environment variable FUNTIDES_BIN is set, it is used directly.
+  Otherwise the script searches for '{BINARY_NAME}' in build*/bin/ under the
+  project root, and picks the most recently modified binary if several exist.
+
+MPI:
+  mpi-np: N          Number of MPI processes (default: 1 = direct launch).
+  mpi-launcher: X    Launcher to use: mpirun | mpiexec | srun | jsrun.
+                     Auto-detected when inside a SLURM or LSF allocation
+                     (SLURM → srun, LSF → mpirun).  Under srun, omitting
+                     mpi-np lets the job inherit --ntasks from the batch header.
+  Environment overrides: FUNTIDES_MPI_NP, FUNTIDES_MPI_LAUNCHER.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    args = sys.argv[1:]
+
+    if not args or args[0] in ("-h", "--help"):
+        print(HELP_TEXT)
+        return 0
+
+    config_path = Path(args[0])
+    extra_args = args[1:]
+
+    if not config_path.exists():
+        print(f"[run_funtides] Error: config file not found: {config_path}", file=sys.stderr)
+        return 1
+
+    try:
+        with config_path.open() as f:
+            config = yaml.safe_load(f)
+    except yaml.YAMLError as exc:
+        print(f"[run_funtides] Error parsing {config_path}: {exc}", file=sys.stderr)
+        return 1
+
+    # Locate executable — honour FUNTIDES_BIN if set, otherwise auto-detect
+    env_bin = os.environ.get("FUNTIDES_BIN")
+    if env_bin:
+        binary = Path(env_bin)
+        if not binary.exists():
+            print(f"[run_funtides] FUNTIDES_BIN points to a non-existent path: {binary}", file=sys.stderr)
+            return 1
+        print(f"[run_funtides] Binary (FUNTIDES_BIN): {binary}\n")
+    else:
+        try:
+            binary = find_executable(PROJECT_ROOT)
+        except FileNotFoundError as exc:
+            print(f"[run_funtides] {exc}", file=sys.stderr)
+            return 1
+
+    mpi_prefix = build_mpi_prefix(config)
+    cli_args = yaml_to_cli_args(config)
+    cmd = mpi_prefix + [str(binary)] + cli_args + extra_args
+
+    print(f"[run_funtides] Binary : {binary}")
+    print(f"[run_funtides] Command: {' '.join(cmd)}\n")
+
+    result = subprocess.run(cmd)
+    return result.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/run_funtides.py
+++ b/python/run_funtides.py
@@ -71,7 +71,7 @@ def find_executable(root: Path) -> Path:
 # ---------------------------------------------------------------------------
 
 # Keys consumed by this script — never forwarded to the binary.
-_SCRIPT_KEYS = {"mpi-np", "mpi-launcher"}
+_SCRIPT_KEYS = {"mpi-np", "mpi-launcher", "launcher"}
 
 # Flag used by each supported launcher to set the number of processes.
 _NP_FLAG: dict[str, str] = {
@@ -114,13 +114,19 @@ def build_mpi_prefix(config: dict) -> list[str]:
     Returns:
         Launcher prefix as a list of strings, or ``[]`` for a direct launch.
     """
+    # mpi-np / mpi-launcher may live under a "launcher:" section or at root
+    launcher_section = config.get("launcher") or {}
+
     # Resolve number of processes
     env_np = os.environ.get("FUNTIDES_MPI_NP")
-    np = int(env_np) if env_np is not None else int(config.get("mpi-np", 1))
+    np = int(env_np) if env_np is not None else int(
+        launcher_section.get("mpi-np", config.get("mpi-np", 1))
+    )
 
     # Resolve launcher
     launcher = (
         os.environ.get("FUNTIDES_MPI_LAUNCHER")
+        or launcher_section.get("mpi-launcher")
         or config.get("mpi-launcher")
     )
     if launcher is None:
@@ -188,11 +194,15 @@ def _normalize_key(key: str) -> str:
 def yaml_to_cli_args(config: dict) -> list[str]:
     """Convert a YAML config dict to a list of CLI arguments.
 
-    Mapping rules:
+    The config may be flat or organized into arbitrary sections (nested dicts).
+    Section names are ignored — only leaf values are converted.
+
+    Mapping rules for leaf values:
     - bool True  → ``--key``
     - bool False → omitted (leaves binary default unchanged)
     - list       → ``--key val1,val2,val3``
     - empty list → omitted
+    - dict       → recurse (section grouping, name ignored)
     - other      → ``--key value``
 
     Args:
@@ -206,7 +216,11 @@ def yaml_to_cli_args(config: dict) -> list[str]:
         key = _normalize_key(raw_key)
         if key in _SCRIPT_KEYS:
             continue
-        if isinstance(value, bool):
+        if value is None:
+            continue  # commented-out or empty YAML section
+        if isinstance(value, dict):
+            args.extend(yaml_to_cli_args(value))  # section — recurse, name ignored
+        elif isinstance(value, bool):
             if value:
                 args.append(f"--{key}")
         elif isinstance(value, list):

--- a/src/main/fd/src/fd_proxy.cc
+++ b/src/main/fd/src/fd_proxy.cc
@@ -274,8 +274,9 @@ void FdtdProxy::InitSource()
   // Compute source term (e.g., Ricker wavelet)
   kernels_.RHSTerm = allocateVector<vectorReal>(num_time_samples_, "RHSTerm");
 
+  float const tpeak = 1.0f / source_frequency_;
   std::vector<float> source_term = utils_.computeSourceTerm(
-      num_time_samples_, time_step_, source_frequency_, source_order_);
+      num_time_samples_, time_step_, source_frequency_, source_order_, tpeak);
 
   for (int i = 0; i < num_time_samples_; i++)
   {

--- a/src/main/fe/include/sem_proxy.h
+++ b/src/main/fe/include/sem_proxy.h
@@ -125,9 +125,10 @@ class SEMproxy
   int num_sample_;
   // source parameters
   const int myNumberOfRHS = 1;
-  const float f0 = 5.0f;
-  const int sourceOrder = 2;
   int myElementSource = 0;
+  float tpeak_;
+  float f0_;
+  int ricker_order_;
 
   std::shared_ptr<model::ModelApi<float, int>> m_mesh;
   std::unique_ptr<solver::fe::Solver> m_solver;

--- a/src/main/fe/include/sem_proxy_options.h
+++ b/src/main/fe/include/sem_proxy_options.h
@@ -17,9 +17,9 @@ class SemProxyOptions
   float lx = 2000.f, ly = 2000.f, lz = 2000.f;
   float srcx = 1010.f, srcy = 1010.f, srcz = 1010.f;
   float rcvx = 1310.f, rcvy = 1310.f, rcvz = 1310.f;
-  float f0 = 10.f;       // dominant frequency of the source in Hz
+  float f0 = 5.0f;       // dominant frequency of the source in Hz
   int ricker_order = 2;  // order of the Ricker wavelet source
-  float tpeak = 0.1f;    // peak time of the Ricker wavelet source
+  float tpeak = 0.2f;    // peak time of the Ricker wavelet source
 
   std::string implem = "makutu";  // makutu
   std::string method = "sem";     // sem

--- a/src/main/fe/include/sem_proxy_options.h
+++ b/src/main/fe/include/sem_proxy_options.h
@@ -17,6 +17,9 @@ class SemProxyOptions
   float lx = 2000.f, ly = 2000.f, lz = 2000.f;
   float srcx = 1010.f, srcy = 1010.f, srcz = 1010.f;
   float rcvx = 1310.f, rcvy = 1310.f, rcvz = 1310.f;
+  float f0 = 10.f;       // dominant frequency of the source in Hz
+  int ricker_order = 2;  // order of the Ricker wavelet source
+  float tpeak = 0.1f;    // peak time of the Ricker wavelet source
 
   std::string implem = "makutu";  // makutu
   std::string method = "sem";     // sem
@@ -120,6 +123,12 @@ class SemProxyOptions
         "das-samples",
         "Number of integration points along DAS fiber (default=5)",
         cxxopts::value<int>(o.das_samples))(
+        "f0", "Dominant frequency of the source in Hz",
+        cxxopts::value<float>(o.f0))("tpeak",
+                                     "Peak time of the Ricker wavelet source",
+                                     cxxopts::value<float>(o.tpeak))(
+        "ricker-order", "Order of the Ricker wavelet source",
+        cxxopts::value<int>(o.ricker_order))(
         "srcx", "Source position X (meters)", cxxopts::value<float>(o.srcx))(
         "srcy", "Source position Y (meters)", cxxopts::value<float>(o.srcy))(
         "srcz", "Source position Z (meters)", cxxopts::value<float>(o.srcz))(

--- a/src/main/fe/src/sem_proxy.cc
+++ b/src/main/fe/src/sem_proxy.cc
@@ -98,9 +98,9 @@ SEMproxy::SEMproxy(const SemProxyOptions& opt)
   else if (opt.qp > 0 || opt.qs > 0)
   {
     // Auto-enable SLS with default reference frequency based on source f0
-    float omega0 = 2.0f * M_PI * f0;
+    float omega0 = 2.0f * M_PI * opt.f0;
     std::cout << "Auto-enabling SLS attenuation at omega0=" << omega0
-              << " rad/s (f0=" << f0 << " Hz)" << std::endl;
+              << " rad/s (f0=" << opt.f0 << " Hz)" << std::endl;
     auto freqView = allocateVector<vectorReal>(1, "slsFreqAuto");
     freqView[0] = omega0;
     m_solver->setSLSAttenuation(freqView);
@@ -738,7 +738,7 @@ void SEMproxy::init_source()
 
   // initialize source term
   vector<float> sourceTerm =
-      myUtils.computeSourceTerm(num_sample_, dt_, f0, sourceOrder);
+      myUtils.computeSourceTerm(num_sample_, dt_, f0_, ricker_order_, tpeak_);
   if (isAcoustoElastic_)
   {
     // Auto-detect source domain based on depth vs interface boundary.
@@ -1141,6 +1141,9 @@ void SEMproxy::init_sim_params(const SemProxyOptions& opt)
   src_coord_[0] = opt.srcx;
   src_coord_[1] = opt.srcy;
   src_coord_[2] = opt.srcz;
+  tpeak_ = opt.tpeak;
+  f0_ = opt.f0;
+  ricker_order_ = opt.ricker_order;
 
   rcv_coord_[0] = opt.rcvx;
   rcv_coord_[1] = opt.rcvy;

--- a/src/utils/include/utils.h
+++ b/src/utils/include/utils.h
@@ -63,7 +63,7 @@ struct SolverUtils
 
   std::vector<float> computeSourceTerm(const int nSamples,
                                        const float timeSample, const float f0,
-                                       const float tpeak, const int order)
+                                       const int order, const float tpeak)
   {
     std::vector<float> sourceTerm(nSamples);
     for (int i = 0; i < nSamples; i++)

--- a/src/utils/include/utils.h
+++ b/src/utils/include/utils.h
@@ -6,11 +6,12 @@ using namespace std::chrono;
 
 struct SolverUtils
 {
-  float evaluateRicker(float const& time_n, float const& f0, int order)
+  float evaluateRicker(float const& time_n, float const& f0, int order,
+                       float const& tpeak)
   {
-    float const o_tpeak = 1.0 / f0;
+    // float const tpeak = 1.0 / f0;
     float pulse = 0.0;
-    if ((time_n <= -0.9 * o_tpeak) || (time_n >= 2.9 * o_tpeak))
+    if ((time_n <= -0.9 * tpeak) || (time_n >= 2.9 * tpeak))
     {
       return pulse;
     }
@@ -22,32 +23,32 @@ struct SolverUtils
     {
       case 4: {
         pulse = 4.0 * lam * lam *
-                (3.0 - 12.0 * lam * (time_n - o_tpeak) * (time_n - o_tpeak) +
-                 4.0 * lam * lam * (time_n - o_tpeak) * (time_n - o_tpeak) *
-                     (time_n - o_tpeak) * (time_n - o_tpeak)) *
-                exp(-lam * (time_n - o_tpeak) * (time_n - o_tpeak));
+                (3.0 - 12.0 * lam * (time_n - tpeak) * (time_n - tpeak) +
+                 4.0 * lam * lam * (time_n - tpeak) * (time_n - tpeak) *
+                     (time_n - tpeak) * (time_n - tpeak)) *
+                exp(-lam * (time_n - tpeak) * (time_n - tpeak));
       }
       break;
       case 3: {
-        pulse = 4.0 * lam * lam * (time_n - o_tpeak) *
-                (3.0 - 2.0 * lam * (time_n - o_tpeak) * (time_n - o_tpeak)) *
-                exp(-lam * (time_n - o_tpeak) * (time_n - o_tpeak));
+        pulse = 4.0 * lam * lam * (time_n - tpeak) *
+                (3.0 - 2.0 * lam * (time_n - tpeak) * (time_n - tpeak)) *
+                exp(-lam * (time_n - tpeak) * (time_n - tpeak));
       }
       break;
       case 2: {
         pulse = 2.0 * lam *
-                (2.0 * lam * (time_n - o_tpeak) * (time_n - o_tpeak) - 1.0) *
-                exp(-lam * (time_n - o_tpeak) * (time_n - o_tpeak));
+                (2.0 * lam * (time_n - tpeak) * (time_n - tpeak) - 1.0) *
+                exp(-lam * (time_n - tpeak) * (time_n - tpeak));
       }
       break;
       case 1: {
-        pulse = -2.0 * lam * (time_n - o_tpeak) *
-                exp(-lam * (time_n - o_tpeak) * (time_n - o_tpeak));
+        pulse = -2.0 * lam * (time_n - tpeak) *
+                exp(-lam * (time_n - tpeak) * (time_n - tpeak));
       }
       break;
       case 0: {
-        pulse = -(time_n - o_tpeak) *
-                exp(-2 * lam * (time_n - o_tpeak) * (time_n - o_tpeak));
+        pulse = -(time_n - tpeak) *
+                exp(-2 * lam * (time_n - tpeak) * (time_n - tpeak));
       }
       break;
       default:
@@ -62,13 +63,13 @@ struct SolverUtils
 
   std::vector<float> computeSourceTerm(const int nSamples,
                                        const float timeSample, const float f0,
-                                       const int order)
+                                       const float tpeak, const int order)
   {
     std::vector<float> sourceTerm(nSamples);
     for (int i = 0; i < nSamples; i++)
     {
       float time_n = i * timeSample;
-      sourceTerm[i] = evaluateRicker(time_n, f0, order);
+      sourceTerm[i] = evaluateRicker(time_n, f0, order, tpeak);
     }
     return sourceTerm;
   }

--- a/tests/benchmarks/cpp/src/bench_solver_fe_cartesian_struct_acoustic.cc
+++ b/tests/benchmarks/cpp/src/bench_solver_fe_cartesian_struct_acoustic.cc
@@ -165,8 +165,9 @@ BENCHMARK_TEMPLATE_METHOD_F(SolverStructFixture, OneStep)
 
   // ricker wavelet
   SolverUtils myUtils;
-  std::vector<float> sourceTerm =
-      myUtils.computeSourceTerm(this->n_time_steps, this->dt, this->f0, 2);
+  float const tpeak = 1.0f / this->f0;
+  std::vector<float> sourceTerm = myUtils.computeSourceTerm(
+      this->n_time_steps, this->dt, this->f0, 2, tpeak);
   for (int j = 0; j < this->n_time_steps; j++)
   {
     arrays.rhsTerm(0, j) = sourceTerm[j];

--- a/tests/benchmarks/cpp/src/bench_solver_fe_cartesian_struct_elastic.cc
+++ b/tests/benchmarks/cpp/src/bench_solver_fe_cartesian_struct_elastic.cc
@@ -177,8 +177,9 @@ BENCHMARK_TEMPLATE_METHOD_F(SolverStructFixture, OneStep)
 
   // ricker wavelet
   SolverUtils myUtils;
-  std::vector<float> sourceTerm =
-      myUtils.computeSourceTerm(this->n_time_steps, this->dt, this->f0, 2);
+  float const tpeak = 1.0f / this->f0;
+  std::vector<float> sourceTerm = myUtils.computeSourceTerm(
+      this->n_time_steps, this->dt, this->f0, 2, tpeak);
   for (int j = 0; j < this->n_time_steps; j++)
   {
     arrays.rhsTermx(0, j) = sourceTerm[j];

--- a/tests/benchmarks/cpp/src/bench_solver_fe_cartesian_unstruct_acoustic.cc
+++ b/tests/benchmarks/cpp/src/bench_solver_fe_cartesian_unstruct_acoustic.cc
@@ -165,8 +165,9 @@ BENCHMARK_TEMPLATE_METHOD_F(SolverUnstructFixture, OneStep)
 
   // ricker wavelet
   SolverUtils myUtils;
-  std::vector<float> sourceTerm =
-      myUtils.computeSourceTerm(this->n_time_steps, this->dt, this->f0, 2);
+  float const tpeak = 1.0f / this->f0;
+  std::vector<float> sourceTerm = myUtils.computeSourceTerm(
+      this->n_time_steps, this->dt, this->f0, 2, tpeak);
   for (int j = 0; j < this->n_time_steps; j++)
   {
     arrays.rhsTerm(0, j) = sourceTerm[j];

--- a/tests/benchmarks/cpp/src/bench_solver_fe_cartesian_unstruct_elastic.cc
+++ b/tests/benchmarks/cpp/src/bench_solver_fe_cartesian_unstruct_elastic.cc
@@ -176,8 +176,9 @@ BENCHMARK_TEMPLATE_METHOD_F(SolverUnstructFixture, OneStep)
 
   // ricker wavelet
   SolverUtils myUtils;
-  std::vector<float> sourceTerm =
-      myUtils.computeSourceTerm(this->n_time_steps, this->dt, this->f0, 2);
+  float const tpeak = 1.0f / this->f0;
+  std::vector<float> sourceTerm = myUtils.computeSourceTerm(
+      this->n_time_steps, this->dt, this->f0, 2, tpeak);
   for (int j = 0; j < this->n_time_steps; j++)
   {
     arrays.rhsTermx(0, j) = sourceTerm[j];

--- a/tests/units/utils/test_evaluate_ricker.cc
+++ b/tests/units/utils/test_evaluate_ricker.cc
@@ -23,22 +23,22 @@ class EvaluateRickerTest : public ::testing::Test
 // At t = tpeak => 0
 TEST_F(EvaluateRickerTest, Order0_AtPeak_IsZero)
 {
-  EXPECT_NEAR(ricker.evaluateRicker(tpeak, f0, 0), 0.0f, 1e-7f);
+  EXPECT_NEAR(ricker.evaluateRicker(tpeak, f0, 0, tpeak), 0.0f, 1e-7f);
 }
 
 // --- Order 1 (first derivative of Gaussian): -2*lam*(t-tpeak)*exp(...)  ---
 // At t = tpeak => 0  (odd function around tpeak)
 TEST_F(EvaluateRickerTest, Order1_AtPeak_IsZero)
 {
-  EXPECT_NEAR(ricker.evaluateRicker(tpeak, f0, 1), 0.0f, 1e-7f);
+  EXPECT_NEAR(ricker.evaluateRicker(tpeak, f0, 1, tpeak), 0.0f, 1e-7f);
 }
 
 // Order 1 is antisymmetric: f(tpeak + dt) = -f(tpeak - dt)
 TEST_F(EvaluateRickerTest, Order1_IsAntisymmetric)
 {
   float dt = 0.02f;
-  float vp = ricker.evaluateRicker(tpeak + dt, f0, 1);
-  float vm = ricker.evaluateRicker(tpeak - dt, f0, 1);
+  float vp = ricker.evaluateRicker(tpeak + dt, f0, 1, tpeak);
+  float vm = ricker.evaluateRicker(tpeak - dt, f0, 1, tpeak);
   EXPECT_NEAR(vp, -vm, 1e-6f);
 }
 
@@ -47,15 +47,15 @@ TEST_F(EvaluateRickerTest, Order1_IsAntisymmetric)
 TEST_F(EvaluateRickerTest, Order2_AtPeak)
 {
   float expected = -2.0f * lam;
-  EXPECT_NEAR(ricker.evaluateRicker(tpeak, f0, 2), expected, 1e-3f);
+  EXPECT_NEAR(ricker.evaluateRicker(tpeak, f0, 2, tpeak), expected, 1e-3f);
 }
 
 // Order 2 is symmetric: f(tpeak + dt) = f(tpeak - dt)
 TEST_F(EvaluateRickerTest, Order2_IsSymmetric)
 {
   float dt = 0.03f;
-  float vp = ricker.evaluateRicker(tpeak + dt, f0, 2);
-  float vm = ricker.evaluateRicker(tpeak - dt, f0, 2);
+  float vp = ricker.evaluateRicker(tpeak + dt, f0, 2, tpeak);
+  float vm = ricker.evaluateRicker(tpeak - dt, f0, 2, tpeak);
   EXPECT_NEAR(vp, vm, 1e-6f);
 }
 
@@ -63,15 +63,15 @@ TEST_F(EvaluateRickerTest, Order2_IsSymmetric)
 // At t = tpeak: (time_n - o_tpeak) = 0 => pulse = 0
 TEST_F(EvaluateRickerTest, Order3_AtPeak_IsZero)
 {
-  EXPECT_NEAR(ricker.evaluateRicker(tpeak, f0, 3), 0.0f, 1e-7f);
+  EXPECT_NEAR(ricker.evaluateRicker(tpeak, f0, 3, tpeak), 0.0f, 1e-7f);
 }
 
 // Order 3 is antisymmetric
 TEST_F(EvaluateRickerTest, Order3_IsAntisymmetric)
 {
   float dt = 0.02f;
-  float vp = ricker.evaluateRicker(tpeak + dt, f0, 3);
-  float vm = ricker.evaluateRicker(tpeak - dt, f0, 3);
+  float vp = ricker.evaluateRicker(tpeak + dt, f0, 3, tpeak);
+  float vm = ricker.evaluateRicker(tpeak - dt, f0, 3, tpeak);
   EXPECT_NEAR(vp, -vm, 1e-5f);
 }
 
@@ -80,15 +80,15 @@ TEST_F(EvaluateRickerTest, Order3_IsAntisymmetric)
 TEST_F(EvaluateRickerTest, Order4_AtPeak)
 {
   float expected = 12.0f * lam * lam;
-  EXPECT_NEAR(ricker.evaluateRicker(tpeak, f0, 4), expected, 1e-1f);
+  EXPECT_NEAR(ricker.evaluateRicker(tpeak, f0, 4, tpeak), expected, 1e-1f);
 }
 
 // Order 4 is symmetric
 TEST_F(EvaluateRickerTest, Order4_IsSymmetric)
 {
   float dt = 0.02f;
-  float vp = ricker.evaluateRicker(tpeak + dt, f0, 4);
-  float vm = ricker.evaluateRicker(tpeak - dt, f0, 4);
+  float vp = ricker.evaluateRicker(tpeak + dt, f0, 4, tpeak);
+  float vm = ricker.evaluateRicker(tpeak - dt, f0, 4, tpeak);
   EXPECT_NEAR(vp, vm, 1e-4f);
 }
 
@@ -97,10 +97,11 @@ TEST_F(EvaluateRickerTest, OutsideWindow_ReturnsZero)
 {
   for (int ord = 0; ord <= 4; ++ord)
   {
-    EXPECT_FLOAT_EQ(ricker.evaluateRicker(-0.9f * tpeak - 0.001f, f0, ord),
-                    0.0f)
+    EXPECT_FLOAT_EQ(
+        ricker.evaluateRicker(-0.9f * tpeak - 0.001f, f0, ord, tpeak), 0.0f)
         << "order=" << ord << " before window";
-    EXPECT_FLOAT_EQ(ricker.evaluateRicker(2.9f * tpeak + 0.001f, f0, ord), 0.0f)
+    EXPECT_FLOAT_EQ(
+        ricker.evaluateRicker(2.9f * tpeak + 0.001f, f0, ord, tpeak), 0.0f)
         << "order=" << ord << " after window";
   }
 }
@@ -111,10 +112,10 @@ TEST_F(EvaluateRickerTest, DerivativeConsistency_Order1vs2)
 {
   float t = tpeak + 0.04f;
   float h = 1e-4f;
-  float fd = (ricker.evaluateRicker(t + h, f0, 1) -
-              ricker.evaluateRicker(t - h, f0, 1)) /
+  float fd = (ricker.evaluateRicker(t + h, f0, 1, tpeak) -
+              ricker.evaluateRicker(t - h, f0, 1, tpeak)) /
              (2.0f * h);
-  float analytical = ricker.evaluateRicker(t, f0, 2);
+  float analytical = ricker.evaluateRicker(t, f0, 2, tpeak);
   EXPECT_NEAR(fd, analytical, std::abs(analytical) * 0.01f);
 }
 
@@ -122,10 +123,10 @@ TEST_F(EvaluateRickerTest, DerivativeConsistency_Order2vs3)
 {
   float t = tpeak + 0.04f;
   float h = 1e-4f;
-  float fd = (ricker.evaluateRicker(t + h, f0, 2) -
-              ricker.evaluateRicker(t - h, f0, 2)) /
+  float fd = (ricker.evaluateRicker(t + h, f0, 2, tpeak) -
+              ricker.evaluateRicker(t - h, f0, 2, tpeak)) /
              (2.0f * h);
-  float analytical = ricker.evaluateRicker(t, f0, 3);
+  float analytical = ricker.evaluateRicker(t, f0, 3, tpeak);
   EXPECT_NEAR(fd, analytical, std::abs(analytical) * 0.01f);
 }
 
@@ -133,10 +134,10 @@ TEST_F(EvaluateRickerTest, DerivativeConsistency_Order3vs4)
 {
   float t = tpeak + 0.04f;
   float h = 1e-4f;
-  float fd = (ricker.evaluateRicker(t + h, f0, 3) -
-              ricker.evaluateRicker(t - h, f0, 3)) /
+  float fd = (ricker.evaluateRicker(t + h, f0, 3, tpeak) -
+              ricker.evaluateRicker(t - h, f0, 3, tpeak)) /
              (2.0f * h);
-  float analytical = ricker.evaluateRicker(t, f0, 4);
+  float analytical = ricker.evaluateRicker(t, f0, 4, tpeak);
   EXPECT_NEAR(fd, analytical, std::abs(analytical) * 0.01f);
 }
 


### PR DESCRIPTION
This PR add a python script which reads an input file (yaml format)  and launch the executable funtides-sem using the options defined inside the yaml file (see an example in examples/example_config.yaml)

You can also use as an option the number of mpi rank and the scheduler (if needed on a cluster)