### PR TITLE
Optimize stiffness computation

### DIFF
--- a/src/discretization/fe/makutu/include/Qk_Hexahedron_Lagrange_GaussLobatto.h
+++ b/src/discretization/fe/makutu/include/Qk_Hexahedron_Lagrange_GaussLobatto.h
@@ -596,6 +596,39 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
       TransformType const &transformData, FUNC1 &&func1, FUNC2 &&func2);
 
   /**
+   * @brief Sum-factorized elastic stiffness kernel (O(N^4)).
+   *
+   * Computes the stiffness contribution for an elastic element using sum
+   * factorization, reducing the per-element cost from O(N^5) to O(N^4).
+   * Three passes:
+   *   1. Gradient: compute ∂u_s/∂ξ_r at each quad point for all displacement
+   *      components s and reference directions r.
+   *   2. Flux: call @p func1 to obtain the flux contributions F^p_f[q]
+   *      (test direction p, force component f), which are then scaled by
+   *      the quadrature weight and Jacobian determinant inside the kernel.
+   *   3. Divergence: scatter D^T·F back to node forces for each component.
+   *
+   * @tparam FUNC1 Callable with signature
+   *   `void(int qa, int qb, int qc,
+   *         real_t const (&J_inv)[3][3],
+   *         real_t const (&grad_u_ref)[3][3],
+   *         real_t (&flux)[3][3])`
+   *   where @p J_inv is the inverted Jacobian, @p grad_u_ref[r][s] =
+   *   ∂u_s/∂ξ_r, and @p flux[p][f] is the unscaled flux contribution
+   *   (scaled by w·|detJ| inside the kernel).
+   * @param transformData  8 corner coordinates of the hexahedral element.
+   * @param u_local        Displacement at element nodes, shape [3][numNodes].
+   * @param f_local        Force accumulation buffer, shape [3][numNodes],
+   *                       accumulated in-place.
+   * @param func1          Constitutive callback; all physics stays in the
+   *                       caller, the kernel remains physics-free.
+   */
+  template <typename FUNC1>
+  PROXY_HOST_DEVICE static void computeElasticStiffnessSumFact(
+      TransformType const &transformData, real_t const (&u_local)[3][numNodes],
+      real_t (&f_local)[3][numNodes], FUNC1 &&func1);
+
+  /**
    * @brief Apply a Jacobian transformation matrix from the parent space to the
    *   physical space on the parent shape function derivatives, producing the
    *   shape function derivatives in the physical space.
@@ -1202,6 +1235,106 @@ Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeStiffNessTermwithJac(
         JacobianType J = {{0}};
         jacobianTransformation(qa, qb, qc, transformData.data, J.data);
         computeGradPhiGradPhi<qa, qb, qc>(J, func1, func2);
+      });
+}
+
+template <typename GL_BASIS>
+template <typename FUNC1>
+PROXY_HOST_DEVICE void
+Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeElasticStiffnessSumFact(
+    TransformType const &transformData, real_t const (&u_local)[3][numNodes],
+    real_t (&f_local)[3][numNodes], FUNC1 &&func1)
+{
+  // 9 flux arrays: F_xi/F_eta/F_zeta[force_comp][quad_point]
+  real_t F_xi[3][numNodes] = {{0}};
+  real_t F_eta[3][numNodes] = {{0}};
+  real_t F_zeta[3][numNodes] = {{0}};
+
+  // Pass 1+2: gradient + flux.
+  // For each quad point: compute reference gradients of all 3 displacement
+  // components, invert the Jacobian, delegate the constitutive computation to
+  // func1, then scale and store into the flux arrays.
+  triple_loop<num1dNodes, num1dNodes, num1dNodes>(
+      [&](auto const icqa, auto const icqb, auto const icqc) {
+        constexpr int qa = decltype(icqa)::value;
+        constexpr int qb = decltype(icqb)::value;
+        constexpr int qc = decltype(icqc)::value;
+        constexpr int q = GL_BASIS::TensorProduct3D::linearIndex(qa, qb, qc);
+        constexpr real_t w =
+            GL_BASIS::weight(qa) * GL_BASIS::weight(qb) * GL_BASIS::weight(qc);
+
+        // Reference gradients of each displacement component along ξ, η, ζ.
+        // grad_u_ref[r][s] = ∂u_s/∂ξ_r
+        real_t grad_u_ref[3][3] = {{0}};
+        for_constexpr<num1dNodes>([&](auto ici) {
+          constexpr int i = decltype(ici)::value;
+          constexpr int ibc = GL_BASIS::TensorProduct3D::linearIndex(i, qb, qc);
+          constexpr int aic = GL_BASIS::TensorProduct3D::linearIndex(qa, i, qc);
+          constexpr int abi = GL_BASIS::TensorProduct3D::linearIndex(qa, qb, i);
+          const real_t gxi = basisGradientAt(i, qa);
+          const real_t geta = basisGradientAt(i, qb);
+          const real_t gzeta = basisGradientAt(i, qc);
+          for (int s = 0; s < 3; ++s)
+          {
+            grad_u_ref[0][s] += gxi * u_local[s][ibc];
+            grad_u_ref[1][s] += geta * u_local[s][aic];
+            grad_u_ref[2][s] += gzeta * u_local[s][abi];
+          }
+        });
+
+        // Jacobian (inverted in-place, returns det).
+        JacobianType J = {{0}};
+        jacobianTransformation(qa, qb, qc, transformData.data, J.data);
+        real_t const detJ = invert3x3(J.data);
+        const real_t scale = w * detJ;
+
+        // flux[p][f] = unscaled flux contribution for test direction p and
+        // force component f — filled by the constitutive callback.
+        real_t flux[3][3] = {{0}};
+        func1(qa, qb, qc, J.data, grad_u_ref, flux);
+
+        F_xi[0][q] = scale * flux[0][0];
+        F_xi[1][q] = scale * flux[0][1];
+        F_xi[2][q] = scale * flux[0][2];
+        F_eta[0][q] = scale * flux[1][0];
+        F_eta[1][q] = scale * flux[1][1];
+        F_eta[2][q] = scale * flux[1][2];
+        F_zeta[0][q] = scale * flux[2][0];
+        F_zeta[1][q] = scale * flux[2][1];
+        F_zeta[2][q] = scale * flux[2][2];
+      });
+
+  // Pass 3: divergence — f_{ia,ib,ic} += D^T·F^ξ + D^T·F^η + D^T·F^ζ
+  triple_loop<num1dNodes, num1dNodes, num1dNodes>(
+      [&](auto const icia, auto const icib, auto const icic) {
+        constexpr int ia = decltype(icia)::value;
+        constexpr int ib = decltype(icib)::value;
+        constexpr int ic = decltype(icic)::value;
+        constexpr int node = GL_BASIS::TensorProduct3D::linearIndex(ia, ib, ic);
+
+        for (int f = 0; f < 3; ++f)
+        {
+          real_t v = 0;
+          for_constexpr<num1dNodes>([&](auto icqa) {
+            constexpr int qa = decltype(icqa)::value;
+            constexpr int q_xi =
+                GL_BASIS::TensorProduct3D::linearIndex(qa, ib, ic);
+            v += basisGradientAt(ia, qa) * F_xi[f][q_xi];
+          });
+          for_constexpr<num1dNodes>([&](auto icqb) {
+            constexpr int qb = decltype(icqb)::value;
+            constexpr int q_eta =
+                GL_BASIS::TensorProduct3D::linearIndex(ia, qb, ic);
+            v += basisGradientAt(ib, qb) * F_eta[f][q_eta];
+          });
+          for_constexpr<num1dNodes>([&](auto icqc) {
+            constexpr int qc = decltype(icqc)::value;
+            constexpr int q_zeta =
+                GL_BASIS::TensorProduct3D::linearIndex(ia, ib, qc);
+            v += basisGradientAt(ic, qc) * F_zeta[f][q_zeta];
+          });
+          f_local[f][node] += v;
+        }
       });
 }
 

--- a/src/discretization/fe/makutu/include/Qk_Hexahedron_Lagrange_GaussLobatto.h
+++ b/src/discretization/fe/makutu/include/Qk_Hexahedron_Lagrange_GaussLobatto.h
@@ -24,7 +24,6 @@ template <typename GL_BASIS>
 class Qk_Hexahedron_Lagrange_GaussLobatto final
 {
  public:
-  constexpr static bool isShiva = false;
 
   // Expose the basis type for tests and external use
   using BasisType = GL_BASIS;

--- a/src/discretization/fe/makutu/include/Qk_Hexahedron_Lagrange_GaussLobatto.h
+++ b/src/discretization/fe/makutu/include/Qk_Hexahedron_Lagrange_GaussLobatto.h
@@ -504,6 +504,31 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
       TransformType const &transformData, FUNC1 &&func1, FUNC2 &&func2);
 
   /**
+   * @brief Acoustic stiffness K·p via sum factorization (3-pass algorithm).
+   *
+   * Computes the elemental contribution (K·p)_i = ∫ ∇φ_i · (1/ρ) ∇p dV and
+   * accumulates it into @p f_local using three passes:
+   *   1. Gradient: compute ∂p/∂ξ, ∂p/∂η, ∂p/∂ζ at each quad point via D·p.
+   *   2. Flux: apply B/ρ and quadrature weight to obtain G^{ξ,η,ζ} at each
+   *      quad point.
+   *   3. Divergence: scatter D^T·G back to node forces.
+   *
+   * Complexity per element: O(N^4) vs O(N^5) for the direct assembly.
+   *
+   * @tparam FUNC_RHO Callable with signature `real_t(int qa, int qb, int qc)`
+   *                  returning 1/ρ at reference quad point (qa, qb, qc).
+   * @param transformData 8 corner coordinates of the hexahedral element.
+   * @param p_local       Pressure at element nodes (size numNodes).
+   * @param f_local       Force accumulation buffer (size numNodes), added
+   *                      to in-place.
+   * @param get_inv_rho   Material callback returning 1/ρ per quad point.
+   */
+  template <typename FUNC_ALPHA>
+  PROXY_HOST_DEVICE static void computeStiffnessTermSumFact(
+      TransformType const &transformData, real_t const (&p_local)[numNodes],
+      real_t (&f_local)[numNodes], FUNC_ALPHA &&get_alpha);
+
+  /**
    * @brief Computes the "Grad(Phi)*B*Grad(Phi)" coefficient of the stiffness
    * term. The matrix B must be provided and Phi denotes a basis function.
    * @param qa The 1d quadrature point index in xi0 direction (0,1)
@@ -1079,6 +1104,88 @@ Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeStiffnessTerm(
         computeBMatrix(qa, qb, qc, X, J, B);
         computeGradPhiBGradPhi<qa, qb, qc>(B, func1, func2);
       });
+}
+
+template <typename GL_BASIS>
+template <typename FUNC_ALPHA>
+PROXY_HOST_DEVICE void
+Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeStiffnessTermSumFact(
+    TransformType const &transformData, real_t const (&u_local)[numNodes],
+    real_t (&v_local)[numNodes], FUNC_ALPHA &&get_alpha)
+{
+  float const(&X)[8][3] = transformData.data;
+
+  // Flux pondérés G^{ξ,η,ζ}[q] = w_q * alpha_q * M(B_q) · ∇_ξ u_q
+  real_t G_xi[numNodes] = {0};
+  real_t G_eta[numNodes] = {0};
+  real_t G_zeta[numNodes] = {0};
+
+  // Pass 1+2 fused: gradient de u, puis application de la métrique, de alpha et
+  // du poids
+  triple_loop<num1dNodes, num1dNodes, num1dNodes>(
+      [&](auto const icqa, auto const icqb, auto const icqc) {
+        constexpr int qa = decltype(icqa)::value;
+        constexpr int qb = decltype(icqb)::value;
+        constexpr int qc = decltype(icqc)::value;
+        constexpr int q = GL_BASIS::TensorProduct3D::linearIndex(qa, qb, qc);
+
+        // La gestion des poids de quadrature est interne à la bibliothèque
+        // mathématique
+        constexpr real_t w =
+            GL_BASIS::weight(qa) * GL_BASIS::weight(qb) * GL_BASIS::weight(qc);
+
+        real_t dxi_q = 0, deta_q = 0, dzeta_q = 0;
+        for_constexpr<num1dNodes>([&](auto ici) {
+          constexpr int i = decltype(ici)::value;
+          constexpr int ibc = GL_BASIS::TensorProduct3D::linearIndex(i, qb, qc);
+          constexpr int aic = GL_BASIS::TensorProduct3D::linearIndex(qa, i, qc);
+          constexpr int abi = GL_BASIS::TensorProduct3D::linearIndex(qa, qb, i);
+
+          dxi_q += basisGradientAt(i, qa) * u_local[ibc];
+          deta_q += basisGradientAt(i, qb) * u_local[aic];
+          dzeta_q += basisGradientAt(i, qc) * u_local[abi];
+        });
+
+        real_t J[3][3] = {{0}};
+        real_t B[6] = {0};
+        computeBMatrix(qa, qb, qc, X, J, B);
+
+        // 'scale' fusionne la physique (alpha) et la quadrature (w)
+        real_t const scale = w * get_alpha(qa, qb, qc);
+
+        G_xi[q] = scale * (B[0] * dxi_q + B[5] * deta_q + B[4] * dzeta_q);
+        G_eta[q] = scale * (B[5] * dxi_q + B[1] * deta_q + B[3] * dzeta_q);
+        G_zeta[q] = scale * (B[4] * dxi_q + B[3] * deta_q + B[2] * dzeta_q);
+      });
+
+  // Pass 3: divergence — v_{ia,ib,ic} += D^T·G^ξ + D^T·G^η + D^T·G^ζ
+  triple_loop<num1dNodes, num1dNodes, num1dNodes>([&](auto const icia,
+                                                      auto const icib,
+                                                      auto const icic) {
+    constexpr int ia = decltype(icia)::value;
+    constexpr int ib = decltype(icib)::value;
+    constexpr int ic = decltype(icic)::value;
+    constexpr int node = GL_BASIS::TensorProduct3D::linearIndex(ia, ib, ic);
+
+    real_t v = 0;
+    for_constexpr<num1dNodes>([&](auto icqa) {
+      constexpr int qa = decltype(icqa)::value;
+      constexpr int q_xi = GL_BASIS::TensorProduct3D::linearIndex(qa, ib, ic);
+      v += basisGradientAt(ia, qa) * G_xi[q_xi];
+    });
+    for_constexpr<num1dNodes>([&](auto icqb) {
+      constexpr int qb = decltype(icqb)::value;
+      constexpr int q_eta = GL_BASIS::TensorProduct3D::linearIndex(ia, qb, ic);
+      v += basisGradientAt(ib, qb) * G_eta[q_eta];
+    });
+    for_constexpr<num1dNodes>([&](auto icqc) {
+      constexpr int qc = decltype(icqc)::value;
+      constexpr int q_zeta = GL_BASIS::TensorProduct3D::linearIndex(ia, ib, qc);
+      v += basisGradientAt(ic, qc) * G_zeta[q_zeta];
+    });
+
+    v_local[node] += v;
+  });
 }
 
 template <typename GL_BASIS>

--- a/src/discretization/fe/makutu/include/Qk_Hexahedron_Lagrange_GaussLobatto.h
+++ b/src/discretization/fe/makutu/include/Qk_Hexahedron_Lagrange_GaussLobatto.h
@@ -24,7 +24,6 @@ template <typename GL_BASIS>
 class Qk_Hexahedron_Lagrange_GaussLobatto final
 {
  public:
-
   // Expose the basis type for tests and external use
   using BasisType = GL_BASIS;
 

--- a/src/discretization/fe/makutu/include/Qk_Hexahedron_Lagrange_GaussLobatto.h
+++ b/src/discretization/fe/makutu/include/Qk_Hexahedron_Lagrange_GaussLobatto.h
@@ -675,11 +675,24 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
   PROXY_HOST_DEVICE static void supportLoop(real_t const (&coords)[3],
                                             FUNC &&func, PARAMS &&...params);
   /**
-   * @brief Applies a function inside a generic loop in over the tensor product
-   *   indices.
+   * @brief Applies a function over the (3N-2) nodes with non-zero parent
+   *   gradient at quadrature point @p q.
+   *
+   * At a Gauss-Lobatto quadrature point q=(qa,qb,qc) the parent-space gradient
+   * of basis function (a,b,c) is zero unless (a,b,c) lies on one of the three
+   * coordinate lines through q.  Only those 3N-2 nodes are visited:
+   *   - ξ-line: b=qb, c=qc, a=0..N-1 (includes center; carries all 3
+   * components).
+   *   - η-line: a=qa, c=qc, b≠qb.
+   *   - ζ-line: a=qa, b=qb, c≠qc.
+   *
+   * @note Callers that ASSIGN to output arrays indexed by nodeIndex (rather
+   * than accumulating) must zero-initialise those arrays before calling this
+   *   function, since off-line nodes are never visited.
+   *
    * @tparam FUNC The type of function to call within the support loop.
    * @tparam PARAMS The parameter pack types to pass through to @p FUNC.
-   * @param q The quadrature node at which to evaluate the shape function value
+   * @param q The quadrature node at which to evaluate the shape function value.
    * @param func The function to call within the support loop.
    * @param params The parameters to pass to @p func.
    */
@@ -728,22 +741,33 @@ Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::supportLoop(int const q,
 {
   int qa, qb, qc;
   GL_BASIS::TensorProduct3D::multiIndex(q, qa, qb, qc);
+
+  // ξ-line: b=qb, c=qc, a varies.
+  // The center node (qa,qb,qc) is processed here with all three non-zero
+  // components; the other nodes on this line have only dNdXi[0] non-zero.
+  for (int a = 0; a < num1dNodes; ++a)
+  {
+    real_t const dNdXi[3] = {basisGradientAt(a, qa),
+                             (a == qa) ? basisGradientAt(qb, qb) : real_t(0),
+                             (a == qa) ? basisGradientAt(qc, qc) : real_t(0)};
+    int const nodeIndex = linearIndex3DVal(a, qb, qc);
+    func(dNdXi, nodeIndex, std::forward<PARAMS>(params)...);
+  }
+  // η-line: a=qa, c=qc, b varies — skip b=qb (center, already processed above).
+  for (int b = 0; b < num1dNodes; ++b)
+  {
+    if (b == qb) continue;
+    real_t const dNdXi[3] = {real_t(0), basisGradientAt(b, qb), real_t(0)};
+    int const nodeIndex = linearIndex3DVal(qa, b, qc);
+    func(dNdXi, nodeIndex, std::forward<PARAMS>(params)...);
+  }
+  // ζ-line: a=qa, b=qb, c varies — skip c=qc (center, already processed above).
   for (int c = 0; c < num1dNodes; ++c)
   {
-    for (int b = 0; b < num1dNodes; ++b)
-    {
-      for (int a = 0; a < num1dNodes; ++a)
-      {
-        real_t const dNdXi[3] = {
-            (b == qb && c == qc) ? basisGradientAt(a, qa) : 0,
-            (a == qa && c == qc) ? basisGradientAt(b, qb) : 0,
-            (a == qa && b == qb) ? basisGradientAt(c, qc) : 0};
-
-        int const nodeIndex = GL_BASIS::TensorProduct3D::linearIndex(a, b, c);
-
-        func(dNdXi, nodeIndex, std::forward<PARAMS>(params)...);
-      }
-    }
+    if (c == qc) continue;
+    real_t const dNdXi[3] = {real_t(0), real_t(0), basisGradientAt(c, qc)};
+    int const nodeIndex = linearIndex3DVal(qa, qb, c);
+    func(dNdXi, nodeIndex, std::forward<PARAMS>(params)...);
   }
 }
 
@@ -1075,9 +1099,6 @@ PROXY_HOST_DEVICE void
 Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeGradPhiBGradPhi(
     real_t const (&B)[6], FUNC1 &&func1, FUNC2 &&func2)
 {
-  constexpr real_t wa = GL_BASIS::weight(qa);
-  constexpr real_t wb = GL_BASIS::weight(qb);
-  constexpr real_t wc = GL_BASIS::weight(qc);
   const real_t w =
       GL_BASIS::weight(qa) * GL_BASIS::weight(qb) * GL_BASIS::weight(qc);
   func1(qa, qb, qc);
@@ -1303,37 +1324,38 @@ Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeElasticStiffnessSumFact(
       });
 
   // Pass 3: divergence — f_{ia,ib,ic} += D^T·F^ξ + D^T·F^η + D^T·F^ζ
-  triple_loop<num1dNodes, num1dNodes, num1dNodes>(
-      [&](auto const icia, auto const icib, auto const icic) {
-        constexpr int ia = decltype(icia)::value;
-        constexpr int ib = decltype(icib)::value;
-        constexpr int ic = decltype(icic)::value;
-        constexpr int node = GL_BASIS::TensorProduct3D::linearIndex(ia, ib, ic);
+  // The gradient coefficient (basisGradientAt) is independent of force
+  // component f, so it is computed once and the short f-loop is kept innermost
+  // to expose it for vectorization.
+  triple_loop<num1dNodes, num1dNodes, num1dNodes>([&](auto const icia,
+                                                      auto const icib,
+                                                      auto const icic) {
+    constexpr int ia = decltype(icia)::value;
+    constexpr int ib = decltype(icib)::value;
+    constexpr int ic = decltype(icic)::value;
+    constexpr int node = GL_BASIS::TensorProduct3D::linearIndex(ia, ib, ic);
 
-        for (int f = 0; f < 3; ++f)
-        {
-          real_t v = 0;
-          for_constexpr<num1dNodes>([&](auto icqa) {
-            constexpr int qa = decltype(icqa)::value;
-            constexpr int q_xi =
-                GL_BASIS::TensorProduct3D::linearIndex(qa, ib, ic);
-            v += basisGradientAt(ia, qa) * F_xi[f][q_xi];
-          });
-          for_constexpr<num1dNodes>([&](auto icqb) {
-            constexpr int qb = decltype(icqb)::value;
-            constexpr int q_eta =
-                GL_BASIS::TensorProduct3D::linearIndex(ia, qb, ic);
-            v += basisGradientAt(ib, qb) * F_eta[f][q_eta];
-          });
-          for_constexpr<num1dNodes>([&](auto icqc) {
-            constexpr int qc = decltype(icqc)::value;
-            constexpr int q_zeta =
-                GL_BASIS::TensorProduct3D::linearIndex(ia, ib, qc);
-            v += basisGradientAt(ic, qc) * F_zeta[f][q_zeta];
-          });
-          f_local[f][node] += v;
-        }
-      });
+    real_t v[3] = {0};
+    for_constexpr<num1dNodes>([&](auto icqa) {
+      constexpr int qa = decltype(icqa)::value;
+      constexpr int q_xi = GL_BASIS::TensorProduct3D::linearIndex(qa, ib, ic);
+      const real_t g = basisGradientAt(ia, qa);
+      for (int f = 0; f < 3; ++f) v[f] += g * F_xi[f][q_xi];
+    });
+    for_constexpr<num1dNodes>([&](auto icqb) {
+      constexpr int qb = decltype(icqb)::value;
+      constexpr int q_eta = GL_BASIS::TensorProduct3D::linearIndex(ia, qb, ic);
+      const real_t g = basisGradientAt(ib, qb);
+      for (int f = 0; f < 3; ++f) v[f] += g * F_eta[f][q_eta];
+    });
+    for_constexpr<num1dNodes>([&](auto icqc) {
+      constexpr int qc = decltype(icqc)::value;
+      constexpr int q_zeta = GL_BASIS::TensorProduct3D::linearIndex(ia, ib, qc);
+      const real_t g = basisGradientAt(ic, qc);
+      for (int f = 0; f < 3; ++f) v[f] += g * F_zeta[f][q_zeta];
+    });
+    for (int f = 0; f < 3; ++f) f_local[f][node] += v[f];
+  });
 }
 
 template <typename GL_BASIS>
@@ -1391,6 +1413,13 @@ PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::
                                          real_t const (&invJ)[3][3],
                                          real_t (&gradN)[numNodes][3])
 {
+  // The sparse supportLoop only visits the 3N-2 non-zero nodes; off-line
+  // entries must be zeroed explicitly since this function assigns (not
+  // accumulates) gradN[nodeIndex].
+  for (int node = 0; node < numNodes; ++node)
+  {
+    gradN[node][0] = gradN[node][1] = gradN[node][2] = real_t(0);
+  }
   supportLoop(
       q,
       [](real_t const(&dNdXi)[3], int const nodeIndex,

--- a/src/solver/fe/impl/common/include/sem_solver_impl.h
+++ b/src/solver/fe/impl/common/include/sem_solver_impl.h
@@ -521,137 +521,82 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
           }
         }
 
-        typename INTEGRAL_TYPE::TransformType transformData;
-        model_discretization_interface::gatherTransformData(
-            elementNumber, mesh_local, transformData);
-
-#if defined(__CUDACC__) || defined(__HIPCC__)
-
-        struct CJPacked
+        if constexpr (PHYSICS == utils::enums::physicType::kElastic)
         {
-          float4 a;
-          float2 b;
-        };
-#else
-        struct CJPacked
-        {
-          alignas(16) float a0, a1, a2, a3;
-          float b0, b1;
-          float pad[2];
-        };
-#endif
-        CJPacked CJflat[3 * 3];
+          typename INTEGRAL_TYPE::TransformType transformData;
+          model_discretization_interface::gatherTransformData(
+              elementNumber, mesh_local, transformData);
 
-        INTEGRAL_TYPE::computeStiffNessTermwithJac(
-            transformData,
-            [&](int qa, int qb, int qc, float const(&J)[3][3]) {
-              // Get material properties
-              float vp, vs, rho;
-              if constexpr (IS_MODEL_ON_NODES)
-              {
-                int const gIndex =
-                    mesh_local.globalNodeIndex(elementNumber, qa, qb, qc);
-                vp = mesh_local.getModelVpOnNodes(gIndex);
-                vs = mesh_local.getModelVsOnNodes(gIndex);
-                rho = mesh_local.getModelRhoOnNodes(gIndex);
-              }
-              else
-              {
-                vp = mesh_local.getModelVpOnElement(elementNumber);
-                vs = mesh_local.getModelVsOnElement(elementNumber);
-                rho = mesh_local.getModelRhoOnElement(elementNumber);
-              }
-
-              // Lamé parameters
-              float const mu = rho * vs * vs;
-              float const lambda = rho * (vp * vp - 2.0f * vs * vs);
-              float const lambda_plus_2mu = lambda + 2.0f * mu;
-
-              for (int p = 0; p < 3; ++p)
-              {
-                float const Jp0 = J[p][0], Jp1 = J[p][1], Jp2 = J[p][2];
-
-                for (int r = 0; r < 3; ++r)
+          INTEGRAL_TYPE::computeElasticStiffnessSumFact(
+              transformData, localFields, localWork,
+              [&](int qa, int qb, int qc, float const(&J_inv)[3][3],
+                  float const(&grad_u_ref)[3][3], float(&flux)[3][3]) {
+                float vp, vs, rho;
+                if constexpr (IS_MODEL_ON_NODES)
                 {
-                  float const Jr0 = J[r][0], Jr1 = J[r][1], Jr2 = J[r][2];
-                  int const idx = p * 3 + r;
-
-                  float const v0 = lambda_plus_2mu * Jp0 * Jr0 +
-                                   mu * (Jp1 * Jr1 + Jp2 * Jr2);
-                  float const v1 = mu * Jp0 * Jr0 +
-                                   lambda_plus_2mu * Jp1 * Jr1 + mu * Jp2 * Jr2;
-                  float const v2 = mu * (Jp0 * Jr0 + Jp1 * Jr1) +
-                                   lambda_plus_2mu * Jp2 * Jr2;
-
-                  float const v3 = lambda * Jp0 * Jr1 + mu * Jp1 * Jr0;
-                  float const v4 = lambda * Jp0 * Jr2 + mu * Jp2 * Jr0;
-                  float const v5 = lambda * Jp1 * Jr2 + mu * Jp2 * Jr1;
-
-#if defined(__CUDACC__) || defined(__HIPCC__)
-
-                  CJflat[idx].a = make_float4(v0, v1, v2, v3);
-                  CJflat[idx].b = make_float2(v4, v5);
-#else
-                  CJflat[idx].a0 = v0;
-                  CJflat[idx].a1 = v1;
-                  CJflat[idx].a2 = v2;
-                  CJflat[idx].a3 = v3;
-                  CJflat[idx].b0 = v4;
-                  CJflat[idx].b1 = v5;
-#endif
+                  int const gIndex =
+                      mesh_local.globalNodeIndex(elementNumber, qa, qb, qc);
+                  vp = mesh_local.getModelVpOnNodes(gIndex);
+                  vs = mesh_local.getModelVsOnNodes(gIndex);
+                  rho = mesh_local.getModelRhoOnNodes(gIndex);
                 }
-              }
-            },
-            [&](int i, int j, float val, const int p, const int r) {
-              int const idx = p * 3 + r;
-#if defined(__CUDACC__) || defined(__HIPCC__)
+                else
+                {
+                  vp = mesh_local.getModelVpOnElement(elementNumber);
+                  vs = mesh_local.getModelVsOnElement(elementNumber);
+                  rho = mesh_local.getModelRhoOnElement(elementNumber);
+                }
+                float const mu = rho * vs * vs;
+                float const lambda = rho * (vp * vp - 2.0f * vs * vs);
+                float const lam2mu = lambda + 2.0f * mu;
 
-              float3 const u_local = make_float3(
-                  localFields[0][j], localFields[1][j], localFields[2][j]);
-              float4 const a = CJflat[idx].a;
-              float2 const b = CJflat[idx].b;
-              localWork[0][i] +=
-                  fmaf(val * a.x, u_local.x,
-                       fmaf(val * a.w, u_local.y, val * b.x * u_local.z));
-              localWork[1][i] +=
-                  fmaf(val * a.w, u_local.x,
-                       fmaf(val * a.y, u_local.y, val * b.y * u_local.z));
-              localWork[2][i] +=
-                  fmaf(val * b.x, u_local.x,
-                       fmaf(val * b.y, u_local.y, val * a.z * u_local.z));
-#else
-              float const uxj = localFields[0][j];
-              float const uyj = localFields[1][j];
-              float const uzj = localFields[2][j];
-              float const rxx = CJflat[idx].a0;
-              float const ryy = CJflat[idx].a1;
-              float const rzz = CJflat[idx].a2;
-              float const rxy = CJflat[idx].a3;
-              float const rxz = CJflat[idx].b0;
-              float const ryz = CJflat[idx].b1;
-              localWork[0][i] +=
-                  fmaf(val * rxx, uxj, fmaf(val * rxy, uyj, val * rxz * uzj));
-              localWork[1][i] +=
-                  fmaf(val * rxy, uxj, fmaf(val * ryy, uyj, val * ryz * uzj));
-              localWork[2][i] +=
-                  fmaf(val * rxz, uxj, fmaf(val * ryz, uyj, val * rzz * uzj));
-#endif
-            });
+                for (int p = 0; p < 3; ++p)
+                {
+                  float const Jp0 = J_inv[p][0];
+                  float const Jp1 = J_inv[p][1];
+                  float const Jp2 = J_inv[p][2];
+                  flux[p][0] = 0.0f;
+                  flux[p][1] = 0.0f;
+                  flux[p][2] = 0.0f;
+                  for (int r = 0; r < 3; ++r)
+                  {
+                    float const Jr0 = J_inv[r][0];
+                    float const Jr1 = J_inv[r][1];
+                    float const Jr2 = J_inv[r][2];
+                    float const v0 =
+                        lam2mu * Jp0 * Jr0 + mu * (Jp1 * Jr1 + Jp2 * Jr2);
+                    float const v1 =
+                        mu * Jp0 * Jr0 + lam2mu * Jp1 * Jr1 + mu * Jp2 * Jr2;
+                    float const v2 =
+                        mu * (Jp0 * Jr0 + Jp1 * Jr1) + lam2mu * Jp2 * Jr2;
+                    float const v3 = lambda * Jp0 * Jr1 + mu * Jp1 * Jr0;
+                    float const v4 = lambda * Jp0 * Jr2 + mu * Jp2 * Jr0;
+                    float const v5 = lambda * Jp1 * Jr2 + mu * Jp2 * Jr1;
+                    float const g0 = grad_u_ref[r][0];
+                    float const g1 = grad_u_ref[r][1];
+                    float const g2 = grad_u_ref[r][2];
+                    flux[p][0] += v0 * g0 + v3 * g1 + v4 * g2;
+                    flux[p][1] += v3 * g0 + v1 * g1 + v5 * g2;
+                    flux[p][2] += v4 * g0 + v5 * g1 + v2 * g2;
+                  }
+                }
+              });
 
-        for (int i = 0; i < dim; ++i)
-        {
-          for (int j = 0; j < dim; ++j)
+          for (int i = 0; i < dim; ++i)
           {
-            for (int k = 0; k < dim; ++k)
+            for (int j = 0; j < dim; ++j)
             {
-              int const globalIdx =
-                  mesh_local.globalNodeIndex(elementNumber, i, j, k);
-              int const localIdx = i + j * dim + k * dim * dim;
-
-              for (int f = 0; f < kNumFields; ++f)
+              for (int k = 0; k < dim; ++k)
               {
-                ATOMICADD(workVectorsGlobal_[f][globalIdx],
-                          localWork[f][localIdx]);
+                int const globalIdx =
+                    mesh_local.globalNodeIndex(elementNumber, i, j, k);
+                int const localIdx = i + j * dim + k * dim * dim;
+
+                for (int f = 0; f < kNumFields; ++f)
+                {
+                  ATOMICADD(workVectorsGlobal_[f][globalIdx],
+                            localWork[f][localIdx]);
+                }
               }
             }
           }
@@ -706,155 +651,101 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
           }
         }
 
-        typename INTEGRAL_TYPE::TransformType transformData;
-        model_discretization_interface::gatherTransformData(
-            elementNumber, mesh_local, transformData);
-
-#if defined(__CUDACC__) || defined(__HIPCC__)
-
-        struct CJPacked
+        if constexpr (PHYSICS == utils::enums::physicType::kElastic)
         {
-          float4 a;
-          float2 b;
-        };
-#else
-        struct CJPacked
-        {
-          alignas(16) float a0, a1, a2, a3;
-          float b0, b1;
-          float pad[2];
-        };
-#endif
-        CJPacked CJflat[3 * 3];
+          typename INTEGRAL_TYPE::TransformType transformData;
+          model_discretization_interface::gatherTransformData(
+              elementNumber, mesh_local, transformData);
 
-        INTEGRAL_TYPE::computeStiffNessTermwithJac(
-            transformData,
-            [&](int qa, int qb, int qc, float const(&J)[3][3]) {
-              // Get material properties + Thomsen parameters
-              float vp, vs, rho, delta, epsilon, gamma;
-
-              if constexpr (IS_MODEL_ON_NODES)
-              {
-                int const gIndex =
-                    mesh_local.globalNodeIndex(elementNumber, qa, qb, qc);
-                vp = mesh_local.getModelVpOnNodes(gIndex);
-                vs = mesh_local.getModelVsOnNodes(gIndex);
-                rho = mesh_local.getModelRhoOnNodes(gIndex);
-                delta = mesh_local.getModelDeltaOnNodes(gIndex);
-                epsilon = mesh_local.getModelEpsilonOnNodes(gIndex);
-                gamma = mesh_local.getModelGammaOnNodes(gIndex);
-              }
-              else
-              {
-                vp = mesh_local.getModelVpOnElement(elementNumber);
-                vs = mesh_local.getModelVsOnElement(elementNumber);
-                rho = mesh_local.getModelRhoOnElement(elementNumber);
-                delta = mesh_local.getModelDeltaOnElement(elementNumber);
-                epsilon = mesh_local.getModelEpsilonOnElement(elementNumber);
-                gamma = mesh_local.getModelGammaOnElement(elementNumber);
-              }
-
-              // Compute 5 independent VTI coefficients
-              float const rho_vp2 = rho * vp * vp;
-              float const rho_vs2 = rho * vs * vs;
-              float const c33 = rho_vp2;
-              float const c44 = rho_vs2;
-              float const c11 = rho_vp2 * (1.0f + 2.0f * epsilon);
-              float const c66 = rho_vs2 * (1.0f + 2.0f * gamma);
-
-              float const vp2_vs2 = vp * vp - vs * vs;
-              float const sqrt_arg =
-                  vp2_vs2 * vp2_vs2 + 2.0f * rho_vp2 * delta * vp2_vs2;
-              float const c13 = rho * sqrtf(sqrt_arg) - rho_vs2;
-              float const c12 = c11 - 2.0f * c66;
-
-              for (int p = 0; p < 3; ++p)
-              {
-                float const Jp0 = J[p][0], Jp1 = J[p][1], Jp2 = J[p][2];
-
-                for (int r = 0; r < 3; ++r)
+          INTEGRAL_TYPE::computeElasticStiffnessSumFact(
+              transformData, localFields, localWork,
+              [&](int qa, int qb, int qc, float const(&J_inv)[3][3],
+                  float const(&grad_u_ref)[3][3], float(&flux)[3][3]) {
+                float vp, vs, rho, delta, epsilon, gamma;
+                if constexpr (IS_MODEL_ON_NODES)
                 {
-                  float const Jr0 = J[r][0], Jr1 = J[r][1], Jr2 = J[r][2];
-                  float const p0r0 = Jp0 * Jr0, p0r1 = Jp0 * Jr1,
-                              p0r2 = Jp0 * Jr2;
-                  float const p1r0 = Jp1 * Jr0, p1r1 = Jp1 * Jr1,
-                              p1r2 = Jp1 * Jr2;
-                  float const p2r0 = Jp2 * Jr0, p2r1 = Jp2 * Jr1,
-                              p2r2 = Jp2 * Jr2;
-                  int const idx = p * 3 + r;
-
-                  float const v0 = c11 * p0r0 + c66 * p1r1 + c44 * p2r2;
-                  float const v1 = c66 * p0r0 + c11 * p1r1 + c44 * p2r2;
-                  float const v2 = c44 * p0r0 + c44 * p1r1 + c33 * p2r2;
-                  float const v3 = c66 * p0r1 + c12 * p1r0;
-                  float const v4 = c44 * p0r2 + c13 * p2r0;
-                  float const v5 = c44 * p1r2 + c13 * p2r1;
-
-#if defined(__CUDACC__) || defined(__HIPCC__)
-
-                  CJflat[idx].a = make_float4(v0, v1, v2, v3);
-                  CJflat[idx].b = make_float2(v4, v5);
-#else
-                  CJflat[idx].a0 = v0;
-                  CJflat[idx].a1 = v1;
-                  CJflat[idx].a2 = v2;
-                  CJflat[idx].a3 = v3;
-                  CJflat[idx].b0 = v4;
-                  CJflat[idx].b1 = v5;
-#endif
+                  int const gIndex =
+                      mesh_local.globalNodeIndex(elementNumber, qa, qb, qc);
+                  vp = mesh_local.getModelVpOnNodes(gIndex);
+                  vs = mesh_local.getModelVsOnNodes(gIndex);
+                  rho = mesh_local.getModelRhoOnNodes(gIndex);
+                  delta = mesh_local.getModelDeltaOnNodes(gIndex);
+                  epsilon = mesh_local.getModelEpsilonOnNodes(gIndex);
+                  gamma = mesh_local.getModelGammaOnNodes(gIndex);
                 }
-              }
-            },
-            [&](int i, int j, float val, const int p, const int r) {
-              int const idx = p * 3 + r;
-#if defined(__CUDACC__) || defined(__HIPCC__)
+                else
+                {
+                  vp = mesh_local.getModelVpOnElement(elementNumber);
+                  vs = mesh_local.getModelVsOnElement(elementNumber);
+                  rho = mesh_local.getModelRhoOnElement(elementNumber);
+                  delta = mesh_local.getModelDeltaOnElement(elementNumber);
+                  epsilon = mesh_local.getModelEpsilonOnElement(elementNumber);
+                  gamma = mesh_local.getModelGammaOnElement(elementNumber);
+                }
 
-              float3 const u_local = make_float3(
-                  localFields[0][j], localFields[1][j], localFields[2][j]);
-              float4 const a = CJflat[idx].a;
-              float2 const b = CJflat[idx].b;
-              localWork[0][i] +=
-                  fmaf(val * a.x, u_local.x,
-                       fmaf(val * a.w, u_local.y, val * b.x * u_local.z));
-              localWork[1][i] +=
-                  fmaf(val * a.w, u_local.x,
-                       fmaf(val * a.y, u_local.y, val * b.y * u_local.z));
-              localWork[2][i] +=
-                  fmaf(val * b.x, u_local.x,
-                       fmaf(val * b.y, u_local.y, val * a.z * u_local.z));
-#else
-              float const uxj = localFields[0][j];
-              float const uyj = localFields[1][j];
-              float const uzj = localFields[2][j];
-              float const rxx = CJflat[idx].a0;
-              float const ryy = CJflat[idx].a1;
-              float const rzz = CJflat[idx].a2;
-              float const rxy = CJflat[idx].a3;
-              float const rxz = CJflat[idx].b0;
-              float const ryz = CJflat[idx].b1;
-              localWork[0][i] +=
-                  fmaf(val * rxx, uxj, fmaf(val * rxy, uyj, val * rxz * uzj));
-              localWork[1][i] +=
-                  fmaf(val * rxy, uxj, fmaf(val * ryy, uyj, val * ryz * uzj));
-              localWork[2][i] +=
-                  fmaf(val * rxz, uxj, fmaf(val * ryz, uyj, val * rzz * uzj));
-#endif
-            });
+                float const rho_vp2 = rho * vp * vp;
+                float const rho_vs2 = rho * vs * vs;
+                float const c33 = rho_vp2;
+                float const c44 = rho_vs2;
+                float const c11 = rho_vp2 * (1.0f + 2.0f * epsilon);
+                float const c66 = rho_vs2 * (1.0f + 2.0f * gamma);
+                float const vp2_vs2 = vp * vp - vs * vs;
+                float const c13 =
+                    rho * sqrtf(vp2_vs2 * vp2_vs2 +
+                                2.0f * rho_vp2 * delta * vp2_vs2) -
+                    rho_vs2;
+                float const c12 = c11 - 2.0f * c66;
 
-        for (int i = 0; i < dim; ++i)
-        {
-          for (int j = 0; j < dim; ++j)
+                for (int p = 0; p < 3; ++p)
+                {
+                  float const Jp0 = J_inv[p][0];
+                  float const Jp1 = J_inv[p][1];
+                  float const Jp2 = J_inv[p][2];
+                  flux[p][0] = 0.0f;
+                  flux[p][1] = 0.0f;
+                  flux[p][2] = 0.0f;
+                  for (int r = 0; r < 3; ++r)
+                  {
+                    float const Jr0 = J_inv[r][0];
+                    float const Jr1 = J_inv[r][1];
+                    float const Jr2 = J_inv[r][2];
+                    float const p0r0 = Jp0 * Jr0, p0r1 = Jp0 * Jr1,
+                                p0r2 = Jp0 * Jr2;
+                    float const p1r0 = Jp1 * Jr0, p1r1 = Jp1 * Jr1,
+                                p1r2 = Jp1 * Jr2;
+                    float const p2r0 = Jp2 * Jr0, p2r1 = Jp2 * Jr1,
+                                p2r2 = Jp2 * Jr2;
+                    float const v0 = c11 * p0r0 + c66 * p1r1 + c44 * p2r2;
+                    float const v1 = c66 * p0r0 + c11 * p1r1 + c44 * p2r2;
+                    float const v2 = c44 * p0r0 + c44 * p1r1 + c33 * p2r2;
+                    float const v3 = c66 * p0r1 + c12 * p1r0;
+                    float const v4 = c44 * p0r2 + c13 * p2r0;
+                    float const v5 = c44 * p1r2 + c13 * p2r1;
+                    float const g0 = grad_u_ref[r][0];
+                    float const g1 = grad_u_ref[r][1];
+                    float const g2 = grad_u_ref[r][2];
+                    flux[p][0] += v0 * g0 + v3 * g1 + v4 * g2;
+                    flux[p][1] += v3 * g0 + v1 * g1 + v5 * g2;
+                    flux[p][2] += v4 * g0 + v5 * g1 + v2 * g2;
+                  }
+                }
+              });
+
+          for (int i = 0; i < dim; ++i)
           {
-            for (int k = 0; k < dim; ++k)
+            for (int j = 0; j < dim; ++j)
             {
-              int const globalIdx =
-                  mesh_local.globalNodeIndex(elementNumber, i, j, k);
-              int const localIdx = i + j * dim + k * dim * dim;
-
-              for (int f = 0; f < kNumFields; ++f)
+              for (int k = 0; k < dim; ++k)
               {
-                ATOMICADD(workVectorsGlobal_[f][globalIdx],
-                          localWork[f][localIdx]);
+                int const globalIdx =
+                    mesh_local.globalNodeIndex(elementNumber, i, j, k);
+                int const localIdx = i + j * dim + k * dim * dim;
+
+                for (int f = 0; f < kNumFields; ++f)
+                {
+                  ATOMICADD(workVectorsGlobal_[f][globalIdx],
+                            localWork[f][localIdx]);
+                }
               }
             }
           }
@@ -917,35 +808,16 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
           model_discretization_interface::gatherTransformData(
               elementNumber, mesh_local, transformData);
 
-          float CTTI[6][6];
-
-          // For elements, preload tensor
+          float CTTI[6][6] = {};
           if constexpr (!IS_MODEL_ON_NODES)
           {
             mesh_local.getCTensorOnElement(elementNumber, CTTI);
           }
 
-#if defined(__CUDACC__) || defined(__HIPCC__)
-
-          struct CJPacked
-          {
-            float4 a;
-            float2 b;
-          };
-#else
-          struct CJPacked
-          {
-            alignas(16) float a0, a1, a2, a3;
-            float b0, b1;
-            float pad[2];
-          };
-#endif
-          CJPacked CJflat[3 * 3];
-
-          INTEGRAL_TYPE::computeStiffNessTermwithJac(
-              transformData,
-              [&](int qa, int qb, int qc, float const(&J)[3][3]) {
-                // For nodes, compute on-the-fly with rotation
+          INTEGRAL_TYPE::computeElasticStiffnessSumFact(
+              transformData, localFields, localWork,
+              [&](int qa, int qb, int qc, float const(&J_inv)[3][3],
+                  float const(&grad_u_ref)[3][3], float(&flux)[3][3]) {
                 if constexpr (IS_MODEL_ON_NODES)
                 {
                   int const gIndex =
@@ -963,7 +835,6 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
                                  CTTI);
                 }
 
-                // Apply tensor C (identique aux autres)
                 float const C00 = CTTI[0][0], C01 = CTTI[0][1],
                             C02 = CTTI[0][2];
                 float const C03 = CTTI[0][3], C04 = CTTI[0][4],
@@ -980,86 +851,49 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
 
                 for (int p = 0; p < 3; ++p)
                 {
-                  const float Jp0 = J[p][0], Jp1 = J[p][1], Jp2 = J[p][2];
+                  float const Jp0 = J_inv[p][0];
+                  float const Jp1 = J_inv[p][1];
+                  float const Jp2 = J_inv[p][2];
+                  flux[p][0] = 0.0f;
+                  flux[p][1] = 0.0f;
+                  flux[p][2] = 0.0f;
                   for (int r = 0; r < 3; ++r)
                   {
-                    const float Jr0 = J[r][0], Jr1 = J[r][1], Jr2 = J[r][2];
-                    const float p0r0 = Jp0 * Jr0, p0r1 = Jp0 * Jr1,
+                    float const Jr0 = J_inv[r][0];
+                    float const Jr1 = J_inv[r][1];
+                    float const Jr2 = J_inv[r][2];
+                    float const p0r0 = Jp0 * Jr0, p0r1 = Jp0 * Jr1,
                                 p0r2 = Jp0 * Jr2;
-                    const float p1r0 = Jp1 * Jr0, p1r1 = Jp1 * Jr1,
+                    float const p1r0 = Jp1 * Jr0, p1r1 = Jp1 * Jr1,
                                 p1r2 = Jp1 * Jr2;
-                    const float p2r0 = Jp2 * Jr0, p2r1 = Jp2 * Jr1,
+                    float const p2r0 = Jp2 * Jr0, p2r1 = Jp2 * Jr1,
                                 p2r2 = Jp2 * Jr2;
-                    const int idx = p * 3 + r;
-
-                    float v0 = C00 * p0r0 + C05 * p0r1 + C04 * p0r2 +
-                               C05 * p1r0 + C55 * p1r1 + C45 * p1r2 +
-                               C04 * p2r0 + C45 * p2r1 + C44 * p2r2;
-                    float v1 = C55 * p0r0 + C15 * p0r1 + C35 * p0r2 +
-                               C15 * p1r0 + C11 * p1r1 + C13 * p1r2 +
-                               C35 * p2r0 + C13 * p2r1 + C33 * p2r2;
-                    float v2 = C44 * p0r0 + C34 * p0r1 + C24 * p0r2 +
-                               C34 * p1r0 + C33 * p1r1 + C23 * p1r2 +
-                               C24 * p2r0 + C23 * p2r1 + C22 * p2r2;
-                    float v3 = C05 * p0r0 + C01 * p0r1 + C03 * p0r2 +
-                               C55 * p1r0 + C15 * p1r1 + C35 * p1r2 +
-                               C45 * p2r0 + C14 * p2r1 + C34 * p2r2;
-                    float v4 = C04 * p0r0 + C03 * p0r1 + C02 * p0r2 +
-                               C45 * p1r0 + C35 * p1r1 + C25 * p1r2 +
-                               C44 * p2r0 + C34 * p2r1 + C24 * p2r2;
-                    float v5 = C45 * p0r0 + C35 * p0r1 + C25 * p0r2 +
-                               C14 * p1r0 + C13 * p1r1 + C12 * p1r2 +
-                               C34 * p2r0 + C33 * p2r1 + C23 * p2r2;
-
-#if defined(__CUDACC__) || defined(__HIPCC__)
-
-                    CJflat[idx].a = make_float4(v0, v1, v2, v3);
-                    CJflat[idx].b = make_float2(v4, v5);
-#else
-                    CJflat[idx].a0 = v0;
-                    CJflat[idx].a1 = v1;
-                    CJflat[idx].a2 = v2;
-                    CJflat[idx].a3 = v3;
-                    CJflat[idx].b0 = v4;
-                    CJflat[idx].b1 = v5;
-#endif
+                    float const v0 = C00 * p0r0 + C05 * p0r1 + C04 * p0r2 +
+                                     C05 * p1r0 + C55 * p1r1 + C45 * p1r2 +
+                                     C04 * p2r0 + C45 * p2r1 + C44 * p2r2;
+                    float const v1 = C55 * p0r0 + C15 * p0r1 + C35 * p0r2 +
+                                     C15 * p1r0 + C11 * p1r1 + C13 * p1r2 +
+                                     C35 * p2r0 + C13 * p2r1 + C33 * p2r2;
+                    float const v2 = C44 * p0r0 + C34 * p0r1 + C24 * p0r2 +
+                                     C34 * p1r0 + C33 * p1r1 + C23 * p1r2 +
+                                     C24 * p2r0 + C23 * p2r1 + C22 * p2r2;
+                    float const v3 = C05 * p0r0 + C01 * p0r1 + C03 * p0r2 +
+                                     C55 * p1r0 + C15 * p1r1 + C35 * p1r2 +
+                                     C45 * p2r0 + C14 * p2r1 + C34 * p2r2;
+                    float const v4 = C04 * p0r0 + C03 * p0r1 + C02 * p0r2 +
+                                     C45 * p1r0 + C35 * p1r1 + C25 * p1r2 +
+                                     C44 * p2r0 + C34 * p2r1 + C24 * p2r2;
+                    float const v5 = C45 * p0r0 + C35 * p0r1 + C25 * p0r2 +
+                                     C14 * p1r0 + C13 * p1r1 + C12 * p1r2 +
+                                     C34 * p2r0 + C33 * p2r1 + C23 * p2r2;
+                    float const g0 = grad_u_ref[r][0];
+                    float const g1 = grad_u_ref[r][1];
+                    float const g2 = grad_u_ref[r][2];
+                    flux[p][0] += v0 * g0 + v3 * g1 + v4 * g2;
+                    flux[p][1] += v3 * g0 + v1 * g1 + v5 * g2;
+                    flux[p][2] += v4 * g0 + v5 * g1 + v2 * g2;
                   }
                 }
-              },
-              [&](int i, int j, float val, const int p, const int r) {
-                const int idx = p * 3 + r;
-#if defined(__CUDACC__) || defined(__HIPCC__)
-
-                const float3 u_local = make_float3(
-                    localFields[0][j], localFields[1][j], localFields[2][j]);
-                const float4 a = CJflat[idx].a;
-                const float2 b = CJflat[idx].b;
-                localWork[0][i] +=
-                    fmaf(val * a.x, u_local.x,
-                         fmaf(val * a.w, u_local.y, val * b.x * u_local.z));
-                localWork[1][i] +=
-                    fmaf(val * a.w, u_local.x,
-                         fmaf(val * a.y, u_local.y, val * b.y * u_local.z));
-                localWork[2][i] +=
-                    fmaf(val * b.x, u_local.x,
-                         fmaf(val * b.y, u_local.y, val * a.z * u_local.z));
-#else
-                const float uxj = localFields[0][j];
-                const float uyj = localFields[1][j];
-                const float uzj = localFields[2][j];
-                const float rxx = CJflat[idx].a0;
-                const float ryy = CJflat[idx].a1;
-                const float rzz = CJflat[idx].a2;
-                const float rxy = CJflat[idx].a3;
-                const float rxz = CJflat[idx].b0;
-                const float ryz = CJflat[idx].b1;
-                localWork[0][i] +=
-                    fmaf(val * rxx, uxj, fmaf(val * rxy, uyj, val * rxz * uzj));
-                localWork[1][i] +=
-                    fmaf(val * rxy, uxj, fmaf(val * ryy, uyj, val * ryz * uzj));
-                localWork[2][i] +=
-                    fmaf(val * rxz, uxj, fmaf(val * ryz, uyj, val * rzz * uzj));
-#endif
               });
 
           for (int i = 0; i < dim; ++i)

--- a/src/solver/fe/impl/common/include/sem_solver_impl.h
+++ b/src/solver/fe/impl/common/include/sem_solver_impl.h
@@ -228,7 +228,6 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
                                                  LaunchMinBlocksPerSM>>(0,
                                                                         n_iter),
         KOKKOS_CLASS_LAMBDA(const int _loop_idx) {
-          if (_loop_idx >= n_iter) return;
           int const elementNumber = list_on ? list_local[_loop_idx] : _loop_idx;
 
           int const dim = mesh_local.getOrder() + 1;
@@ -319,8 +318,6 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
           Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(
           0, mesh_local.getNumberOfElements()),
       KOKKOS_CLASS_LAMBDA(const int elementNumber) {
-        if (elementNumber >= mesh_local.getNumberOfElements()) return;
-
         int const dim = mesh_local.getOrder() + 1;
         float localFields[kNumFields][kPointsPerElement] = {{0}};
         float localWorkA[kNumFields][kPointsPerElement] = {{0}};
@@ -496,7 +493,6 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
           Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(
           0, n_iter),
       KOKKOS_CLASS_LAMBDA(const int _loop_idx) {
-        if (_loop_idx >= n_iter) return;
         int const elementNumber = list_on ? list_local[_loop_idx] : _loop_idx;
 
         int const dim = mesh_local.getOrder() + 1;
@@ -527,28 +523,41 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
           model_discretization_interface::gatherTransformData(
               elementNumber, mesh_local, transformData);
 
+          // Hoist per-element material constants; per-node models are read
+          // inside the callback since they vary per quadrature point.
+          float mu_e = 0.0f, lambda_e = 0.0f, lam2mu_e = 0.0f;
+          if constexpr (!IS_MODEL_ON_NODES)
+          {
+            float const vp_e = mesh_local.getModelVpOnElement(elementNumber);
+            float const vs_e = mesh_local.getModelVsOnElement(elementNumber);
+            float const rho_e = mesh_local.getModelRhoOnElement(elementNumber);
+            mu_e = rho_e * vs_e * vs_e;
+            lambda_e = rho_e * (vp_e * vp_e - 2.0f * vs_e * vs_e);
+            lam2mu_e = lambda_e + 2.0f * mu_e;
+          }
+
           INTEGRAL_TYPE::computeElasticStiffnessSumFact(
               transformData, localFields, localWork,
               [&](int qa, int qb, int qc, float const(&J_inv)[3][3],
                   float const(&grad_u_ref)[3][3], float(&flux)[3][3]) {
-                float vp, vs, rho;
+                float mu, lambda, lam2mu;
                 if constexpr (IS_MODEL_ON_NODES)
                 {
                   int const gIndex =
                       mesh_local.globalNodeIndex(elementNumber, qa, qb, qc);
-                  vp = mesh_local.getModelVpOnNodes(gIndex);
-                  vs = mesh_local.getModelVsOnNodes(gIndex);
-                  rho = mesh_local.getModelRhoOnNodes(gIndex);
+                  float const vp = mesh_local.getModelVpOnNodes(gIndex);
+                  float const vs = mesh_local.getModelVsOnNodes(gIndex);
+                  float const rho = mesh_local.getModelRhoOnNodes(gIndex);
+                  mu = rho * vs * vs;
+                  lambda = rho * (vp * vp - 2.0f * vs * vs);
+                  lam2mu = lambda + 2.0f * mu;
                 }
                 else
                 {
-                  vp = mesh_local.getModelVpOnElement(elementNumber);
-                  vs = mesh_local.getModelVsOnElement(elementNumber);
-                  rho = mesh_local.getModelRhoOnElement(elementNumber);
+                  mu = mu_e;
+                  lambda = lambda_e;
+                  lam2mu = lam2mu_e;
                 }
-                float const mu = rho * vs * vs;
-                float const lambda = rho * (vp * vp - 2.0f * vs * vs);
-                float const lam2mu = lambda + 2.0f * mu;
 
                 for (int p = 0; p < 3; ++p)
                 {
@@ -626,7 +635,6 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
           Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(
           0, n_iter),
       KOKKOS_CLASS_LAMBDA(const int _loop_idx) {
-        if (_loop_idx >= n_iter) return;
         int const elementNumber = list_on ? list_local[_loop_idx] : _loop_idx;
 
         int const dim = mesh_local.getOrder() + 1;
@@ -657,44 +665,70 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
           model_discretization_interface::gatherTransformData(
               elementNumber, mesh_local, transformData);
 
+          // Hoist per-element VTI stiffness coefficients.
+          float c11_e = 0, c12_e = 0, c13_e = 0, c33_e = 0, c44_e = 0,
+                c66_e = 0;
+          if constexpr (!IS_MODEL_ON_NODES)
+          {
+            float const vp_e = mesh_local.getModelVpOnElement(elementNumber);
+            float const vs_e = mesh_local.getModelVsOnElement(elementNumber);
+            float const rho_e = mesh_local.getModelRhoOnElement(elementNumber);
+            float const delta_e =
+                mesh_local.getModelDeltaOnElement(elementNumber);
+            float const epsilon_e =
+                mesh_local.getModelEpsilonOnElement(elementNumber);
+            float const gamma_e =
+                mesh_local.getModelGammaOnElement(elementNumber);
+            float const rho_vp2 = rho_e * vp_e * vp_e;
+            float const rho_vs2 = rho_e * vs_e * vs_e;
+            c33_e = rho_vp2;
+            c44_e = rho_vs2;
+            c11_e = rho_vp2 * (1.0f + 2.0f * epsilon_e);
+            c66_e = rho_vs2 * (1.0f + 2.0f * gamma_e);
+            float const vp2_vs2 = vp_e * vp_e - vs_e * vs_e;
+            c13_e = rho_e * sqrtf(vp2_vs2 * vp2_vs2 +
+                                  2.0f * rho_vp2 * delta_e * vp2_vs2) -
+                    rho_vs2;
+            c12_e = c11_e - 2.0f * c66_e;
+          }
+
           INTEGRAL_TYPE::computeElasticStiffnessSumFact(
               transformData, localFields, localWork,
               [&](int qa, int qb, int qc, float const(&J_inv)[3][3],
                   float const(&grad_u_ref)[3][3], float(&flux)[3][3]) {
-                float vp, vs, rho, delta, epsilon, gamma;
+                float c11, c12, c13, c33, c44, c66;
                 if constexpr (IS_MODEL_ON_NODES)
                 {
                   int const gIndex =
                       mesh_local.globalNodeIndex(elementNumber, qa, qb, qc);
-                  vp = mesh_local.getModelVpOnNodes(gIndex);
-                  vs = mesh_local.getModelVsOnNodes(gIndex);
-                  rho = mesh_local.getModelRhoOnNodes(gIndex);
-                  delta = mesh_local.getModelDeltaOnNodes(gIndex);
-                  epsilon = mesh_local.getModelEpsilonOnNodes(gIndex);
-                  gamma = mesh_local.getModelGammaOnNodes(gIndex);
+                  float const vp = mesh_local.getModelVpOnNodes(gIndex);
+                  float const vs = mesh_local.getModelVsOnNodes(gIndex);
+                  float const rho = mesh_local.getModelRhoOnNodes(gIndex);
+                  float const delta = mesh_local.getModelDeltaOnNodes(gIndex);
+                  float const epsilon =
+                      mesh_local.getModelEpsilonOnNodes(gIndex);
+                  float const gamma = mesh_local.getModelGammaOnNodes(gIndex);
+                  float const rho_vp2 = rho * vp * vp;
+                  float const rho_vs2 = rho * vs * vs;
+                  c33 = rho_vp2;
+                  c44 = rho_vs2;
+                  c11 = rho_vp2 * (1.0f + 2.0f * epsilon);
+                  c66 = rho_vs2 * (1.0f + 2.0f * gamma);
+                  float const vp2_vs2 = vp * vp - vs * vs;
+                  c13 = rho * sqrtf(vp2_vs2 * vp2_vs2 +
+                                    2.0f * rho_vp2 * delta * vp2_vs2) -
+                        rho_vs2;
+                  c12 = c11 - 2.0f * c66;
                 }
                 else
                 {
-                  vp = mesh_local.getModelVpOnElement(elementNumber);
-                  vs = mesh_local.getModelVsOnElement(elementNumber);
-                  rho = mesh_local.getModelRhoOnElement(elementNumber);
-                  delta = mesh_local.getModelDeltaOnElement(elementNumber);
-                  epsilon = mesh_local.getModelEpsilonOnElement(elementNumber);
-                  gamma = mesh_local.getModelGammaOnElement(elementNumber);
+                  c11 = c11_e;
+                  c12 = c12_e;
+                  c13 = c13_e;
+                  c33 = c33_e;
+                  c44 = c44_e;
+                  c66 = c66_e;
                 }
-
-                float const rho_vp2 = rho * vp * vp;
-                float const rho_vs2 = rho * vs * vs;
-                float const c33 = rho_vp2;
-                float const c44 = rho_vs2;
-                float const c11 = rho_vp2 * (1.0f + 2.0f * epsilon);
-                float const c66 = rho_vs2 * (1.0f + 2.0f * gamma);
-                float const vp2_vs2 = vp * vp - vs * vs;
-                float const c13 =
-                    rho * sqrtf(vp2_vs2 * vp2_vs2 +
-                                2.0f * rho_vp2 * delta * vp2_vs2) -
-                    rho_vs2;
-                float const c12 = c11 - 2.0f * c66;
 
                 for (int p = 0; p < 3; ++p)
                 {
@@ -779,7 +813,6 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
                                                  LaunchMinBlocksPerSM>>(0,
                                                                         n_iter),
         KOKKOS_CLASS_LAMBDA(const int _loop_idx) {
-          if (_loop_idx >= n_iter) return;
           int const elementNumber = list_on ? list_local[_loop_idx] : _loop_idx;
 
           int const dim = mesh_local.getOrder() + 1;
@@ -1135,8 +1168,6 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
           Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(
           0, mesh_local.getNumberOfElements()),
       KOKKOS_CLASS_LAMBDA(const int elementNumber) {
-        if (elementNumber >= mesh_local.getNumberOfElements()) return;
-
         float massMatrixLocal[kPointsPerElement] = {0};
         int const dim = mesh_local.getOrder() + 1;
 
@@ -1208,8 +1239,6 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
           Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(
           0, mesh_local.getNumberOfElements()),
       KOKKOS_CLASS_LAMBDA(const int elementNumber) {
-        if (elementNumber >= mesh_local.getNumberOfElements()) return;
-
         for (int i = 0; i < 6; ++i)
         {
           // Get global face ID for this element face

--- a/src/solver/fe/impl/common/include/sem_solver_impl.h
+++ b/src/solver/fe/impl/common/include/sem_solver_impl.h
@@ -263,19 +263,19 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
             inv_density = 1.0f / mesh_local.getModelRhoOnElement(elementNumber);
           }
 
-          INTEGRAL_TYPE::computeStiffnessTerm(
-              transformData,
-              [&](const int qa, const int qb, const int qc) {
+          INTEGRAL_TYPE::computeStiffnessTermSumFact(
+              transformData, localFields[0], localWork[0],
+              [&](const int qa, const int qb, const int qc) -> real_t {
                 if constexpr (IS_MODEL_ON_NODES)
                 {
                   int const gIndex =
                       mesh_local.globalNodeIndex(elementNumber, qa, qb, qc);
-                  inv_density = 1.0f / mesh_local.getModelRhoOnNodes(gIndex);
+                  return 1.0f / mesh_local.getModelRhoOnNodes(gIndex);
                 }
-              },
-              [&](const int i, const int j, const real_t val) {
-                float localIncrement = inv_density * val * localFields[0][j];
-                localWork[0][i] += localIncrement;
+                else
+                {
+                  return inv_density;
+                }
               });
 
           for (int i = 0; i < dim; ++i)


### PR DESCRIPTION
This PR optmize the computation of the stiffness coefficients in the acoustic solver case. 

We now use an algorithm with complexity 6*N^4  (N = number of degrees of freedom)  instead of 6*N^5

It seperates the computation of the stiffness values in three steps:
- Compute grad(u) 
- Multiply by B and a coefficient alpha (which is transparent inside Qk_hex, and in the acoustic case it is 1/rho)
- Multiply the previous results by grad(v) 

On a 100x100x100 cartesian mesh using order 3 and a simulation duration time of 1.5s in acoustic:

Main: 30s

With optim: 18.5s

Same case in élastic (order 2 instead of 3): 

Main:41.6s

With optim: 19.2s

Elastoc-acoustic case (the one used to validate the solver):

Main:285.2s

With optim: 148.6s