### PR TITLE
clang format update

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,14 +1,7 @@
 BasedOnStyle: Google
 Language: Cpp
-BreakBeforeBraces: Custom
-BraceWrapping:
-  AfterClass: true
-  AfterControlStatement: true
-  AfterEnum: true
-  AfterFunction: true
-  AfterNamespace: true
-  AfterStruct: true
-  AfterUnion: true
-  BeforeCatch: true
-  BeforeElse: true
-  IndentBraces: false
+# Ensure it parses modern C++ correctly (C++20/C++23)
+Standard: Latest
+
+# Increase from Google's default 80 to prevent excessive line wrapping with templates.
+ColumnLimit: 120

--- a/.github/workflows/format-check.yaml
+++ b/.github/workflows/format-check.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Run clang-format style check
-        uses: jidicula/clang-format-action@v4.16.0
+        uses: jidicula/clang-format-action@v4.18.0
         with:
-          clang-format-version: '18'
+          clang-format-version: '20'
           check-path: ${{ matrix.path }}

--- a/.github/workflows/format-check.yaml
+++ b/.github/workflows/format-check.yaml
@@ -17,5 +17,5 @@ jobs:
       - name: Run clang-format style check
         uses: jidicula/clang-format-action@v4.18.0
         with:
-          clang-format-version: '20'
+          clang-format-version: '19'
           check-path: ${{ matrix.path }}

--- a/src/discretization/fd/abckernels/include/fd_abckernels.h
+++ b/src/discretization/fd/abckernels/include/fd_abckernels.h
@@ -5,54 +5,42 @@
 
 using namespace std;
 
-namespace fdtd
-{
-namespace abckernel
-{
-struct FdtdAbcKernels
-{
+namespace fdtd {
+namespace abckernel {
+struct FdtdAbcKernels {
   vectorReal eta;
   vectorReal spongeArray;
   //------------------------------------------------------------------
   // sponge boundary
   //------------------------------------------------------------------
   // define sponge boundary
-  void defineSpongeBoundary(int nx, int ny, int nz)
-  {
+  void defineSpongeBoundary(int nx, int ny, int nz) {
     const int L = 20;
     const float alpha = -0.00015;
     // const float alpha = -0.00035;
     //  compute sponge boundary terms
     //  intailize to 1
-    for (int k = 0; k < nz; k++)
-    {
-      for (int j = 0; j < ny; j++)
-      {
-        for (int i = 0; i < nx; i++)
-        {
+    for (int k = 0; k < nz; k++) {
+      for (int j = 0; j < ny; j++) {
+        for (int i = 0; i < nx; i++) {
           spongeArray(IDX3(i, j, k)) = 1;
         }
-        for (int i = 0; i < nx; i++)
-        {
+        for (int i = 0; i < nx; i++) {
           spongeArray(IDX3(i, j, k)) = 1;
         }
       }
     }
 
     // X boundary
-    for (int k = L; k < nz - L; k++)
-    {
-      for (int j = L; j < ny - L; j++)
-      {
-        for (int i = 0; i < L; i++)
-        {
+    for (int k = L; k < nz - L; k++) {
+      for (int j = L; j < ny - L; j++) {
+        for (int i = 0; i < L; i++) {
           // spongeArray(IDX3(i,j,k))= exp(alpha*pow((L-i)*dx,2));
           spongeArray(IDX3(i, j, k)) = exp(alpha * pow((L - i), 2));
           // printf("spongeArray(%d,%d,%d)=%f\n",i,j,k,spongeArray(IDX3(i, j,
           // k)));
         }
-        for (int i = nx - L; i < nx; i++)
-        {
+        for (int i = nx - L; i < nx; i++) {
           // spongeArray(IDX3(i,j,k))= exp(alpha*pow((L-(nx-i))*dx,2));
           spongeArray(IDX3(i, j, k)) = exp(alpha * pow((L - (nx - i)), 2));
         }
@@ -60,17 +48,13 @@ struct FdtdAbcKernels
     }
 
     // Y boundary
-    for (int k = L; k < nz - L; k++)
-    {
-      for (int i = L; i < nx - L; i++)
-      {
-        for (int j = 0; j < L; j++)
-        {
+    for (int k = L; k < nz - L; k++) {
+      for (int i = L; i < nx - L; i++) {
+        for (int j = 0; j < L; j++) {
           // spongeArray(IDX3(i,j,k))= exp(alpha*pow((L-j)*dy,2));
           spongeArray(IDX3(i, j, k)) = exp(alpha * pow((L - j), 2));
         }
-        for (int j = ny - L; j < ny; j++)
-        {
+        for (int j = ny - L; j < ny; j++) {
           // spongeArray(IDX3(i,j,k))= exp(alpha*pow((L-(ny-j))*dy,2));
           spongeArray(IDX3(i, j, k)) = exp(alpha * pow((L - (ny - j)), 2));
         }
@@ -78,17 +62,13 @@ struct FdtdAbcKernels
     }
 
     // Z boundary
-    for (int j = L; j < ny - L; j++)
-    {
-      for (int i = L; i < nx - L; i++)
-      {
-        for (int k = 0; k < L; k++)
-        {
+    for (int j = L; j < ny - L; j++) {
+      for (int i = L; i < nx - L; i++) {
+        for (int k = 0; k < L; k++) {
           // spongeArray(IDX3(i,j,k))= exp(alpha*pow((L-k))*dz,2));
           spongeArray(IDX3(i, j, k)) = exp(alpha * pow((L - k), 2));
         }
-        for (int k = nz - L; k < nz; k++)
-        {
+        for (int k = nz - L; k < nz; k++) {
           // spongeArray(IDX3(i,j,k))= exp(alpha*pow((L-(nz-k))*dz,2));
           spongeArray(IDX3(i, j, k)) = exp(alpha * pow((L - (nz - k)), 2));
         }
@@ -100,9 +80,7 @@ struct FdtdAbcKernels
   // PML
   //------------------------------------------------------------------
   // Initialize the PML profile
-  void pml_profile_init(vector<float> &profile, int i_min, int i_max,
-                        int n_first, int n_last, float scale)
-  {
+  void pml_profile_init(vector<float> &profile, int i_min, int i_max, int n_first, int n_last, float scale) {
     int n = i_max - i_min + 1;
     int shift = i_min - 1;
 
@@ -112,95 +90,63 @@ struct FdtdAbcKernels
     int last_end = n + shift;
 
 #pragma omp parallel for
-    for (int i = i_min; i <= i_max; ++i)
-    {
+    for (int i = i_min; i <= i_max; ++i) {
       profile[i] = 0.f;
     }
 
     float tmp = scale / POW2(first_end - first_beg + 1);
 #pragma omp parallel for
-    for (int i = 1; i <= first_end - first_beg + 1; ++i)
-    {
+    for (int i = 1; i <= first_end - first_beg + 1; ++i) {
       profile[first_end - i + 1] = POW2(i) * tmp;
     }
 
 #pragma omp parallel for
-    for (int i = 1; i <= last_end - last_beg + 1; ++i)
-    {
+    for (int i = 1; i <= last_end - last_beg + 1; ++i) {
       profile[last_beg + i - 1] = POW2(i) * tmp;
     }
   }
 
-  void pml_profile_extend(int nx, int ny, int nz, vectorReal &eta,
-                          const vector<float> &etax, const vector<float> &etay,
-                          const vector<float> &etaz, int xbeg, int xend,
-                          int ybeg, int yend, int zbeg, int zend)
-  {
+  void pml_profile_extend(int nx, int ny, int nz, vectorReal &eta, const vector<float> &etax, const vector<float> &etay,
+                          const vector<float> &etaz, int xbeg, int xend, int ybeg, int yend, int zbeg, int zend) {
     const int n_ghost = 1;
 #pragma omp parallel for collapse(3)
-    for (int ix = xbeg - n_ghost; ix <= xend + n_ghost; ++ix)
-    {
-      for (int iy = ybeg - n_ghost; iy <= yend + n_ghost; ++iy)
-      {
-        for (int iz = zbeg - n_ghost; iz <= zend + n_ghost; ++iz)
-        {
-          eta[(nz + 2) * (ny + 2) * ix + (nz + 2) * (iy) + iz] =
-              etax[ix] + etay[iy] + etaz[iz];
+    for (int ix = xbeg - n_ghost; ix <= xend + n_ghost; ++ix) {
+      for (int iy = ybeg - n_ghost; iy <= yend + n_ghost; ++iy) {
+        for (int iz = zbeg - n_ghost; iz <= zend + n_ghost; ++iz) {
+          eta[(nz + 2) * (ny + 2) * ix + (nz + 2) * (iy) + iz] = etax[ix] + etay[iy] + etaz[iz];
         }
       }
     }
   }
 
-  void pml_profile_extend_all(int nx, int ny, int nz, vectorReal &eta,
-                              const vector<float> &etax,
-                              const vector<float> &etay,
-                              const vector<float> &etaz, int xmin, int xmax,
-                              int ymin, int ymax, int x1, int x2, int x5,
-                              int x6, int y1, int y2, int y3, int y4, int y5,
-                              int y6, int z1, int z2, int z3, int z4, int z5,
-                              int z6)
-  {
+  void pml_profile_extend_all(int nx, int ny, int nz, vectorReal &eta, const vector<float> &etax,
+                              const vector<float> &etay, const vector<float> &etaz, int xmin, int xmax, int ymin,
+                              int ymax, int x1, int x2, int x5, int x6, int y1, int y2, int y3, int y4, int y5, int y6,
+                              int z1, int z2, int z3, int z4, int z5, int z6) {
     // Top.
-    if (z1 != -1)
-      pml_profile_extend(nx, ny, nz, eta, etax, etay, etaz, xmin, xmax, ymin,
-                         ymax, z1, z2);
+    if (z1 != -1) pml_profile_extend(nx, ny, nz, eta, etax, etay, etaz, xmin, xmax, ymin, ymax, z1, z2);
     // Bottom.
-    if (z5 != -5)
-      pml_profile_extend(nx, ny, nz, eta, etax, etay, etaz, xmin, xmax, ymin,
-                         ymax, z5, z6);
+    if (z5 != -5) pml_profile_extend(nx, ny, nz, eta, etax, etay, etaz, xmin, xmax, ymin, ymax, z5, z6);
     // Front.
-    if ((y1 != -1) && (z3 != -3))
-      pml_profile_extend(nx, ny, nz, eta, etax, etay, etaz, xmin, xmax, y1, y2,
-                         z3, z4);
+    if ((y1 != -1) && (z3 != -3)) pml_profile_extend(nx, ny, nz, eta, etax, etay, etaz, xmin, xmax, y1, y2, z3, z4);
     // Back.
-    if ((y6 != -6) && (z3 != -3))
-      pml_profile_extend(nx, ny, nz, eta, etax, etay, etaz, xmin, xmax, y5, y6,
-                         z3, z4);
+    if ((y6 != -6) && (z3 != -3)) pml_profile_extend(nx, ny, nz, eta, etax, etay, etaz, xmin, xmax, y5, y6, z3, z4);
     // Left.
     if ((x1 != -1) && (y3 != -3) && (z3 != -3))
-      pml_profile_extend(nx, ny, nz, eta, etax, etay, etaz, x1, x2, y3, y4, z3,
-                         z4);
+      pml_profile_extend(nx, ny, nz, eta, etax, etay, etaz, x1, x2, y3, y4, z3, z4);
     // Right.
     if ((x6 != -6) && (y3 != -3) && (z3 != -3))
-      pml_profile_extend(nx, ny, nz, eta, etax, etay, etaz, x5, x6, y3, y4, z3,
-                         z4);
+      pml_profile_extend(nx, ny, nz, eta, etax, etay, etaz, x5, x6, y3, y4, z3, z4);
   }
 
-  void init_eta(int nx, int ny, int nz, int ndampx, int ndampy, int ndampz,
-                int x1, int x2, int x3, int x4, int x5, int x6, int y1, int y2,
-                int y3, int y4, int y5, int y6, int z1, int z2, int z3, int z4,
-                int z5, int z6, float dx, float dy, float dz, float dt_sch,
-                float vmax, vectorReal &eta)
-  {
+  void init_eta(int nx, int ny, int nz, int ndampx, int ndampy, int ndampz, int x1, int x2, int x3, int x4, int x5,
+                int x6, int y1, int y2, int y3, int y4, int y5, int y6, int z1, int z2, int z3, int z4, int z5, int z6,
+                float dx, float dy, float dz, float dt_sch, float vmax, vectorReal &eta) {
 #pragma omp parallel for collapse(3)
-    for (int i = -1; i < nx + 1; ++i)
-    {
-      for (int j = -1; j < ny + 1; ++j)
-      {
-        for (int k = -1; k < nz + 1; ++k)
-        {
-          eta[(nz + 2) * (ny + 2) * (i + 1) + (nz + 2) * (j + 1) + (k + 1)] =
-              0.f;
+    for (int i = -1; i < nx + 1; ++i) {
+      for (int j = -1; j < ny + 1; ++j) {
+        for (int k = -1; k < nz + 1; ++k) {
+          eta[(nz + 2) * (ny + 2) * (i + 1) + (nz + 2) * (j + 1) + (k + 1)] = 0.f;
         }
       }
     }
@@ -224,9 +170,8 @@ struct FdtdAbcKernels
     // printf("param=%f\n",param);
     pml_profile_init(etaz, 0, nz + 1, ndampz, ndampz, param);
 
-    (void)pml_profile_extend_all(
-        nx, ny, nz, eta, etax, etay, etaz, 1, nx, 1, ny, x1 + 1, x2, x5 + 1, x6,
-        y1 + 1, y2, y3 + 1, y4, y5 + 1, y6, z1 + 1, z2, z3 + 1, z4, z5 + 1, z6);
+    (void)pml_profile_extend_all(nx, ny, nz, eta, etax, etay, etaz, 1, nx, 1, ny, x1 + 1, x2, x5 + 1, x6, y1 + 1, y2,
+                                 y3 + 1, y4, y5 + 1, y6, z1 + 1, z2, z3 + 1, z4, z5 + 1, z6);
   }
 };
 

--- a/src/discretization/fd/kernels/include/fd_kernels.h
+++ b/src/discretization/fd/kernels/include/fd_kernels.h
@@ -4,30 +4,23 @@
 #include "fd_abckernels.h"
 #include "fd_macros.h"
 
-namespace fdtd
-{
-namespace kernel
-{
-struct FdtdKernels
-{
+namespace fdtd {
+namespace kernel {
+struct FdtdKernels {
   vectorReal phi;
   vectorReal RHSTerm;
   arrayReal pnGlobal;
 
   // allocate arrays and vectors
-  void initFieldsArrays(int nx, int ny, int nz, int lx, int ly, int lz)
-  {
+  void initFieldsArrays(int nx, int ny, int nz, int lx, int ly, int lz) {
     int extModelVolume = (nx + 2 * lx) * (ny + 2 * ly) * (nz + 2 * lz);
     int modelVolume = nx * ny * nz;
     pnGlobal = allocateArray2D<arrayReal>(extModelVolume, 2, "pnGlobal");
     phi = allocateVector<vectorReal>(modelVolume, "phi");
 
-    for (int i = -lx; i < nx + lx; i++)
-    {
-      for (int j = -ly; j < ny + ly; j++)
-      {
-        for (int k = -lz; k < nz + lz; k++)
-        {
+    for (int i = -lx; i < nx + lx; i++) {
+      for (int j = -ly; j < ny + ly; j++) {
+        for (int k = -lz; k < nz + lz; k++) {
           pnGlobal(IDX3_l(i, j, k), 0) = 0.000001;
           pnGlobal(IDX3_l(i, j, k), 1) = 0.000001;
         }
@@ -36,11 +29,9 @@ struct FdtdKernels
   }
 
   // add RHS term
-  int addRHS(const int itSample, int &cb, int const &nx, int const &ny,
-             int const &nz, int const &lx, int const &ly, int const &lz,
-             int const &xs, int const &ys, int const &zs, vectorReal const &vp,
-             vectorReal const &RHSTerm, arrayReal &pnGlobal) const
-  {
+  int addRHS(const int itSample, int &cb, int const &nx, int const &ny, int const &nz, int const &lx, int const &ly,
+             int const &lz, int const &xs, int const &ys, int const &zs, vectorReal const &vp,
+             vectorReal const &RHSTerm, arrayReal &pnGlobal) const {
     // CREATEVIEWRHS
     LOOP3DHEAD(xs, ys, zs, xs + 1, ys + 1, zs + 1)
     pnGlobal(IDX3_l(i, j, k), cb) += vp[IDX3(i, j, k)] * RHSTerm[itSample];
@@ -49,112 +40,77 @@ struct FdtdKernels
   }
 
   // innerpoints
-  int inner3D(int &ca, int &cb, int const &nx, int const &ny, int const &nz,
-              int const &lx, int const &ly, int const &lz, const int x3,
-              const int x4, const int y3, const int y4, const int z3,
-              const int z4, const double coef0, vectorReal const &coefx,
-              vectorReal const &coefy, vectorReal const &coefz,
-              vectorReal const &vp, arrayReal &pnGlobal) const
-  {
+  int inner3D(int &ca, int &cb, int const &nx, int const &ny, int const &nz, int const &lx, int const &ly,
+              int const &lz, const int x3, const int x4, const int y3, const int y4, const int z3, const int z4,
+              const double coef0, vectorReal const &coefx, vectorReal const &coefy, vectorReal const &coefz,
+              vectorReal const &vp, arrayReal &pnGlobal) const {
     LOOP3DHEAD(x3, y3, z3, x4, y4, z4)
     float lapx = 0;
-    for (int l = 1; l < coefx.extent(0); l++)
-    {
-      lapx += coefx[l] * (pnGlobal(IDX3_l(i + l, j, k), cb) +
-                          pnGlobal(IDX3_l(i - l, j, k), cb));
+    for (int l = 1; l < coefx.extent(0); l++) {
+      lapx += coefx[l] * (pnGlobal(IDX3_l(i + l, j, k), cb) + pnGlobal(IDX3_l(i - l, j, k), cb));
     }
     float lapy = 0;
-    for (int l = 1; l < coefy.extent(0); l++)
-    {
-      lapy += coefy[l] * (pnGlobal(IDX3_l(i, j + l, k), cb) +
-                          pnGlobal(IDX3_l(i, j - l, k), cb));
+    for (int l = 1; l < coefy.extent(0); l++) {
+      lapy += coefy[l] * (pnGlobal(IDX3_l(i, j + l, k), cb) + pnGlobal(IDX3_l(i, j - l, k), cb));
     }
     float lapz = 0;
-    for (int l = 1; l < coefz.extent(0); l++)
-    {
-      lapz += coefz[l] * (pnGlobal(IDX3_l(i, j, k + l), cb) +
-                          pnGlobal(IDX3_l(i, j, k - l), cb));
+    for (int l = 1; l < coefz.extent(0); l++) {
+      lapz += coefz[l] * (pnGlobal(IDX3_l(i, j, k + l), cb) + pnGlobal(IDX3_l(i, j, k - l), cb));
     }
-    pnGlobal(IDX3_l(i, j, k), ca) =
-        2. * pnGlobal(IDX3_l(i, j, k), cb) - pnGlobal(IDX3_l(i, j, k), ca) +
-        vp[IDX3(i, j, k)] *
-            (coef0 * pnGlobal(IDX3_l(i, j, k), cb) + lapx + lapy + lapz);
+    pnGlobal(IDX3_l(i, j, k), ca) = 2. * pnGlobal(IDX3_l(i, j, k), cb) - pnGlobal(IDX3_l(i, j, k), ca) +
+                                    vp[IDX3(i, j, k)] * (coef0 * pnGlobal(IDX3_l(i, j, k), cb) + lapx + lapy + lapz);
     LOOP3DEND
     return 0;
   }
 
   // pml update
-  int pml3D(int &ca, int &cb, int const &nx, int const &ny, int const &nz,
-            int const &lx, int const &ly, int const &lz, const int x3,
-            const int x4, const int y3, const int y4, const int z3,
-            const int z4, const double coef0, const float &hdx_2,
-            const float &hdy_2, const float &hdz_2, vectorReal const &coefx,
-            vectorReal const &coefy, vectorReal const &coefz,
-            vectorReal const &vp, vectorReal const &eta, vectorReal &phi,
-            arrayReal &pnGlobal) const
-  {
+  int pml3D(int &ca, int &cb, int const &nx, int const &ny, int const &nz, int const &lx, int const &ly, int const &lz,
+            const int x3, const int x4, const int y3, const int y4, const int z3, const int z4, const double coef0,
+            const float &hdx_2, const float &hdy_2, const float &hdz_2, vectorReal const &coefx,
+            vectorReal const &coefy, vectorReal const &coefz, vectorReal const &vp, vectorReal const &eta,
+            vectorReal &phi, arrayReal &pnGlobal) const {
     LOOP3DHEAD(x3, y3, z3, x4, y4, z4)
     float lapx = 0;
-    for (int l = 1; l < coefx.extent(0); l++)
-    {
-      lapx += coefx[l] * (pnGlobal(IDX3_l(i + l, j, k), cb) +
-                          pnGlobal(IDX3_l(i - l, j, k), cb));
+    for (int l = 1; l < coefx.extent(0); l++) {
+      lapx += coefx[l] * (pnGlobal(IDX3_l(i + l, j, k), cb) + pnGlobal(IDX3_l(i - l, j, k), cb));
     }
     float lapy = 0;
-    for (int l = 1; l < coefy.extent(0); l++)
-    {
-      lapy += coefy[l] * (pnGlobal(IDX3_l(i, j + l, k), cb) +
-                          pnGlobal(IDX3_l(i, j - l, k), cb));
+    for (int l = 1; l < coefy.extent(0); l++) {
+      lapy += coefy[l] * (pnGlobal(IDX3_l(i, j + l, k), cb) + pnGlobal(IDX3_l(i, j - l, k), cb));
     }
     float lapz = 0;
-    for (int l = 1; l < coefz.extent(0); l++)
-    {
-      lapz += coefz[l] * (pnGlobal(IDX3_l(i, j, k + l), cb) +
-                          pnGlobal(IDX3_l(i, j, k - l), cb));
+    for (int l = 1; l < coefz.extent(0); l++) {
+      lapz += coefz[l] * (pnGlobal(IDX3_l(i, j, k + l), cb) + pnGlobal(IDX3_l(i, j, k - l), cb));
     }
 
     float lap = coef0 * pnGlobal(IDX3_l(i, j, k), cb) + lapx + lapy + lapz;
 
     pnGlobal(IDX3_l(i, j, k), ca) =
-        ((2. - eta[IDX3_eta1(i, j, k)] * eta[IDX3_eta1(i, j, k)] +
-          2. * eta[IDX3_eta1(i, j, k)]) *
+        ((2. - eta[IDX3_eta1(i, j, k)] * eta[IDX3_eta1(i, j, k)] + 2. * eta[IDX3_eta1(i, j, k)]) *
              pnGlobal(IDX3_l(i, j, k), cb) -
-         pnGlobal(IDX3_l(i, j, k), ca) +
-         vp[IDX3(i, j, k)] * (phi[IDX3(i, j, k)] + lap)) /
+         pnGlobal(IDX3_l(i, j, k), ca) + vp[IDX3(i, j, k)] * (phi[IDX3(i, j, k)] + lap)) /
         (1. + 2. * eta[IDX3_eta1(i, j, k)]);
 
     phi[IDX3(i, j, k)] =
-        (phi[IDX3(i, j, k)] -
-         ((eta[IDX3_eta1(i + 1, j, k)] - eta[IDX3_eta1(i - 1, j, k)]) *
-              (pnGlobal(IDX3_l(i + 1, j, k), cb) -
-               pnGlobal(IDX3_l(i - 1, j, k), cb)) *
-              hdx_2 +
-          (eta[IDX3_eta1(i, j + 1, k)] - eta[IDX3_eta1(i, j - 1, k)]) *
-              (pnGlobal(IDX3_l(i, j + 1, k), cb) -
-               pnGlobal(IDX3_l(i, j - 1, k), cb)) *
-              hdy_2 +
-          (eta[IDX3_eta1(i, j, k + 1)] - eta[IDX3_eta1(i, j, k - 1)]) *
-              (pnGlobal(IDX3_l(i, j, k + 1), cb) -
-               pnGlobal(IDX3_l(i, j, k - 1), cb)) *
-              hdz_2)) /
+        (phi[IDX3(i, j, k)] - ((eta[IDX3_eta1(i + 1, j, k)] - eta[IDX3_eta1(i - 1, j, k)]) *
+                                   (pnGlobal(IDX3_l(i + 1, j, k), cb) - pnGlobal(IDX3_l(i - 1, j, k), cb)) * hdx_2 +
+                               (eta[IDX3_eta1(i, j + 1, k)] - eta[IDX3_eta1(i, j - 1, k)]) *
+                                   (pnGlobal(IDX3_l(i, j + 1, k), cb) - pnGlobal(IDX3_l(i, j - 1, k), cb)) * hdy_2 +
+                               (eta[IDX3_eta1(i, j, k + 1)] - eta[IDX3_eta1(i, j, k - 1)]) *
+                                   (pnGlobal(IDX3_l(i, j, k + 1), cb) - pnGlobal(IDX3_l(i, j, k - 1), cb)) * hdz_2)) /
         (1. + eta[IDX3_eta1(i, j, k)]);
     LOOP3DEND
     return (0);
   }
 
   // apply sponge boundary to wavefield
-  int applySponge(int &ca, int &cb, int const &nx, int const &ny, int const &nz,
-                  int const &lx, int const &ly, int const &lz, const int x3,
-                  const int x4, const int y3, const int y4, const int z3,
-                  const int z4, vectorReal const &spongeArray,
-                  arrayReal &pnGlobal) const
-  {
+  int applySponge(int &ca, int &cb, int const &nx, int const &ny, int const &nz, int const &lx, int const &ly,
+                  int const &lz, const int x3, const int x4, const int y3, const int y4, const int z3, const int z4,
+                  vectorReal const &spongeArray, arrayReal &pnGlobal) const {
     // CREATEVIEWSPONGE
     LOOP3DHEAD(x3, y3, z3, x4, y4, z4)
-    pnGlobal(IDX3_l(i, j, k), ca) =
-        pnGlobal(IDX3_l(i, j, k), ca);  // * spongeArray(IDX3(i, j, k));
-    pnGlobal(IDX3_l(i, j, k), cb) =
-        pnGlobal(IDX3_l(i, j, k), cb);  // * spongeArray(IDX3(i, j, k));
+    pnGlobal(IDX3_l(i, j, k), ca) = pnGlobal(IDX3_l(i, j, k), ca);  // * spongeArray(IDX3(i, j, k));
+    pnGlobal(IDX3_l(i, j, k), cb) = pnGlobal(IDX3_l(i, j, k), cb);  // * spongeArray(IDX3(i, j, k));
     LOOP3DEND
     return 0;
   }

--- a/src/discretization/fd/kernels/include/fd_macros.h
+++ b/src/discretization/fd/kernels/include/fd_macros.h
@@ -2,11 +2,8 @@
 #define FUNTIDES_DISCRETIZATION_FD_KERNELS_INCLUDE_FD_MACROS_H_
 #define POW2(x) ((x) * (x))
 #define IDX3(i, j, k) (nz * ny * (i) + nz * (j) + (k))
-#define IDX3_l(i, j, k)                                                      \
-  ((nz + 2 * lz) * (ny + 2 * ly) * ((i) + lx) + (nz + 2 * lz) * ((j) + ly) + \
-   ((k) + lz))
-#define IDX3_eta1(i, j, k) \
-  ((nz + 2) * (ny + 2) * ((i) + 1) + (nz + 2) * ((j) + 1) + ((k) + 1))
+#define IDX3_l(i, j, k) ((nz + 2 * lz) * (ny + 2 * ly) * ((i) + lx) + (nz + 2 * lz) * ((j) + ly) + ((k) + lz))
+#define IDX3_eta1(i, j, k) ((nz + 2) * (ny + 2) * ((i) + 1) + (nz + 2) * ((j) + 1) + ((k) + 1))
 
 #define LOOP3DHEAD(x3, y3, z3, x4, y4, z4) Kokkos::parallel_for(Kokkos::MDRangePolicy<Kokkos::Rank<3>>({z3,x3,y3},{z4,x4,y4}),KOKKOS_LAMBDA(int k,int i,int j) {
 #define LOOP3DEND \

--- a/src/discretization/fd/stencils/include/fd_stencils.h
+++ b/src/discretization/fd/stencils/include/fd_stencils.h
@@ -8,12 +8,9 @@
 
 using namespace std;
 
-namespace fdtd
-{
-namespace stencils
-{
-struct FdtdStencils
-{
+namespace fdtd {
+namespace stencils {
+struct FdtdStencils {
   int ncoefsX{0}, ncoefsY{0}, ncoefsZ{0};
   int lx{0}, ly{0}, lz{0};  // half stencil lenght
   double coef0{0.0};
@@ -22,11 +19,9 @@ struct FdtdStencils
   vectorReal coefy;
   vectorReal coefz;
 
-  void init_coef(int L, float dx, vectorReal &coef)
-  {
+  void init_coef(int L, float dx, vectorReal &coef) {
     float dx2 = dx * dx;
-    switch (L)
-    {
+    switch (L) {
       case 1:
         coef[0] = -2.f / dx2;
         coef[1] = 1.f / dx2;
@@ -69,9 +64,7 @@ struct FdtdStencils
     }
   }
 
-  void initStencilsCoefficients(fdtd::options::FdtdOptions &m_opt, float dx,
-                                float dy, float dz)
-  {
+  void initStencilsCoefficients(fdtd::options::FdtdOptions &m_opt, float dx, float dy, float dz) {
     // half stencil lenght
     lx = m_opt.stencil.lx;
     ly = m_opt.stencil.ly;
@@ -93,39 +86,32 @@ struct FdtdStencils
 
     // compute coef0 and all coefs such that sum(coef)=0
     float tmpX = 0;
-    for (int i = 1; i < ncoefsX; i++)
-    {
+    for (int i = 1; i < ncoefsX; i++) {
       tmpX += coefx[i];
     }
     float tmpY = 0;
-    for (int i = 1; i < ncoefsY; i++)
-    {
+    for (int i = 1; i < ncoefsY; i++) {
       tmpY += coefy[i];
     }
     float tmpZ = 0;
-    for (int i = 1; i < ncoefsZ; i++)
-    {
+    for (int i = 1; i < ncoefsZ; i++) {
       tmpZ += coefz[i];
     }
     coef0 = -2. * (tmpX + tmpY + tmpZ);
   }
 
   // compute stable time step
-  float compute_dt_sch(float vmax)
-  {
+  float compute_dt_sch(float vmax) {
     float ftmp = 0.;
     float cfl = 0.8;
     ftmp += fabsf(coefx[0]) + fabsf(coefy[0]) + fabsf(coefz[0]);
-    for (int i = 1; i < coefx.extent(0); i++)
-    {
+    for (int i = 1; i < coefx.extent(0); i++) {
       ftmp += 2.f * fabsf(coefx[i]);
     }
-    for (int i = 1; i < coefy.extent(0); i++)
-    {
+    for (int i = 1; i < coefy.extent(0); i++) {
       ftmp += 2.f * fabsf(coefy[i]);
     }
-    for (int i = 1; i < coefz.extent(0); i++)
-    {
+    for (int i = 1; i < coefz.extent(0); i++) {
       ftmp += 2.f * fabsf(coefz[i]);
     }
     return 2 * cfl / (sqrtf(ftmp) * vmax);

--- a/src/discretization/fe/common/Integrals.h
+++ b/src/discretization/fe/common/Integrals.h
@@ -6,19 +6,13 @@
 template <int ORDER, int METHOD_TYPE>
 struct IntegralTypeSelector;
 
-namespace IntegralType
-{
-enum
-{
-  MAKUTU
-};
+namespace IntegralType {
+enum { MAKUTU };
 }
 
 template <int ORDER>
-struct IntegralTypeSelector<ORDER, IntegralType::MAKUTU>
-{
-  using type =
-      typename Qk_Hexahedron_Lagrange_GaussLobatto_Selector<ORDER>::type;
+struct IntegralTypeSelector<ORDER, IntegralType::MAKUTU> {
+  using type = typename Qk_Hexahedron_Lagrange_GaussLobatto_Selector<ORDER>::type;
 };
 
 #endif  // FUNTIDES_DISCRETIZATION_FE_INTEGRALS_H_

--- a/src/discretization/fe/common/mathUtilites.h
+++ b/src/discretization/fe/common/mathUtilites.h
@@ -6,19 +6,14 @@
 #include "macros.h"
 
 template <typename T>
-static constexpr inline SEMKERNELS_HOST_DEVICE T determinant(T const (&m)[3][3])
-{
-  return +m[0][0] * (m[1][1] * m[2][2] - m[2][1] * m[1][2]) -
-         m[0][1] * (m[1][0] * m[2][2] - m[2][0] * m[1][2]) +
+static constexpr inline SEMKERNELS_HOST_DEVICE T determinant(T const (&m)[3][3]) {
+  return +m[0][0] * (m[1][1] * m[2][2] - m[2][1] * m[1][2]) - m[0][1] * (m[1][0] * m[2][2] - m[2][0] * m[1][2]) +
          m[0][2] * (m[1][0] * m[2][1] - m[2][0] * m[1][1]);
 }
 
 template <typename T>
-static constexpr inline SEMKERNELS_HOST_DEVICE typename T::value_type
-determinant(T const& m)
-{
-  return +m(0, 0) * (m(1, 1) * m(2, 2) - m(2, 1) * m(1, 2)) -
-         m(0, 1) * (m(1, 0) * m(2, 2) - m(2, 0) * m(1, 2)) +
+static constexpr inline SEMKERNELS_HOST_DEVICE typename T::value_type determinant(T const& m) {
+  return +m(0, 0) * (m(1, 1) * m(2, 2) - m(2, 1) * m(1, 2)) - m(0, 1) * (m(1, 0) * m(2, 2) - m(2, 0) * m(1, 2)) +
          m(0, 2) * (m(1, 0) * m(2, 1) - m(2, 0) * m(1, 1));
 }
 
@@ -32,10 +27,7 @@ determinant(T const& m)
  * @return The linear index of the support/quadrature point (0-(r+1)^3)
  */
 template <int ORDER>
-static constexpr inline SEMKERNELS_HOST_DEVICE int linearIndex(const int i,
-                                                               const int j,
-                                                               const int k)
-{
+static constexpr inline SEMKERNELS_HOST_DEVICE int linearIndex(const int i, const int j, const int k) {
   return i + (ORDER + 1) * j + (ORDER + 1) * (ORDER + 1) * k;
 }
 
@@ -49,35 +41,27 @@ static constexpr inline SEMKERNELS_HOST_DEVICE int linearIndex(const int i,
  * @param i2 The Cartesian index of the support point in the xi2 direction.
  */
 template <int ORDER>
-static constexpr inline SEMKERNELS_HOST_DEVICE std::tuple<int, int, int>
-tripleIndex(int const linearIndex)
-{
+static constexpr inline SEMKERNELS_HOST_DEVICE std::tuple<int, int, int> tripleIndex(int const linearIndex) {
   return {(linearIndex % ((ORDER + 1) * (ORDER + 1))) % (ORDER + 1),
-          (linearIndex % ((ORDER + 1) * (ORDER + 1))) / (ORDER + 1),
-          (linearIndex / ((ORDER + 1) * (ORDER + 1)))};
+          (linearIndex % ((ORDER + 1) * (ORDER + 1))) / (ORDER + 1), (linearIndex / ((ORDER + 1) * (ORDER + 1)))};
 }
 
 template <typename T>
-PROXY_HOST_DEVICE T symDeterminant(T (&B)[3])
-{
+PROXY_HOST_DEVICE T symDeterminant(T (&B)[3]) {
   return B[0] * B[1] - B[2] * B[2];
 }
 
 template <typename T>
-PROXY_HOST_DEVICE T symDeterminant(T (&B)[6])
-{
-  return B[0] * B[1] * B[2] + B[5] * B[4] * B[3] * 2 - B[0] * B[3] * B[3] -
-         B[1] * B[4] * B[4] - B[2] * B[5] * B[5];
+PROXY_HOST_DEVICE T symDeterminant(T (&B)[6]) {
+  return B[0] * B[1] * B[2] + B[5] * B[4] * B[3] * 2 - B[0] * B[3] * B[3] - B[1] * B[4] * B[4] - B[2] * B[5] * B[5];
 }
 
 template <typename T>
-PROXY_HOST_DEVICE auto invert3x3(T (&Jinv)[3][3], T const (&J)[3][3])
-{
+PROXY_HOST_DEVICE auto invert3x3(T (&Jinv)[3][3], T const (&J)[3][3]) {
   Jinv[0][0] = J[1][1] * J[2][2] - J[1][2] * J[2][1];
   Jinv[0][1] = J[0][2] * J[2][1] - J[0][1] * J[2][2];
   Jinv[0][2] = J[0][1] * J[1][2] - J[0][2] * J[1][1];
-  T const det =
-      J[0][0] * Jinv[0][0] + J[1][0] * Jinv[0][1] + J[2][0] * Jinv[0][2];
+  T const det = J[0][0] * Jinv[0][0] + J[1][0] * Jinv[0][1] + J[2][0] * Jinv[0][2];
 
   T const invDet = T(1) / det;
 
@@ -95,11 +79,9 @@ PROXY_HOST_DEVICE auto invert3x3(T (&Jinv)[3][3], T const (&J)[3][3])
 }
 
 template <typename T>
-PROXY_HOST_DEVICE auto invert3x3(T (&Jinv)[3][3])
-{
-  T const J[3][3] = {{Jinv[0][0], Jinv[0][1], Jinv[0][2]},
-                     {Jinv[1][0], Jinv[1][1], Jinv[1][2]},
-                     {Jinv[2][0], Jinv[2][1], Jinv[2][2]}};
+PROXY_HOST_DEVICE auto invert3x3(T (&Jinv)[3][3]) {
+  T const J[3][3] = {
+      {Jinv[0][0], Jinv[0][1], Jinv[0][2]}, {Jinv[1][0], Jinv[1][1], Jinv[1][2]}, {Jinv[2][0], Jinv[2][1], Jinv[2][2]}};
   return invert3x3(Jinv, J);
 }
 
@@ -113,33 +95,21 @@ PROXY_HOST_DEVICE auto invert3x3(T (&Jinv)[3][3])
  * floating point values.
  */
 template <typename T>
-static constexpr inline SEMKERNELS_HOST_DEVICE void symInvert(
-    T (&dstSymMatrix)[6], T const (&srcSymMatrix)[6])
-{
-  dstSymMatrix[0] =
-      srcSymMatrix[1] * srcSymMatrix[2] - srcSymMatrix[3] * srcSymMatrix[3];
-  dstSymMatrix[5] =
-      srcSymMatrix[4] * srcSymMatrix[3] - srcSymMatrix[5] * srcSymMatrix[2];
-  dstSymMatrix[4] =
-      srcSymMatrix[5] * srcSymMatrix[3] - srcSymMatrix[4] * srcSymMatrix[1];
+static constexpr inline SEMKERNELS_HOST_DEVICE void symInvert(T (&dstSymMatrix)[6], T const (&srcSymMatrix)[6]) {
+  dstSymMatrix[0] = srcSymMatrix[1] * srcSymMatrix[2] - srcSymMatrix[3] * srcSymMatrix[3];
+  dstSymMatrix[5] = srcSymMatrix[4] * srcSymMatrix[3] - srcSymMatrix[5] * srcSymMatrix[2];
+  dstSymMatrix[4] = srcSymMatrix[5] * srcSymMatrix[3] - srcSymMatrix[4] * srcSymMatrix[1];
 
-  T det = srcSymMatrix[0] * dstSymMatrix[0] +
-          srcSymMatrix[5] * dstSymMatrix[5] + srcSymMatrix[4] * dstSymMatrix[4];
+  T det = srcSymMatrix[0] * dstSymMatrix[0] + srcSymMatrix[5] * dstSymMatrix[5] + srcSymMatrix[4] * dstSymMatrix[4];
 
   T const invDet = 1.0 / det;
 
   dstSymMatrix[0] *= invDet;
   dstSymMatrix[5] *= invDet;
   dstSymMatrix[4] *= invDet;
-  dstSymMatrix[1] =
-      (srcSymMatrix[0] * srcSymMatrix[2] - srcSymMatrix[4] * srcSymMatrix[4]) *
-      invDet;
-  dstSymMatrix[3] =
-      (srcSymMatrix[5] * srcSymMatrix[4] - srcSymMatrix[0] * srcSymMatrix[3]) *
-      invDet;
-  dstSymMatrix[2] =
-      (srcSymMatrix[0] * srcSymMatrix[1] - srcSymMatrix[5] * srcSymMatrix[5]) *
-      invDet;
+  dstSymMatrix[1] = (srcSymMatrix[0] * srcSymMatrix[2] - srcSymMatrix[4] * srcSymMatrix[4]) * invDet;
+  dstSymMatrix[3] = (srcSymMatrix[5] * srcSymMatrix[4] - srcSymMatrix[0] * srcSymMatrix[3]) * invDet;
+  dstSymMatrix[2] = (srcSymMatrix[0] * srcSymMatrix[1] - srcSymMatrix[5] * srcSymMatrix[5]) * invDet;
 }
 
 /**
@@ -151,8 +121,7 @@ static constexpr inline SEMKERNELS_HOST_DEVICE void symInvert(
  * floating point values.
  */
 template <typename T>
-static inline SEMKERNELS_HOST_DEVICE void symInvert(T (&symMatrix)[6])
-{
+static inline SEMKERNELS_HOST_DEVICE void symInvert(T (&symMatrix)[6]) {
   T temp[6];
   symInvert(temp, symMatrix);
 
@@ -165,9 +134,7 @@ static inline SEMKERNELS_HOST_DEVICE void symInvert(T (&symMatrix)[6])
 }
 
 template <typename T>
-static constexpr inline SEMKERNELS_HOST_DEVICE void computeB(T const (&J)[3][3],
-                                                             T (&B)[6])
-{
+static constexpr inline SEMKERNELS_HOST_DEVICE void computeB(T const (&J)[3][3], T (&B)[6]) {
   B[0] = (J[0][0] * J[0][0] + J[1][0] * J[1][0] + J[2][0] * J[2][0]);
   B[1] = (J[0][1] * J[0][1] + J[1][1] * J[1][1] + J[2][1] * J[2][1]);
   B[2] = (J[0][2] * J[0][2] + J[1][2] * J[1][2] + J[2][2] * J[2][2]);
@@ -179,9 +146,7 @@ static constexpr inline SEMKERNELS_HOST_DEVICE void computeB(T const (&J)[3][3],
 }
 
 template <typename T>
-static constexpr inline SEMKERNELS_HOST_DEVICE void computeB(
-    T const& J, typename T::value_type (&B)[6])
-{
+static constexpr inline SEMKERNELS_HOST_DEVICE void computeB(T const& J, typename T::value_type (&B)[6]) {
   B[0] = (J(0, 0) * J(0, 0) + J(1, 0) * J(1, 0) + J(2, 0) * J(2, 0));
   B[1] = (J(0, 1) * J(0, 1) + J(1, 1) * J(1, 1) + J(2, 1) * J(2, 1));
   B[2] = (J(0, 2) * J(0, 2) + J(1, 2) * J(1, 2) + J(2, 2) * J(2, 2));

--- a/src/discretization/fe/makutu/include/LagrangeBasis1.h
+++ b/src/discretization/fe/makutu/include/LagrangeBasis1.h
@@ -14,8 +14,7 @@
  *  Coordinate:   -1             1
  *
  */
-class LagrangeBasis1
-{
+class LagrangeBasis1 {
  public:
   /// The number of support points for the basis
   constexpr static int numSupportPoints = 2;
@@ -33,8 +32,7 @@ class LagrangeBasis1
    * @param supportPointIndex The linear index of support point
    * @return parent coordinate in the xi0 direction.
    */
-  constexpr static double parentSupportCoord(const int supportPointIndex)
-  {
+  constexpr static double parentSupportCoord(const int supportPointIndex) {
     return -1.0 + 2.0 * (supportPointIndex & 1);
   }
 
@@ -45,10 +43,7 @@ class LagrangeBasis1
    * @param xi The coordinate at which to evaluate the basis.
    * @return The value of basis function.
    */
-  constexpr static double value(const int index, const double xi)
-  {
-    return 0.5 + 0.5 * xi * parentSupportCoord(index);
-  }
+  constexpr static double value(const int index, const double xi) { return 0.5 + 0.5 * xi * parentSupportCoord(index); }
 
   /**
    * @brief The value of the basis function for the 0 support point.
@@ -69,10 +64,7 @@ class LagrangeBasis1
    * @param xi The coordinate at which to evaluate the basis.
    * @return The value of the basis.
    */
-  constexpr static double valueBubble(const double xi)
-  {
-    return 1.0 - pow(xi, 2);
-  }
+  constexpr static double valueBubble(const double xi) { return 1.0 - pow(xi, 2); }
 
   /**
    * @brief The gradient of the basis function for a support point evaluated at
@@ -82,10 +74,7 @@ class LagrangeBasis1
    * @param xi The coordinate at which to evaluate the gradient.
    * @return The gradient of basis function.
    */
-  constexpr static double gradient(const int index, const double xi)
-  {
-    return 0.5 * parentSupportCoord(index);
-  }
+  constexpr static double gradient(const int index, const double xi) { return 0.5 * parentSupportCoord(index); }
 
   /**
    * @brief The gradient of the basis function for support point 0 evaluated at
@@ -111,10 +100,7 @@ class LagrangeBasis1
    * @param q The index of the basis function
    * @return The gradient of basis function.
    */
-  constexpr static double gradientAt(const int q, const int)
-  {
-    return q == 0 ? -0.5 : 0.5;
-  }
+  constexpr static double gradientAt(const int q, const int) { return q == 0 ? -0.5 : 0.5; }
 
   /**
    * @struct TensorProduct2D
@@ -131,8 +117,7 @@ class LagrangeBasis1
    * ------ xi0
    *
    */
-  struct TensorProduct2D
-  {
+  struct TensorProduct2D {
     /// The number of support points in the basis.
     constexpr static int numSupportPoints = 4;
 
@@ -143,10 +128,7 @@ class LagrangeBasis1
      * @param j The index in the xi1 direction (0,1)
      * @return The linear index of the support/quadrature point (0-3)
      */
-    constexpr static int linearIndex(const int i, const int j)
-    {
-      return i + 2 * j;
-    }
+    constexpr static int linearIndex(const int i, const int j) { return i + 2 * j; }
 
     /**
      * @brief Calculate the Cartesian/TensorProduct index given the linear index
@@ -155,8 +137,7 @@ class LagrangeBasis1
      * @param i0 The Cartesian index of the support point in the xi0 direction.
      * @param i1 The Cartesian index of the support point in the xi1 direction.
      */
-    constexpr static void multiIndex(const int linearIndex, int& i0, int& i1)
-    {
+    constexpr static void multiIndex(const int linearIndex, int& i0, int& i1) {
       i0 = (linearIndex & 1);
       i1 = (linearIndex & 2) >> 1;
     }
@@ -170,15 +151,11 @@ class LagrangeBasis1
      * @param N Array to hold the value of the basis functions at each support
      * point.
      */
-    static void value(double const (&coords)[2], double (&N)[numSupportPoints])
-    {
-      for (int a = 0; a < 2; ++a)
-      {
-        for (int b = 0; b < 2; ++b)
-        {
+    static void value(double const (&coords)[2], double (&N)[numSupportPoints]) {
+      for (int a = 0; a < 2; ++a) {
+        for (int b = 0; b < 2; ++b) {
           const int lindex = LagrangeBasis1::TensorProduct2D::linearIndex(a, b);
-          N[lindex] = LagrangeBasis1::value(a, coords[0]) *
-                      LagrangeBasis1::value(b, coords[1]);
+          N[lindex] = LagrangeBasis1::value(a, coords[0]) * LagrangeBasis1::value(b, coords[1]);
         }
       }
     }
@@ -188,20 +165,14 @@ class LagrangeBasis1
      * @param linearIndex The linear index of the support point
      * @return
      */
-    constexpr static double parentCoords0(int const linearIndex)
-    {
-      return -1.0 + 2.0 * (linearIndex & 1);
-    }
+    constexpr static double parentCoords0(int const linearIndex) { return -1.0 + 2.0 * (linearIndex & 1); }
 
     /**
      * @brief The parent coordinates for a support point in the xi1 direction.
      * @param linearIndex The linear index of the support point
      * @return
      */
-    constexpr static double parentCoords1(int const linearIndex)
-    {
-      return -1.0 + (linearIndex & 2);
-    }
+    constexpr static double parentCoords1(int const linearIndex) { return -1.0 + (linearIndex & 2); }
   };
 
   /**
@@ -224,8 +195,7 @@ class LagrangeBasis1
    * |____________________| o-----------------o            |/ 0 1 ------ xi0
    *
    */
-  struct TensorProduct3D
-  {
+  struct TensorProduct3D {
     /// The number of support points in the basis.
     constexpr static int numSupportPoints = 8;
 
@@ -240,10 +210,7 @@ class LagrangeBasis1
      * @param k The index in the xi2 direction (0,1)
      * @return The linear index of the support/quadrature point (0-7)
      */
-    constexpr static int linearIndex(const int i, const int j, const int k)
-    {
-      return i + 2 * j + 4 * k;
-    }
+    constexpr static int linearIndex(const int i, const int j, const int k) { return i + 2 * j + 4 * k; }
 
     /**
      * @brief Calculate the Cartesian/TensorProduct index given the linear index
@@ -253,9 +220,7 @@ class LagrangeBasis1
      * @param i1 The Cartesian index of the support point in the xi1 direction.
      * @param i2 The Cartesian index of the support point in the xi2 direction.
      */
-    constexpr static void multiIndex(const int linearIndex, int& i0, int& i1,
-                                     int& i2)
-    {
+    constexpr static void multiIndex(const int linearIndex, int& i0, int& i1, int& i2) {
       i0 = (linearIndex & 1);
       i1 = (linearIndex & 2) >> 1;
       i2 = (linearIndex & 4) >> 2;
@@ -271,18 +236,12 @@ class LagrangeBasis1
      * point.
      */
     PROXY_HOST_DEVICE
-    static void value(double const (&coords)[3], double (&N)[numSupportPoints])
-    {
-      for (int a = 0; a < 2; ++a)
-      {
-        for (int b = 0; b < 2; ++b)
-        {
-          for (int c = 0; c < 2; ++c)
-          {
-            const int lindex =
-                LagrangeBasis1::TensorProduct3D::linearIndex(a, b, c);
-            N[lindex] = LagrangeBasis1::value(a, coords[0]) *
-                        LagrangeBasis1::value(b, coords[1]) *
+    static void value(double const (&coords)[3], double (&N)[numSupportPoints]) {
+      for (int a = 0; a < 2; ++a) {
+        for (int b = 0; b < 2; ++b) {
+          for (int c = 0; c < 2; ++c) {
+            const int lindex = LagrangeBasis1::TensorProduct3D::linearIndex(a, b, c);
+            N[lindex] = LagrangeBasis1::value(a, coords[0]) * LagrangeBasis1::value(b, coords[1]) *
                         LagrangeBasis1::value(c, coords[2]);
           }
         }
@@ -294,30 +253,21 @@ class LagrangeBasis1
      * @param linearIndex The linear index of the support point
      * @return
      */
-    constexpr static double parentCoords0(int const linearIndex)
-    {
-      return -1.0 + 2.0 * (linearIndex & 1);
-    }
+    constexpr static double parentCoords0(int const linearIndex) { return -1.0 + 2.0 * (linearIndex & 1); }
 
     /**
      * @brief The parent coordinates for a support point in the xi1 direction.
      * @param linearIndex The linear index of the support point
      * @return
      */
-    constexpr static double parentCoords1(int const linearIndex)
-    {
-      return -1.0 + (linearIndex & 2);
-    }
+    constexpr static double parentCoords1(int const linearIndex) { return -1.0 + (linearIndex & 2); }
 
     /**
      * @brief The parent coordinates for a support point in the xi2 direction.
      * @param linearIndex The linear index of the support point
      * @return
      */
-    constexpr static double parentCoords2(int const linearIndex)
-    {
-      return -1.0 + 0.5 * (linearIndex & 4);
-    }
+    constexpr static double parentCoords2(int const linearIndex) { return -1.0 + 0.5 * (linearIndex & 4); }
   };
 };
 

--- a/src/discretization/fe/makutu/include/LagrangeBasis2.h
+++ b/src/discretization/fe/makutu/include/LagrangeBasis2.h
@@ -15,8 +15,7 @@
  *  Coordinate:   -1             0             1
  *
  */
-class LagrangeBasis2
-{
+class LagrangeBasis2 {
  public:
   /// The number of support points for the basis
   constexpr static int numSupportPoints = 3;
@@ -27,10 +26,8 @@ class LagrangeBasis2
    * @return The value of the weight
    */
   PROXY_HOST_DEVICE
-  constexpr static real_t weight(const int q)
-  {
-    switch (q)
-    {
+  constexpr static real_t weight(const int q) {
+    switch (q) {
       case 0:
       case 2:
         return 1.0 / 3.0;
@@ -46,10 +43,8 @@ class LagrangeBasis2
    * @return parent coordinate in the xi0 direction.
    */
   PROXY_HOST_DEVICE
-  constexpr static double parentSupportCoord(const int supportPointIndex)
-  {
-    switch (supportPointIndex)
-    {
+  constexpr static double parentSupportCoord(const int supportPointIndex) {
+    switch (supportPointIndex) {
       case 0:
         return -1.0;
         break;
@@ -69,10 +64,8 @@ class LagrangeBasis2
    * @return The value of basis function.
    */
   PROXY_HOST_DEVICE
-  constexpr static double value(const int index, const double xi)
-  {
-    switch (index)
-    {
+  constexpr static double value(const int index, const double xi) {
+    switch (index) {
       case 0:
         return value0(xi);
       case 2:
@@ -89,8 +82,7 @@ class LagrangeBasis2
    * @return The value of the basis.
    */
   PROXY_HOST_DEVICE
-  constexpr static double value0(const double xi)
-  {
+  constexpr static double value0(const double xi) {
     const double xi_div2 = 0.5 * xi;
     return -xi_div2 + xi_div2 * xi;
   }
@@ -109,8 +101,7 @@ class LagrangeBasis2
    * @return The value of the basis.
    */
   PROXY_HOST_DEVICE
-  constexpr static double value2(const double xi)
-  {
+  constexpr static double value2(const double xi) {
     const double xi_div2 = 0.5 * xi;
     return xi_div2 + xi_div2 * xi;
   }
@@ -150,10 +141,8 @@ class LagrangeBasis2
    * @return The value of basis function.
    */
   PROXY_HOST_DEVICE
-  constexpr static double gradient(const int index, const double xi)
-  {
-    switch (index)
-    {
+  constexpr static double gradient(const int index, const double xi) {
+    switch (index) {
       case 0:
         return gradient0(xi);
       case 2:
@@ -172,10 +161,8 @@ class LagrangeBasis2
    * @return The gradient of basis function.
    */
   PROXY_HOST_DEVICE
-  constexpr static double gradientAt(const int q, const int p)
-  {
-    switch (q)
-    {
+  constexpr static double gradientAt(const int q, const int p) {
+    switch (q) {
       case 0:
         return p == 0 ? -1.5 : -0.5;
       case 1:
@@ -209,8 +196,7 @@ class LagrangeBasis2
    *
    *
    */
-  struct TensorProduct2D
-  {
+  struct TensorProduct2D {
     /// The number of support points in the basis.
     constexpr static int numSupportPoints = 9;
 
@@ -222,10 +208,7 @@ class LagrangeBasis2
      * @return The linear index of the support/quadrature point (0-8)
      */
     PROXY_HOST_DEVICE
-    constexpr static int linearIndex(const int i, const int j)
-    {
-      return i + 3 * j;
-    }
+    constexpr static int linearIndex(const int i, const int j) { return i + 3 * j; }
 
     /**
      * @brief Calculate the Cartesian/TensorProduct index given the linear index
@@ -235,8 +218,7 @@ class LagrangeBasis2
      * @param i1 The Cartesian index of the support point in the xi1 direction.
      */
     PROXY_HOST_DEVICE
-    constexpr static void multiIndex(const int linearIndex, int &i0, int &i1)
-    {
+    constexpr static void multiIndex(const int linearIndex, int &i0, int &i1) {
       i1 = ((linearIndex * 22) >> 6);
       // i1 = a/3;
 
@@ -253,15 +235,11 @@ class LagrangeBasis2
      * point.
      */
     PROXY_HOST_DEVICE
-    static void value(double const (&coords)[2], double (&N)[numSupportPoints])
-    {
-      for (int a = 0; a < 3; ++a)
-      {
-        for (int b = 0; b < 3; ++b)
-        {
+    static void value(double const (&coords)[2], double (&N)[numSupportPoints]) {
+      for (int a = 0; a < 3; ++a) {
+        for (int b = 0; b < 3; ++b) {
           const int lindex = LagrangeBasis2::TensorProduct2D::linearIndex(a, b);
-          N[lindex] = LagrangeBasis2::value(a, coords[0]) *
-                      LagrangeBasis2::value(b, coords[1]);
+          N[lindex] = LagrangeBasis2::value(a, coords[0]) * LagrangeBasis2::value(b, coords[1]);
         }
       }
     }
@@ -304,8 +282,7 @@ class LagrangeBasis2
    *                                                                 |____________________|
    *
    */
-  struct TensorProduct3D
-  {
+  struct TensorProduct3D {
     /// The number of support points in the basis.
     constexpr static int numSupportPoints = 27;
 
@@ -317,10 +294,7 @@ class LagrangeBasis2
      * @param k The index in the xi2 direction (0,1)
      * @return The linear index of the support/quadrature point (0-26)
      */
-    constexpr static int linearIndex(const int i, const int j, const int k)
-    {
-      return i + 3 * j + 9 * k;
-    }
+    constexpr static int linearIndex(const int i, const int j, const int k) { return i + 3 * j + 9 * k; }
 
     /**
      * @brief Calculate the Cartesian/TensorProduct index given the linear index
@@ -330,9 +304,7 @@ class LagrangeBasis2
      * @param i1 The Cartesian index of the support point in the xi1 direction.
      * @param i2 The Cartesian index of the support point in the xi2 direction.
      */
-    constexpr static void multiIndex(const int linearIndex, int &i0, int &i1,
-                                     int &i2)
-    {
+    constexpr static void multiIndex(const int linearIndex, int &i0, int &i1, int &i2) {
       i2 = (linearIndex * 29) >> 8;
       // i2 = a/9;
 
@@ -352,18 +324,12 @@ class LagrangeBasis2
      * point.
      */
     PROXY_HOST_DEVICE
-    static void value(const double (&coords)[3], double (&N)[numSupportPoints])
-    {
-      for (int a = 0; a < 3; ++a)
-      {
-        for (int b = 0; b < 3; ++b)
-        {
-          for (int c = 0; c < 3; ++c)
-          {
-            const int lindex =
-                LagrangeBasis2::TensorProduct3D::linearIndex(a, b, c);
-            N[lindex] = LagrangeBasis2::value(a, coords[0]) *
-                        LagrangeBasis2::value(b, coords[1]) *
+    static void value(const double (&coords)[3], double (&N)[numSupportPoints]) {
+      for (int a = 0; a < 3; ++a) {
+        for (int b = 0; b < 3; ++b) {
+          for (int c = 0; c < 3; ++c) {
+            const int lindex = LagrangeBasis2::TensorProduct3D::linearIndex(a, b, c);
+            N[lindex] = LagrangeBasis2::value(a, coords[0]) * LagrangeBasis2::value(b, coords[1]) *
                         LagrangeBasis2::value(c, coords[2]);
           }
         }

--- a/src/discretization/fe/makutu/include/LagrangeBasis3GL.h
+++ b/src/discretization/fe/makutu/include/LagrangeBasis3GL.h
@@ -14,8 +14,7 @@
  *  Coordinate:   -1    -1/sqrt(5) 1/sqrt(5)    1
  *
  */
-class LagrangeBasis3GL
-{
+class LagrangeBasis3GL {
  public:
   /// The number of support points for the basis
   constexpr static int numSupportPoints = 4;
@@ -28,10 +27,8 @@ class LagrangeBasis3GL
    * @param q The index of the support point
    * @return The value of the weight
    */
-  inline constexpr static double weight(const int q)
-  {
-    switch (q)
-    {
+  inline constexpr static double weight(const int q) {
+    switch (q) {
       case 1:
       case 2:
         return 5.0 / 6.0;
@@ -51,12 +48,10 @@ class LagrangeBasis3GL
       // one depending on the supportPointIndex value
       // Switch case
       constexpr static double
-      parentSupportCoord(const int supportPointIndex)
-  {
+      parentSupportCoord(const int supportPointIndex) {
     double result = 0.0;
 
-    switch (supportPointIndex)
-    {
+    switch (supportPointIndex) {
       case 0:
         result = -1.0;
         break;
@@ -87,12 +82,10 @@ class LagrangeBasis3GL
       // MODIF3 : Change the  way to return the base function evaluated at the
       // desired coord
       constexpr static double
-      value(const int index, const double xi)
-  {
+      value(const int index, const double xi) {
     double result = 0.0;
 
-    switch (index)
-    {
+    switch (index) {
       case 0:
         result = LagrangeBasis3GL::value0(xi);
         break;
@@ -120,10 +113,8 @@ class LagrangeBasis3GL
   inline
       // MODFI4 : Implemented new base functions and their derivative for Q3
       constexpr static double
-      value0(const double xi)
-  {
-    return -(5.0 / 8.0) *
-           (xi * xi * xi - xi * xi - (1.0 / 5.0) * xi + 1.0 / 5.0);
+      value0(const double xi) {
+    return -(5.0 / 8.0) * (xi * xi * xi - xi * xi - (1.0 / 5.0) * xi + 1.0 / 5.0);
   }
 
   /**
@@ -131,10 +122,8 @@ class LagrangeBasis3GL
    * @param xi The coordinate at which to evaluate the basis.
    * @return The value of the basis.
    */
-  inline constexpr static double value1(const double xi)
-  {
-    return (5.0 * sqrt5 / 8.0) *
-           (xi * xi * xi - (1.0 / sqrt5) * xi * xi - xi + 1.0 / sqrt5);
+  inline constexpr static double value1(const double xi) {
+    return (5.0 * sqrt5 / 8.0) * (xi * xi * xi - (1.0 / sqrt5) * xi * xi - xi + 1.0 / sqrt5);
   }
 
   /**
@@ -142,10 +131,8 @@ class LagrangeBasis3GL
    * @param xi The coordinate at which to evaluate the basis.
    * @return The value of the basis.
    */
-  inline constexpr static double value2(const double xi)
-  {
-    return -(5.0 * sqrt5 / 8.0) *
-           (xi * xi * xi + (1.0 / sqrt5) * xi * xi - xi - 1.0 / sqrt5);
+  inline constexpr static double value2(const double xi) {
+    return -(5.0 * sqrt5 / 8.0) * (xi * xi * xi + (1.0 / sqrt5) * xi * xi - xi - 1.0 / sqrt5);
   }
 
   /**
@@ -153,10 +140,8 @@ class LagrangeBasis3GL
    * @param xi The coordinate at which to evaluate the basis.
    * @return The value of the basis.
    */
-  inline constexpr static double value3(const double xi)
-  {
-    return (5.0 / 8.0) *
-           (xi * xi * xi + xi * xi - (1.0 / 5.0) * xi - 1.0 / 5.0);
+  inline constexpr static double value3(const double xi) {
+    return (5.0 / 8.0) * (xi * xi * xi + xi * xi - (1.0 / 5.0) * xi - 1.0 / 5.0);
   }
 
   /**
@@ -170,12 +155,10 @@ class LagrangeBasis3GL
       // MODIF5 : New function returning the derivated base function at desired
       // coord
       constexpr static double
-      gradient(const int index, const double xi)
-  {
+      gradient(const int index, const double xi) {
     double result = 0.0;
 
-    switch (index)
-    {
+    switch (index) {
       case 0:
         result = LagrangeBasis3GL::gradient0(xi);
         break;
@@ -201,8 +184,7 @@ class LagrangeBasis3GL
    * @param xi The coordinate at which to evaluate the gradient.
    * @return The gradient of basis function
    */
-  inline constexpr static double gradient0(const double xi)
-  {
+  inline constexpr static double gradient0(const double xi) {
     return -(5.0 / 8.0) * (3.0 * xi * xi - 2.0 * xi - (1.0 / 5.0));
   }
 
@@ -212,8 +194,7 @@ class LagrangeBasis3GL
    * @param xi The coordinate at which to evaluate the gradient.
    * @return The gradient of basis function
    */
-  inline constexpr static double gradient1(const double xi)
-  {
+  inline constexpr static double gradient1(const double xi) {
     return (5.0 * sqrt5 / 8.0) * (3.0 * xi * xi - (2.0 / sqrt5) * xi - 1.0);
   }
 
@@ -223,8 +204,7 @@ class LagrangeBasis3GL
    * @param xi The coordinate at which to evaluate the gradient.
    * @return The gradient of basis function
    */
-  inline constexpr static double gradient2(const double xi)
-  {
+  inline constexpr static double gradient2(const double xi) {
     return -(5.0 * sqrt5 / 8.0) * (3.0 * xi * xi + (2.0 / sqrt5) * xi - 1.0);
   }
 
@@ -234,8 +214,7 @@ class LagrangeBasis3GL
    * @param xi The coordinate at which to evaluate the gradient.
    * @return The gradient of basis function
    */
-  inline constexpr static double gradient3(const double xi)
-  {
+  inline constexpr static double gradient3(const double xi) {
     return (5.0 / 8.0) * (3.0 * xi * xi + 2.0 * xi - (1.0 / 5.0));
     ;
   }
@@ -247,10 +226,8 @@ class LagrangeBasis3GL
    * @param p The index of the support point
    * @return The gradient of basis function.
    */
-  constexpr static double gradientAt(const int q, const int p)
-  {
-    switch (q)
-    {
+  constexpr static double gradientAt(const int q, const int p) {
+    switch (q) {
       case 0:
         return p == 0 ? -3.0 : -0.80901699437494742410;
       case 1:
@@ -289,8 +266,7 @@ class LagrangeBasis3GL
    *                                                                 |_____________________________|
    *
    */
-  struct TensorProduct2D
-  {
+  struct TensorProduct2D {
     /// The number of support points in the 2D tensor product
     constexpr static int numSupportPoints = 16;
 
@@ -301,10 +277,7 @@ class LagrangeBasis3GL
      * @param j The index in the xi1 direction (0,1)
      * @return The linear index of the support/quadrature point (0-15)
      */
-    inline constexpr static int linearIndex(const int i, const int j)
-    {
-      return i + 4 * j;
-    }
+    inline constexpr static int linearIndex(const int i, const int j) { return i + 4 * j; }
 
     /**
      * @brief Calculate the Cartesian/TensorProduct index given the linear index
@@ -313,9 +286,7 @@ class LagrangeBasis3GL
      * @param i0 The Cartesian index of the support point in the xi0 direction.
      * @param i1 The Cartesian index of the support point in the xi1 direction.
      */
-    inline constexpr static void multiIndex(int const linearIndex, int &i0,
-                                            int &i1)
-    {
+    inline constexpr static void multiIndex(int const linearIndex, int &i0, int &i1) {
       i1 = linearIndex / 4;
 
       i0 = linearIndex % 4;
@@ -330,17 +301,11 @@ class LagrangeBasis3GL
      * @param N Array to hold the value of the basis functions at each support
      * point.
      */
-    inline static void value(const double (&coords)[2],
-                             double (&N)[numSupportPoints])
-    {
-      for (int a = 0; a < 4; ++a)
-      {
-        for (int b = 0; b < 4; ++b)
-        {
-          const int lindex =
-              LagrangeBasis3GL::TensorProduct2D::linearIndex(a, b);
-          N[lindex] = LagrangeBasis3GL::value(a, coords[0]) *
-                      LagrangeBasis3GL::value(b, coords[1]);
+    inline static void value(const double (&coords)[2], double (&N)[numSupportPoints]) {
+      for (int a = 0; a < 4; ++a) {
+        for (int b = 0; b < 4; ++b) {
+          const int lindex = LagrangeBasis3GL::TensorProduct2D::linearIndex(a, b);
+          N[lindex] = LagrangeBasis3GL::value(a, coords[0]) * LagrangeBasis3GL::value(b, coords[1]);
         }
       }
     }
@@ -382,8 +347,7 @@ class LagrangeBasis3GL
    *                                                                 |_____________________________________|
    *
    */
-  struct TensorProduct3D
-  {
+  struct TensorProduct3D {
     /// The number of support points in the 3D tensor product
     constexpr static int numSupportPoints = 64;
 
@@ -398,8 +362,7 @@ class LagrangeBasis3GL
     inline
         // MODIF6 : Change linearIndex for 64 nodes
         constexpr static int
-        linearIndex(const int i, const int j, const int k)
-    {
+        linearIndex(const int i, const int j, const int k) {
       return i + 4 * j + 16 * k;
     }
 
@@ -414,8 +377,7 @@ class LagrangeBasis3GL
     inline
         // MODIF7 : Change calcul of multiIndex
         constexpr static void
-        multiIndex(int const linearIndex, int &i0, int &i1, int &i2)
-    {
+        multiIndex(int const linearIndex, int &i0, int &i1, int &i2) {
       i2 = linearIndex / 16;
 
       i1 = (linearIndex % 16) / 4;
@@ -433,18 +395,12 @@ class LagrangeBasis3GL
      * point.
      */
     PROXY_HOST_DEVICE
-    static void value(const double (&coords)[3], double (&N)[numSupportPoints])
-    {
-      for (int a = 0; a < 4; ++a)
-      {
-        for (int b = 0; b < 4; ++b)
-        {
-          for (int c = 0; c < 4; ++c)
-          {
-            const int lindex =
-                LagrangeBasis3GL::TensorProduct3D::linearIndex(a, b, c);
-            N[lindex] = LagrangeBasis3GL::value(a, coords[0]) *
-                        LagrangeBasis3GL::value(b, coords[1]) *
+    static void value(const double (&coords)[3], double (&N)[numSupportPoints]) {
+      for (int a = 0; a < 4; ++a) {
+        for (int b = 0; b < 4; ++b) {
+          for (int c = 0; c < 4; ++c) {
+            const int lindex = LagrangeBasis3GL::TensorProduct3D::linearIndex(a, b, c);
+            N[lindex] = LagrangeBasis3GL::value(a, coords[0]) * LagrangeBasis3GL::value(b, coords[1]) *
                         LagrangeBasis3GL::value(c, coords[2]);
           }
         }

--- a/src/discretization/fe/makutu/include/LagrangeBasis4GL.h
+++ b/src/discretization/fe/makutu/include/LagrangeBasis4GL.h
@@ -14,8 +14,7 @@
  *  Coordinate:   -1 -sqrt(3/7)  0  sqrt(3/7)  1
  *
  */
-class LagrangeBasis4GL
-{
+class LagrangeBasis4GL {
  public:
   /// The number of support points for the basis
   constexpr static int numSupportPoints = 5;
@@ -28,10 +27,8 @@ class LagrangeBasis4GL
    * @param q The index of the support point
    * @return The value of the weight
    */
-  constexpr static double weight(const int q)
-  {
-    switch (q)
-    {
+  constexpr static double weight(const int q) {
+    switch (q) {
       case 0:
       case 4:
         return 1.0 / 10.0;
@@ -51,12 +48,10 @@ class LagrangeBasis4GL
    */
   // depending on the supportPointIndex value
   // Switch case
-  constexpr static double parentSupportCoord(const int supportPointIndex)
-  {
+  constexpr static double parentSupportCoord(const int supportPointIndex) {
     double result = 0.0;
 
-    switch (supportPointIndex)
-    {
+    switch (supportPointIndex) {
       case 0:
         result = -1.0;
         break;
@@ -86,12 +81,10 @@ class LagrangeBasis4GL
    * @param xi The coordinate at which to evaluate the basis.
    * @return The value of basis function.
    */
-  constexpr static double value(const int index, const double xi)
-  {
+  constexpr static double value(const int index, const double xi) {
     double result = 0.0;
 
-    switch (index)
-    {
+    switch (index) {
       case 0:
         result = LagrangeBasis4GL::value0(xi);
         break;
@@ -120,28 +113,21 @@ class LagrangeBasis4GL
    * @return The value of the basis.
    */
   // MODFI4 : Implemented new base functions and their derivative for Q3
-  constexpr static double value0(const double xi)
-  {
-    return (1.0 / 8.0) * (-1.0 + xi) * xi * (-3.0 + 7.0 * xi * xi);
-  }
+  constexpr static double value0(const double xi) { return (1.0 / 8.0) * (-1.0 + xi) * xi * (-3.0 + 7.0 * xi * xi); }
 
   /**
    * @brief The value of the basis function for support point 1.
    * @param xi The coordinate at which to evaluate the basis.
    * @return The value of the basis.
    */
-  constexpr static double value1(const double xi)
-  {
-    return (49.0 / 24.0) * (sqrt3_7 - xi) * xi * (-1.0 + xi * xi);
-  }
+  constexpr static double value1(const double xi) { return (49.0 / 24.0) * (sqrt3_7 - xi) * xi * (-1.0 + xi * xi); }
 
   /**
    * @brief The value of the basis function for support point 2.
    * @param xi The coordinate at which to evaluate the basis.
    * @return The value of the basis.
    */
-  constexpr static double value2(const double xi)
-  {
+  constexpr static double value2(const double xi) {
     return (1.0 / 3.0) * (3.0 - 10.0 * xi * xi + 7.0 * xi * xi * xi * xi);
   }
 
@@ -150,20 +136,14 @@ class LagrangeBasis4GL
    * @param xi The coordinate at which to evaluate the basis.
    * @return The value of the basis.
    */
-  constexpr static double value3(const double xi)
-  {
-    return -(49.0 / 24.0) * (sqrt3_7 + xi) * xi * (-1.0 + xi * xi);
-  }
+  constexpr static double value3(const double xi) { return -(49.0 / 24.0) * (sqrt3_7 + xi) * xi * (-1.0 + xi * xi); }
 
   /**
    * @brief The value of the basis function for support point 4.
    * @param xi The coordinate at which to evaluate the basis.
    * @return The value of the basis.
    */
-  constexpr static double value4(const double xi)
-  {
-    return (1.0 / 8.0) * (1.0 + xi) * xi * (-3.0 + 7.0 * xi * xi);
-  }
+  constexpr static double value4(const double xi) { return (1.0 / 8.0) * (1.0 + xi) * xi * (-3.0 + 7.0 * xi * xi); }
 
   /**
    * @brief The gradient of the basis function for a support point evaluated at
@@ -172,12 +152,10 @@ class LagrangeBasis4GL
    * @param xi The coordinate at which to evaluate the basis.
    * @return The value of basis function.
    */
-  constexpr static double gradient(const int index, const double xi)
-  {
+  constexpr static double gradient(const int index, const double xi) {
     double result = 0.0;
 
-    switch (index)
-    {
+    switch (index) {
       case 0:
         result = LagrangeBasis4GL::gradient0(xi);
         break;
@@ -206,8 +184,7 @@ class LagrangeBasis4GL
    * @param xi The coordinate at which to evaluate the gradient.
    * @return The gradient of basis function
    */
-  constexpr static double gradient0(const double xi)
-  {
+  constexpr static double gradient0(const double xi) {
     return (1.0 / 8.0) * (3.0 + xi * (-6.0 + 7.0 * xi * (-3.0 + 4.0 * xi)));
   }
 
@@ -217,10 +194,8 @@ class LagrangeBasis4GL
    * @param xi The coordinate at which to evaluate the gradient.
    * @return The gradient of basis function
    */
-  constexpr static double gradient1(const double xi)
-  {
-    return (49.0 / 24.0) *
-           (-sqrt3_7 + xi * (2.0 + 3.0 * sqrt3_7 * xi - 4.0 * xi * xi));
+  constexpr static double gradient1(const double xi) {
+    return (49.0 / 24.0) * (-sqrt3_7 + xi * (2.0 + 3.0 * sqrt3_7 * xi - 4.0 * xi * xi));
   }
 
   /**
@@ -229,10 +204,7 @@ class LagrangeBasis4GL
    * @param xi The coordinate at which to evaluate the gradient.
    * @return The gradient of basis function
    */
-  constexpr static double gradient2(const double xi)
-  {
-    return (4.0 / 3.0) * xi * (-5.0 + 7.0 * xi * xi);
-  }
+  constexpr static double gradient2(const double xi) { return (4.0 / 3.0) * xi * (-5.0 + 7.0 * xi * xi); }
 
   /**
    * @brief The gradient of the basis function for support point 3 evaluated at
@@ -240,10 +212,8 @@ class LagrangeBasis4GL
    * @param xi The coordinate at which to evaluate the gradient.
    * @return The gradient of basis function
    */
-  constexpr static double gradient3(const double xi)
-  {
-    return (49.0 / 24.0) *
-           (sqrt3_7 + xi * (2.0 - 3.0 * sqrt3_7 * xi - 4.0 * xi * xi));
+  constexpr static double gradient3(const double xi) {
+    return (49.0 / 24.0) * (sqrt3_7 + xi * (2.0 - 3.0 * sqrt3_7 * xi - 4.0 * xi * xi));
   }
 
   /**
@@ -252,8 +222,7 @@ class LagrangeBasis4GL
    * @param xi The coordinate at which to evaluate the gradient.
    * @return The gradient of basis function
    */
-  constexpr static double gradient4(const double xi)
-  {
+  constexpr static double gradient4(const double xi) {
     return (1.0 / 8.0) * (-3.0 + xi * (-6.0 + 7.0 * xi * (3.0 + 4.0 * xi)));
   }
 
@@ -264,13 +233,10 @@ class LagrangeBasis4GL
    * @param p The index of the support point
    * @return The gradient of basis function.
    */
-  constexpr static double gradientAt(const int q, const int p)
-  {
-    switch (q)
-    {
+  constexpr static double gradientAt(const int q, const int p) {
+    switch (q) {
       case 0:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return -5.0000000000000000000;
           case 1:
@@ -280,8 +246,7 @@ class LagrangeBasis4GL
         }
         break;
       case 1:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return 6.7565024887242400038;
           case 1:
@@ -291,8 +256,7 @@ class LagrangeBasis4GL
         }
         break;
       case 2:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return -2.6666666666666666667;
           case 1:
@@ -302,8 +266,7 @@ class LagrangeBasis4GL
         }
         break;
       case 3:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return 1.4101641779424266628;
           case 1:
@@ -313,8 +276,7 @@ class LagrangeBasis4GL
         }
         break;
       case 4:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return -0.50000000000000000000;
           case 1:
@@ -352,8 +314,7 @@ class LagrangeBasis4GL
    *                                                                   |_____________________________|
    *
    */
-  struct TensorProduct2D
-  {
+  struct TensorProduct2D {
     /// The number of support points in the 2D tensor product
     constexpr static int numSupportPoints = 25;
 
@@ -364,10 +325,7 @@ class LagrangeBasis4GL
      * @param j The index in the xi1 direction (0,1)
      * @return The linear index of the support/quadrature point (0-15)
      */
-    constexpr static int linearIndex(const int i, const int j)
-    {
-      return i + 5 * j;
-    }
+    constexpr static int linearIndex(const int i, const int j) { return i + 5 * j; }
 
     /**
      * @brief Calculate the Cartesian/TensorProduct index given the linear index
@@ -376,8 +334,7 @@ class LagrangeBasis4GL
      * @param i0 The Cartesian index of the support point in the xi0 direction.
      * @param i1 The Cartesian index of the support point in the xi1 direction.
      */
-    constexpr static void multiIndex(int const linearIndex, int& i0, int& i1)
-    {
+    constexpr static void multiIndex(int const linearIndex, int& i0, int& i1) {
       i1 = linearIndex / 5;
 
       i0 = linearIndex % 5;
@@ -392,16 +349,11 @@ class LagrangeBasis4GL
      * @param N Array to hold the value of the basis functions at each support
      * point.
      */
-    static void value(const double (&coords)[2], double (&N)[numSupportPoints])
-    {
-      for (int a = 0; a < 5; ++a)
-      {
-        for (int b = 0; b < 5; ++b)
-        {
-          const int lindex =
-              LagrangeBasis4GL::TensorProduct2D::linearIndex(a, b);
-          N[lindex] = LagrangeBasis4GL::value(a, coords[0]) *
-                      LagrangeBasis4GL::value(b, coords[1]);
+    static void value(const double (&coords)[2], double (&N)[numSupportPoints]) {
+      for (int a = 0; a < 5; ++a) {
+        for (int b = 0; b < 5; ++b) {
+          const int lindex = LagrangeBasis4GL::TensorProduct2D::linearIndex(a, b);
+          N[lindex] = LagrangeBasis4GL::value(a, coords[0]) * LagrangeBasis4GL::value(b, coords[1]);
         }
       }
     }
@@ -447,8 +399,7 @@ class LagrangeBasis4GL
    *
    *
    */
-  struct TensorProduct3D
-  {
+  struct TensorProduct3D {
     /// The number of support points in the 3D tensor product
     constexpr static int numSupportPoints = 125;
 
@@ -460,10 +411,7 @@ class LagrangeBasis4GL
      * @param k The index in the xi2 direction (0,1)
      * @return The linear index of the support/quadrature point (0-124)
      */
-    constexpr static int linearIndex(const int i, const int j, const int k)
-    {
-      return i + 5 * j + 25 * k;
-    }
+    constexpr static int linearIndex(const int i, const int j, const int k) { return i + 5 * j + 25 * k; }
 
     /**
      * @brief Calculate the Cartesian/TensorProduct index given the linear index
@@ -473,9 +421,7 @@ class LagrangeBasis4GL
      * @param i1 The Cartesian index of the support point in the xi1 direction.
      * @param i2 The Cartesian index of the support point in the xi2 direction.
      */
-    constexpr static void multiIndex(int const linearIndex, int& i0, int& i1,
-                                     int& i2)
-    {
+    constexpr static void multiIndex(int const linearIndex, int& i0, int& i1, int& i2) {
       i2 = linearIndex / 25;
 
       i1 = (linearIndex % 25) / 5;
@@ -492,18 +438,12 @@ class LagrangeBasis4GL
      * @param N Array to hold the value of the basis functions at each support
      * point.
      */
-    static void value(const double (&coords)[3], double (&N)[numSupportPoints])
-    {
-      for (int a = 0; a < 5; ++a)
-      {
-        for (int b = 0; b < 5; ++b)
-        {
-          for (int c = 0; c < 5; ++c)
-          {
-            const int lindex =
-                LagrangeBasis4GL::TensorProduct3D::linearIndex(a, b, c);
-            N[lindex] = LagrangeBasis4GL::value(a, coords[0]) *
-                        LagrangeBasis4GL::value(b, coords[1]) *
+    static void value(const double (&coords)[3], double (&N)[numSupportPoints]) {
+      for (int a = 0; a < 5; ++a) {
+        for (int b = 0; b < 5; ++b) {
+          for (int c = 0; c < 5; ++c) {
+            const int lindex = LagrangeBasis4GL::TensorProduct3D::linearIndex(a, b, c);
+            N[lindex] = LagrangeBasis4GL::value(a, coords[0]) * LagrangeBasis4GL::value(b, coords[1]) *
                         LagrangeBasis4GL::value(c, coords[2]);
           }
         }

--- a/src/discretization/fe/makutu/include/LagrangeBasis5GL.h
+++ b/src/discretization/fe/makutu/include/LagrangeBasis5GL.h
@@ -15,8 +15,7 @@
  * sqrt(1/21(7-2*sqrt(7)))  sqrt(1/21(7-2*sqrt(7)))     1
  *
  */
-class LagrangeBasis5GL
-{
+class LagrangeBasis5GL {
  public:
   /// The number of support points for the basis
   constexpr static int numSupportPoints = 6;
@@ -44,10 +43,8 @@ class LagrangeBasis5GL
    * @param q The index of the support point
    * @return The value of the weight
    */
-  constexpr static double weight(const int q)
-  {
-    switch (q)
-    {
+  constexpr static double weight(const int q) {
+    switch (q) {
       case 1:
       case 4:
         return (1.0 / 30.0) * (14.0 - sqrt_7_);
@@ -65,12 +62,10 @@ class LagrangeBasis5GL
    * @param supportPointIndex The linear index of support point
    * @return parent coordinate in the xi0 direction.
    */
-  constexpr static double parentSupportCoord(const int supportPointIndex)
-  {
+  constexpr static double parentSupportCoord(const int supportPointIndex) {
     double result = 0.0;
 
-    switch (supportPointIndex)
-    {
+    switch (supportPointIndex) {
       case 0:
         result = -1.0;
         break;
@@ -109,12 +104,10 @@ class LagrangeBasis5GL
    * @param xi The coordinate at which to evaluate the basis.
    * @return The value of basis function.
    */
-  constexpr static double value(const int index, const double xi)
-  {
+  constexpr static double value(const int index, const double xi) {
     double result = 0.0;
 
-    switch (index)
-    {
+    switch (index) {
       case 0:
         return result = LagrangeBasis5GL::value0(xi);
         break;
@@ -151,8 +144,7 @@ class LagrangeBasis5GL
    * @param xi The coordinate at which to evaluate the basis.
    * @return The value of the basis.
    */
-  constexpr static double value0(const double xi)
-  {
+  constexpr static double value0(const double xi) {
     /* Define the two GL points needed to compute the basis function at point
        index 0. Here we need the points at index 3,4 called lambda3, lambda4. */
 
@@ -160,10 +152,8 @@ class LagrangeBasis5GL
     double lambda3 = LagrangeBasis5GL::parentSupportCoord(3);
 
     return (-21.0 / 16.0) *
-           (xi * xi * xi * xi * xi - xi * xi * xi * xi -
-            (lambda3 * lambda3 + lambda4 * lambda4) * xi * xi * xi +
-            (lambda3 * lambda3 + lambda4 * lambda4) * xi * xi +
-            lambda3 * lambda3 * lambda4 * lambda4 * xi -
+           (xi * xi * xi * xi * xi - xi * xi * xi * xi - (lambda3 * lambda3 + lambda4 * lambda4) * xi * xi * xi +
+            (lambda3 * lambda3 + lambda4 * lambda4) * xi * xi + lambda3 * lambda3 * lambda4 * lambda4 * xi -
             lambda3 * lambda3 * lambda4 * lambda4);
   }
 
@@ -172,8 +162,7 @@ class LagrangeBasis5GL
    * @param xi The coordinate at which to evaluate the basis.
    * @return The value of the basis.
    */
-  constexpr static double value1(const double xi)
-  {
+  constexpr static double value1(const double xi) {
     /* Define the two GL points needed to compute the basis function at point
        index 1. Here we need the points at index 3 and 4 called lambda3,
        lambda4. */
@@ -182,10 +171,8 @@ class LagrangeBasis5GL
     double lambda4 = LagrangeBasis5GL::parentSupportCoord(4);
 
     return ((21.0 / 16.0) * sqrt__7_mins_sqrt7_div2__) *
-           (xi * xi * xi * xi * xi - lambda4 * xi * xi * xi * xi -
-            (lambda3 * lambda3 + 1) * xi * xi * xi +
-            lambda4 * (lambda3 * lambda3 + 1) * xi * xi +
-            lambda3 * lambda3 * xi - lambda4 * lambda3 * lambda3);
+           (xi * xi * xi * xi * xi - lambda4 * xi * xi * xi * xi - (lambda3 * lambda3 + 1) * xi * xi * xi +
+            lambda4 * (lambda3 * lambda3 + 1) * xi * xi + lambda3 * lambda3 * xi - lambda4 * lambda3 * lambda3);
   }
 
   /**
@@ -193,8 +180,7 @@ class LagrangeBasis5GL
    * @param xi The coordinate at which to evaluate the basis.
    * @return The value of the basis.
    */
-  constexpr static double value2(const double xi)
-  {
+  constexpr static double value2(const double xi) {
     /* Define the two GL points needed to compute the basis function at point
        index 2. Here we need the points at index 3 and 4 called lambda3,
        lambda4. */
@@ -203,10 +189,8 @@ class LagrangeBasis5GL
     double lambda3 = LagrangeBasis5GL::parentSupportCoord(3);
 
     return ((-21.0 / 16.0) * sqrt__7_plus_sqrt7_div2__) *
-           (xi * xi * xi * xi * xi - lambda3 * xi * xi * xi * xi -
-            (lambda4 * lambda4 + 1) * xi * xi * xi +
-            lambda3 * (lambda4 * lambda4 + 1) * xi * xi +
-            lambda4 * lambda4 * xi - lambda3 * lambda4 * lambda4);
+           (xi * xi * xi * xi * xi - lambda3 * xi * xi * xi * xi - (lambda4 * lambda4 + 1) * xi * xi * xi +
+            lambda3 * (lambda4 * lambda4 + 1) * xi * xi + lambda4 * lambda4 * xi - lambda3 * lambda4 * lambda4);
   }
 
   /**
@@ -214,8 +198,7 @@ class LagrangeBasis5GL
    * @param xi The coordinate at which to evaluate the basis.
    * @return The value of the basis.
    */
-  constexpr static double value3(const double xi)
-  {
+  constexpr static double value3(const double xi) {
     /* Define the two GL points needed to compute the basis function at point
        index 3. Here we need the points at index 3 and 4 called lambda1,
        lambda2. */
@@ -224,10 +207,8 @@ class LagrangeBasis5GL
     double lambda3 = LagrangeBasis5GL::parentSupportCoord(3);
 
     return ((21.0 / 16.0) * sqrt__7_plus_sqrt7_div2__) *
-           (xi * xi * xi * xi * xi + lambda3 * xi * xi * xi * xi -
-            (lambda4 * lambda4 + 1) * xi * xi * xi -
-            lambda3 * (lambda4 * lambda4 + 1) * xi * xi +
-            lambda4 * lambda4 * xi + lambda3 * lambda4 * lambda4);
+           (xi * xi * xi * xi * xi + lambda3 * xi * xi * xi * xi - (lambda4 * lambda4 + 1) * xi * xi * xi -
+            lambda3 * (lambda4 * lambda4 + 1) * xi * xi + lambda4 * lambda4 * xi + lambda3 * lambda4 * lambda4);
   }
 
   /**
@@ -235,8 +216,7 @@ class LagrangeBasis5GL
    * @param xi The coordinate at which to evaluate the basis.
    * @return The value of the basis.
    */
-  constexpr static double value4(const double xi)
-  {
+  constexpr static double value4(const double xi) {
     /* Define the two GL points needed to compute the basis function at point
        index 4. Here we need the points at index 3 and 4 called lambda3,
        lambda4. */
@@ -245,10 +225,8 @@ class LagrangeBasis5GL
     double lambda3 = LagrangeBasis5GL::parentSupportCoord(3);
 
     return ((-21.0 / 16.0) * sqrt__7_mins_sqrt7_div2__) *
-           (xi * xi * xi * xi * xi + lambda4 * xi * xi * xi * xi -
-            (lambda3 * lambda3 + 1) * xi * xi * xi -
-            lambda4 * (lambda3 * lambda3 + 1) * xi * xi +
-            lambda3 * lambda3 * xi + lambda4 * lambda3 * lambda3);
+           (xi * xi * xi * xi * xi + lambda4 * xi * xi * xi * xi - (lambda3 * lambda3 + 1) * xi * xi * xi -
+            lambda4 * (lambda3 * lambda3 + 1) * xi * xi + lambda3 * lambda3 * xi + lambda4 * lambda3 * lambda3);
   }
 
   /**
@@ -256,8 +234,7 @@ class LagrangeBasis5GL
    * @param xi The coordinate at which to evaluate the basis.
    * @return The value of the basis.
    */
-  constexpr static double value5(const double xi)
-  {
+  constexpr static double value5(const double xi) {
     /* Define the two GL points needed to compute the basis function at point
        index 5. Here we need the points at index 3 and 4 called lambda3,
        lambda4. */
@@ -266,10 +243,8 @@ class LagrangeBasis5GL
     double lambda4 = LagrangeBasis5GL::parentSupportCoord(4);
 
     return (21.0 / 16.0) *
-           (xi * xi * xi * xi * xi + xi * xi * xi * xi -
-            (lambda4 * lambda4 + lambda3 * lambda3) * xi * xi * xi -
-            (lambda3 * lambda3 + lambda4 * lambda4) * xi * xi +
-            lambda3 * lambda3 * lambda4 * lambda4 * xi +
+           (xi * xi * xi * xi * xi + xi * xi * xi * xi - (lambda4 * lambda4 + lambda3 * lambda3) * xi * xi * xi -
+            (lambda3 * lambda3 + lambda4 * lambda4) * xi * xi + lambda3 * lambda3 * lambda4 * lambda4 * xi +
             lambda4 * lambda4 * lambda3 * lambda3);
   }
 
@@ -281,12 +256,10 @@ class LagrangeBasis5GL
    * @param xi The coordinate at which to evaluate the gradient.
    * @return The gradient of basis function.
    */
-  constexpr static double gradient(const int index, const double xi)
-  {
+  constexpr static double gradient(const int index, const double xi) {
     double result = 0.0;
 
-    switch (index)
-    {
+    switch (index) {
       case 0:
         result = LagrangeBasis5GL::gradient0(xi);
         break;
@@ -324,16 +297,13 @@ class LagrangeBasis5GL
    * @param xi The coordinate at which to evaluate the gradient.
    * @return The gradient of basis function at point 0.
    */
-  constexpr static double gradient0(const double xi)
-  {
+  constexpr static double gradient0(const double xi) {
     double lambda4 = LagrangeBasis5GL::parentSupportCoord(4);
     double lambda3 = LagrangeBasis5GL::parentSupportCoord(3);
 
     return (-21.0 / 16.0) *
-           (5.0 * xi * xi * xi * xi - 4.0 * xi * xi * xi -
-            3.0 * (lambda3 * lambda3 + lambda4 * lambda4) * xi * xi +
-            2.0 * (lambda3 * lambda3 + lambda4 * lambda4) * xi +
-            lambda3 * lambda3 * lambda4 * lambda4);
+           (5.0 * xi * xi * xi * xi - 4.0 * xi * xi * xi - 3.0 * (lambda3 * lambda3 + lambda4 * lambda4) * xi * xi +
+            2.0 * (lambda3 * lambda3 + lambda4 * lambda4) * xi + lambda3 * lambda3 * lambda4 * lambda4);
   }
 
   /**
@@ -342,14 +312,12 @@ class LagrangeBasis5GL
    * @param xi The coordinate at which to evaluate the gradient.
    * @return The gradient of basis function at point 1.
    */
-  constexpr static double gradient1(const double xi)
-  {
+  constexpr static double gradient1(const double xi) {
     double lambda3 = LagrangeBasis5GL::parentSupportCoord(3);
     double lambda4 = LagrangeBasis5GL::parentSupportCoord(4);
 
     return (21.0 / 16.0) * sqrt__7_mins_sqrt7_div2__ *
-           (5.0 * xi * xi * xi * xi - 4.0 * lambda4 * xi * xi * xi -
-            3.0 * (lambda3 * lambda3 + 1.0) * xi * xi +
+           (5.0 * xi * xi * xi * xi - 4.0 * lambda4 * xi * xi * xi - 3.0 * (lambda3 * lambda3 + 1.0) * xi * xi +
             2.0 * lambda4 * (lambda3 * lambda3 + 1.0) * xi + lambda3 * lambda3);
   }
 
@@ -359,14 +327,12 @@ class LagrangeBasis5GL
    * @param xi The coordinate at which to evaluate the gradient.
    * @return The gradient of basis function at point 2.
    */
-  constexpr static double gradient2(const double xi)
-  {
+  constexpr static double gradient2(const double xi) {
     double lambda4 = LagrangeBasis5GL::parentSupportCoord(4);
     double lambda3 = LagrangeBasis5GL::parentSupportCoord(3);
 
     return (-21.0 / 16.0) * sqrt__7_plus_sqrt7_div2__ *
-           (5.0 * xi * xi * xi * xi - 4.0 * lambda3 * xi * xi * xi -
-            3.0 * (lambda4 * lambda4 + 1.0) * xi * xi +
+           (5.0 * xi * xi * xi * xi - 4.0 * lambda3 * xi * xi * xi - 3.0 * (lambda4 * lambda4 + 1.0) * xi * xi +
             2.0 * lambda3 * (lambda4 * lambda4 + 1.0) * xi + lambda4 * lambda4);
   }
 
@@ -376,14 +342,12 @@ class LagrangeBasis5GL
    * @param xi The coordinate at which to evaluate the gradient.
    * @return The gradient of basis function at point 3.
    */
-  constexpr static double gradient3(const double xi)
-  {
+  constexpr static double gradient3(const double xi) {
     double lambda4 = LagrangeBasis5GL::parentSupportCoord(4);
     double lambda3 = LagrangeBasis5GL::parentSupportCoord(3);
 
     return (21.0 / 16.0) * sqrt__7_plus_sqrt7_div2__ *
-           (5.0 * xi * xi * xi * xi + 4.0 * lambda3 * xi * xi * xi -
-            3.0 * (lambda4 * lambda4 + 1.0) * xi * xi -
+           (5.0 * xi * xi * xi * xi + 4.0 * lambda3 * xi * xi * xi - 3.0 * (lambda4 * lambda4 + 1.0) * xi * xi -
             2 * lambda3 * (lambda4 * lambda4 + 1.0) * xi + lambda4 * lambda4);
   }
 
@@ -393,14 +357,12 @@ class LagrangeBasis5GL
    * @param xi The coordinate at which to evaluate the gradient.
    * @return The gradient of basis function at point 0.
    */
-  constexpr static double gradient4(const double xi)
-  {
+  constexpr static double gradient4(const double xi) {
     double lambda4 = LagrangeBasis5GL::parentSupportCoord(4);
     double lambda3 = LagrangeBasis5GL::parentSupportCoord(3);
 
     return (-21.0 / 16.0) * sqrt__7_mins_sqrt7_div2__ *
-           (5.0 * xi * xi * xi * xi + 4.0 * lambda4 * xi * xi * xi -
-            3.0 * (lambda3 * lambda3 + 1.0) * xi * xi -
+           (5.0 * xi * xi * xi * xi + 4.0 * lambda4 * xi * xi * xi - 3.0 * (lambda3 * lambda3 + 1.0) * xi * xi -
             2.0 * lambda4 * (lambda3 * lambda3 + 1.0) * xi + lambda3 * lambda3);
   }
 
@@ -410,16 +372,13 @@ class LagrangeBasis5GL
    * @param xi The coordinate at which to evaluate the gradient.
    * @return The gradient of basis function at point 5.
    */
-  constexpr static double gradient5(const double xi)
-  {
+  constexpr static double gradient5(const double xi) {
     double lambda4 = LagrangeBasis5GL::parentSupportCoord(4);
     double lambda3 = LagrangeBasis5GL::parentSupportCoord(3);
 
     return (21.0 / 16.0) *
-           (5.0 * xi * xi * xi * xi + 4.0 * xi * xi * xi -
-            3.0 * (lambda3 * lambda3 + lambda4 * lambda4) * xi * xi -
-            2.0 * (lambda3 * lambda3 + lambda4 * lambda4) * xi +
-            lambda3 * lambda3 * lambda4 * lambda4);
+           (5.0 * xi * xi * xi * xi + 4.0 * xi * xi * xi - 3.0 * (lambda3 * lambda3 + lambda4 * lambda4) * xi * xi -
+            2.0 * (lambda3 * lambda3 + lambda4 * lambda4) * xi + lambda3 * lambda3 * lambda4 * lambda4);
   }
 
   /**
@@ -429,13 +388,10 @@ class LagrangeBasis5GL
    * @param p The index of the support point
    * @return The gradient of basis function.
    */
-  constexpr static double gradientAt(const int q, const int p)
-  {
-    switch (q)
-    {
+  constexpr static double gradientAt(const int q, const int p) {
+    switch (q) {
       case 0:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return -7.5000000000000000000;
           case 1:
@@ -445,8 +401,7 @@ class LagrangeBasis5GL
         }
         break;
       case 1:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return 10.14141593631966928023;
           case 1:
@@ -456,8 +411,7 @@ class LagrangeBasis5GL
         }
         break;
       case 2:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return -4.03618727030534800527;
           case 1:
@@ -467,8 +421,7 @@ class LagrangeBasis5GL
         }
         break;
       case 3:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return 2.2446846481761668242712;
           case 1:
@@ -478,8 +431,7 @@ class LagrangeBasis5GL
         }
         break;
       case 4:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return -1.3499133141904880992312;
           case 1:
@@ -489,8 +441,7 @@ class LagrangeBasis5GL
         }
         break;
       case 5:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return 0.500000000000000000000;
           case 1:
@@ -541,8 +492,7 @@ class LagrangeBasis5GL
    * 3        4         5                  o----- xi0
    */
 
-  struct TensorProduct2D
-  {
+  struct TensorProduct2D {
     /// The number of support points in the basis.
     constexpr static int numSupportPoints = 36;
 
@@ -553,10 +503,7 @@ class LagrangeBasis5GL
      * @param j The index in the xi1 direction (0,5)
      * @return The linear index of the support/quadrature point (0-35)
      */
-    constexpr static int linearIndex(const int i, const int j)
-    {
-      return i + 6 * j;
-    }
+    constexpr static int linearIndex(const int i, const int j) { return i + 6 * j; }
 
     /**
      * @brief Calculate the Cartesian/TensorProduct index given the linear index
@@ -565,8 +512,7 @@ class LagrangeBasis5GL
      * @param i0 The Cartesian index of the support point in the xi0 direction.
      * @param i1 The Cartesian index of the support point in the xi1 direction.
      */
-    constexpr static void multiIndex(const int linearIndex, int& i0, int& i1)
-    {
+    constexpr static void multiIndex(const int linearIndex, int& i0, int& i1) {
       i1 = linearIndex / 6;
 
       i0 = linearIndex % 6;
@@ -581,16 +527,11 @@ class LagrangeBasis5GL
      * @param N Array to hold the value of the basis functions at each support
      * point.
      */
-    static void value(const double (&coords)[2], double (&N)[numSupportPoints])
-    {
-      for (int a = 0; a < 6; ++a)
-      {
-        for (int b = 0; b < 6; ++b)
-        {
-          const int lindex =
-              LagrangeBasis5GL::TensorProduct2D::linearIndex(a, b);
-          N[lindex] = LagrangeBasis5GL::value(a, coords[0]) *
-                      LagrangeBasis5GL::value(b, coords[1]);
+    static void value(const double (&coords)[2], double (&N)[numSupportPoints]) {
+      for (int a = 0; a < 6; ++a) {
+        for (int b = 0; b < 6; ++b) {
+          const int lindex = LagrangeBasis5GL::TensorProduct2D::linearIndex(a, b);
+          N[lindex] = LagrangeBasis5GL::value(a, coords[0]) * LagrangeBasis5GL::value(b, coords[1]);
         }
       }
     }
@@ -656,8 +597,7 @@ class LagrangeBasis5GL
    * xi0
    */
 
-  struct TensorProduct3D
-  {
+  struct TensorProduct3D {
     /// The number of support points in the basis.
     constexpr static int numSupportPoints = 216;
 
@@ -669,10 +609,7 @@ class LagrangeBasis5GL
      * @param k The index in the xi2 direction (0,5)
      * @return The linear index of the support/quadrature point (0-215)
      */
-    constexpr static int linearIndex(const int i, const int j, const int k)
-    {
-      return i + 6 * j + 36 * k;
-    }
+    constexpr static int linearIndex(const int i, const int j, const int k) { return i + 6 * j + 36 * k; }
 
     /**
      * @brief Calculate the Cartesian/TensorProduct index given the linear index
@@ -682,9 +619,7 @@ class LagrangeBasis5GL
      * @param i1 The Cartesian index of the support point in the xi1 direction.
      * @param i2 The Cartesian index of the support point in the xi2 direction.
      */
-    constexpr static void multiIndex(const int linearIndex, int& i0, int& i1,
-                                     int& i2)
-    {
+    constexpr static void multiIndex(const int linearIndex, int& i0, int& i1, int& i2) {
       i2 = linearIndex / 36;
 
       i1 = (linearIndex % 36) / 6;
@@ -701,18 +636,12 @@ class LagrangeBasis5GL
      * @param N Array to hold the value of the basis functions at each support
      * point.
      */
-    static void value(const double (&coords)[3], double (&N)[numSupportPoints])
-    {
-      for (int a = 0; a < 6; ++a)
-      {
-        for (int b = 0; b < 6; ++b)
-        {
-          for (int c = 0; c < 6; ++c)
-          {
-            const int lindex =
-                LagrangeBasis5GL::TensorProduct3D::linearIndex(a, b, c);
-            N[lindex] = LagrangeBasis5GL::value(a, coords[0]) *
-                        LagrangeBasis5GL::value(b, coords[1]) *
+    static void value(const double (&coords)[3], double (&N)[numSupportPoints]) {
+      for (int a = 0; a < 6; ++a) {
+        for (int b = 0; b < 6; ++b) {
+          for (int c = 0; c < 6; ++c) {
+            const int lindex = LagrangeBasis5GL::TensorProduct3D::linearIndex(a, b, c);
+            N[lindex] = LagrangeBasis5GL::value(a, coords[0]) * LagrangeBasis5GL::value(b, coords[1]) *
                         LagrangeBasis5GL::value(c, coords[2]);
           }
         }

--- a/src/discretization/fe/makutu/include/LagrangeBasis6GL.h
+++ b/src/discretization/fe/makutu/include/LagrangeBasis6GL.h
@@ -12,8 +12,7 @@
  *   lambda1 = 0.8302238962785670
  *   lambda2 = 0.4688487934707142
  */
-class LagrangeBasis6GL
-{
+class LagrangeBasis6GL {
  public:
   constexpr static int numSupportPoints = 7;
 
@@ -26,10 +25,8 @@ class LagrangeBasis6GL
   /**
    * @brief GLL quadrature weight for node q.
    */
-  constexpr static double weight(const int q)
-  {
-    switch (q)
-    {
+  constexpr static double weight(const int q) {
+    switch (q) {
       case 1:
       case 5:
         return 0.2768260473615657;
@@ -46,10 +43,8 @@ class LagrangeBasis6GL
   /**
    * @brief Parent coordinate of support point @p supportPointIndex.
    */
-  constexpr static double parentSupportCoord(const int supportPointIndex)
-  {
-    switch (supportPointIndex)
-    {
+  constexpr static double parentSupportCoord(const int supportPointIndex) {
+    switch (supportPointIndex) {
       case 0:
         return -1.0;
       case 1:
@@ -72,10 +67,8 @@ class LagrangeBasis6GL
   /**
    * @brief Value of basis function @p index at @p xi.
    */
-  constexpr static double value(const int index, const double xi)
-  {
-    switch (index)
-    {
+  constexpr static double value(const int index, const double xi) {
+    switch (index) {
       case 0:
         return value0(xi);
       case 1:
@@ -98,87 +91,67 @@ class LagrangeBasis6GL
   /**
    * @brief Basis function for support point 0.
    */
-  constexpr static double value0(const double xi)
-  {
-    return 2.0625 * xi * xi * xi * xi * xi * xi -
-           2.0625 * xi * xi * xi * xi * xi - 1.875 * xi * xi * xi * xi +
+  constexpr static double value0(const double xi) {
+    return 2.0625 * xi * xi * xi * xi * xi * xi - 2.0625 * xi * xi * xi * xi * xi - 1.875 * xi * xi * xi * xi +
            1.875 * xi * xi * xi + 0.3125 * xi * xi - 0.3125 * xi;
   }
 
   /**
    * @brief Basis function for support point 1.
    */
-  constexpr static double value1(const double xi)
-  {
-    return -4.97286970608696 * xi * xi * xi * xi * xi * xi +
-           4.12859526307317 * xi * xi * xi * xi * xi +
-           6.06600190251835 * xi * xi * xi * xi -
-           5.03613973434199 * xi * xi * xi - 1.09313219643140 * xi * xi +
+  constexpr static double value1(const double xi) {
+    return -4.97286970608696 * xi * xi * xi * xi * xi * xi + 4.12859526307317 * xi * xi * xi * xi * xi +
+           6.06600190251835 * xi * xi * xi * xi - 5.03613973434199 * xi * xi * xi - 1.09313219643140 * xi * xi +
            0.90754447126882 * xi;
   }
 
   /**
    * @brief Basis function for support point 2.
    */
-  constexpr static double value2(const double xi)
-  {
-    return 6.21036970608696 * xi * xi * xi * xi * xi * xi -
-           2.91172434370594 * xi * xi * xi * xi * xi -
-           10.4910019025184 * xi * xi * xi * xi +
-           4.91869358429470 * xi * xi * xi + 4.28063219643140 * xi * xi -
+  constexpr static double value2(const double xi) {
+    return 6.21036970608696 * xi * xi * xi * xi * xi * xi - 2.91172434370594 * xi * xi * xi * xi * xi -
+           10.4910019025184 * xi * xi * xi * xi + 4.91869358429470 * xi * xi * xi + 4.28063219643140 * xi * xi -
            2.00696924058875 * xi;
   }
 
   /**
    * @brief Basis function for support point 3 (center node).
    */
-  constexpr static double value3(const double xi)
-  {
-    return -6.6 * xi * xi * xi * xi * xi * xi + 12.6 * xi * xi * xi * xi -
-           7.0 * xi * xi + 1.0;
+  constexpr static double value3(const double xi) {
+    return -6.6 * xi * xi * xi * xi * xi * xi + 12.6 * xi * xi * xi * xi - 7.0 * xi * xi + 1.0;
   }
 
   /**
    * @brief Basis function for support point 4.
    */
-  constexpr static double value4(const double xi)
-  {
-    return 6.21036970608696 * xi * xi * xi * xi * xi * xi +
-           2.91172434370594 * xi * xi * xi * xi * xi -
-           10.4910019025184 * xi * xi * xi * xi -
-           4.91869358429470 * xi * xi * xi + 4.28063219643140 * xi * xi +
+  constexpr static double value4(const double xi) {
+    return 6.21036970608696 * xi * xi * xi * xi * xi * xi + 2.91172434370594 * xi * xi * xi * xi * xi -
+           10.4910019025184 * xi * xi * xi * xi - 4.91869358429470 * xi * xi * xi + 4.28063219643140 * xi * xi +
            2.00696924058875 * xi;
   }
 
   /**
    * @brief Basis function for support point 5.
    */
-  constexpr static double value5(const double xi)
-  {
-    return -4.97286970608696 * xi * xi * xi * xi * xi * xi -
-           4.12859526307317 * xi * xi * xi * xi * xi +
-           6.06600190251835 * xi * xi * xi * xi +
-           5.03613973434199 * xi * xi * xi - 1.09313219643140 * xi * xi -
+  constexpr static double value5(const double xi) {
+    return -4.97286970608696 * xi * xi * xi * xi * xi * xi - 4.12859526307317 * xi * xi * xi * xi * xi +
+           6.06600190251835 * xi * xi * xi * xi + 5.03613973434199 * xi * xi * xi - 1.09313219643140 * xi * xi -
            0.90754447126882 * xi;
   }
 
   /**
    * @brief Basis function for support point 6.
    */
-  constexpr static double value6(const double xi)
-  {
-    return 2.0625 * xi * xi * xi * xi * xi * xi +
-           2.0625 * xi * xi * xi * xi * xi - 1.875 * xi * xi * xi * xi -
+  constexpr static double value6(const double xi) {
+    return 2.0625 * xi * xi * xi * xi * xi * xi + 2.0625 * xi * xi * xi * xi * xi - 1.875 * xi * xi * xi * xi -
            1.875 * xi * xi * xi + 0.3125 * xi * xi + 0.3125 * xi;
   }
 
   /**
    * @brief Gradient of basis function @p index at @p xi.
    */
-  constexpr static double gradient(const int index, const double xi)
-  {
-    switch (index)
-    {
+  constexpr static double gradient(const int index, const double xi) {
+    switch (index) {
       case 0:
         return gradient0(xi);
       case 1:
@@ -201,71 +174,56 @@ class LagrangeBasis6GL
   /**
    * @brief Gradient of basis function for support point 0.
    */
-  constexpr static double gradient0(const double xi)
-  {
-    return 12.375 * xi * xi * xi * xi * xi - 10.3125 * xi * xi * xi * xi -
-           7.5 * xi * xi * xi + 5.625 * xi * xi + 0.625 * xi - 0.3125;
+  constexpr static double gradient0(const double xi) {
+    return 12.375 * xi * xi * xi * xi * xi - 10.3125 * xi * xi * xi * xi - 7.5 * xi * xi * xi + 5.625 * xi * xi +
+           0.625 * xi - 0.3125;
   }
 
   /**
    * @brief Gradient of basis function for support point 1.
    */
-  constexpr static double gradient1(const double xi)
-  {
-    return -29.8372182365218 * xi * xi * xi * xi * xi +
-           20.6429763153658 * xi * xi * xi * xi +
-           24.2640076100734 * xi * xi * xi - 15.1084192030260 * xi * xi -
-           2.18626439286279 * xi + 0.90754447126882;
+  constexpr static double gradient1(const double xi) {
+    return -29.8372182365218 * xi * xi * xi * xi * xi + 20.6429763153658 * xi * xi * xi * xi +
+           24.2640076100734 * xi * xi * xi - 15.1084192030260 * xi * xi - 2.18626439286279 * xi + 0.90754447126882;
   }
 
   /**
    * @brief Gradient of basis function for support point 2.
    */
-  constexpr static double gradient2(const double xi)
-  {
-    return 37.2622182365217 * xi * xi * xi * xi * xi -
-           14.5586217185297 * xi * xi * xi * xi -
-           41.9640076100734 * xi * xi * xi + 14.7560807528841 * xi * xi +
-           8.56126439286279 * xi - 2.00696924058875;
+  constexpr static double gradient2(const double xi) {
+    return 37.2622182365217 * xi * xi * xi * xi * xi - 14.5586217185297 * xi * xi * xi * xi -
+           41.9640076100734 * xi * xi * xi + 14.7560807528841 * xi * xi + 8.56126439286279 * xi - 2.00696924058875;
   }
 
   /**
    * @brief Gradient of basis function for support point 3 (center node).
    */
-  constexpr static double gradient3(const double xi)
-  {
+  constexpr static double gradient3(const double xi) {
     return -39.6 * xi * xi * xi * xi * xi + 50.4 * xi * xi * xi - 14.0 * xi;
   }
 
   /**
    * @brief Gradient of basis function for support point 4.
    */
-  constexpr static double gradient4(const double xi)
-  {
-    return 37.2622182365217 * xi * xi * xi * xi * xi +
-           14.5586217185297 * xi * xi * xi * xi -
-           41.9640076100734 * xi * xi * xi - 14.7560807528841 * xi * xi +
-           8.56126439286279 * xi + 2.00696924058875;
+  constexpr static double gradient4(const double xi) {
+    return 37.2622182365217 * xi * xi * xi * xi * xi + 14.5586217185297 * xi * xi * xi * xi -
+           41.9640076100734 * xi * xi * xi - 14.7560807528841 * xi * xi + 8.56126439286279 * xi + 2.00696924058875;
   }
 
   /**
    * @brief Gradient of basis function for support point 5.
    */
-  constexpr static double gradient5(const double xi)
-  {
-    return -29.8372182365218 * xi * xi * xi * xi * xi -
-           20.6429763153658 * xi * xi * xi * xi +
-           24.2640076100734 * xi * xi * xi + 15.1084192030260 * xi * xi -
-           2.18626439286279 * xi - 0.90754447126882;
+  constexpr static double gradient5(const double xi) {
+    return -29.8372182365218 * xi * xi * xi * xi * xi - 20.6429763153658 * xi * xi * xi * xi +
+           24.2640076100734 * xi * xi * xi + 15.1084192030260 * xi * xi - 2.18626439286279 * xi - 0.90754447126882;
   }
 
   /**
    * @brief Gradient of basis function for support point 6.
    */
-  constexpr static double gradient6(const double xi)
-  {
-    return 12.375 * xi * xi * xi * xi * xi + 10.3125 * xi * xi * xi * xi -
-           7.5 * xi * xi * xi - 5.625 * xi * xi + 0.625 * xi + 0.3125;
+  constexpr static double gradient6(const double xi) {
+    return 12.375 * xi * xi * xi * xi * xi + 10.3125 * xi * xi * xi * xi - 7.5 * xi * xi * xi - 5.625 * xi * xi +
+           0.625 * xi + 0.3125;
   }
 
   /**
@@ -273,13 +231,10 @@ class LagrangeBasis6GL
    * Full 7x7 table computed via GL.py.
    * Anti-symmetry: gradientAt(q,p) == -gradientAt(6-q, 6-p).
    */
-  constexpr static double gradientAt(const int q, const int p)
-  {
-    switch (q)
-    {
+  constexpr static double gradientAt(const int q, const int p) {
+    switch (q) {
       case 0:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return -10.5000000000000000;
           case 1:
@@ -297,8 +252,7 @@ class LagrangeBasis6GL
         }
         break;
       case 1:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return 14.2015766029198272;
           case 1:
@@ -316,8 +270,7 @@ class LagrangeBasis6GL
         }
         break;
       case 2:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return -5.6689852255454998;
           case 1:
@@ -335,8 +288,7 @@ class LagrangeBasis6GL
         }
         break;
       case 3:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return 3.2000000000000000;
           case 1:
@@ -354,8 +306,7 @@ class LagrangeBasis6GL
         }
         break;
       case 4:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return -2.0499648130767412;
           case 1:
@@ -373,8 +324,7 @@ class LagrangeBasis6GL
         }
         break;
       case 5:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return 1.3173734357024465;
           case 1:
@@ -392,8 +342,7 @@ class LagrangeBasis6GL
         }
         break;
       case 6:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return -0.5000000000000000;
           case 1:
@@ -415,74 +364,48 @@ class LagrangeBasis6GL
   }
 
   /* Tensor product helpers (2D / 3D) */
-  struct TensorProduct2D
-  {
-    constexpr static int numSupportPoints1D =
-        LagrangeBasis6GL::numSupportPoints;
-    constexpr static int numSupportPoints =
-        numSupportPoints1D * numSupportPoints1D;  // 7*7 = 49
+  struct TensorProduct2D {
+    constexpr static int numSupportPoints1D = LagrangeBasis6GL::numSupportPoints;
+    constexpr static int numSupportPoints = numSupportPoints1D * numSupportPoints1D;  // 7*7 = 49
 
-    constexpr static int linearIndex(const int i, const int j)
-    {
-      return i + numSupportPoints1D * j;
-    }
+    constexpr static int linearIndex(const int i, const int j) { return i + numSupportPoints1D * j; }
 
-    constexpr static void multiIndex(const int linearIndex, int& i0, int& i1)
-    {
+    constexpr static void multiIndex(const int linearIndex, int& i0, int& i1) {
       i1 = linearIndex / numSupportPoints1D;
       i0 = linearIndex % numSupportPoints1D;
     }
 
-    static void value(const double (&coords)[2], double (&N)[numSupportPoints])
-    {
-      for (int a = 0; a < LagrangeBasis6GL::numSupportPoints; ++a)
-      {
-        for (int b = 0; b < LagrangeBasis6GL::numSupportPoints; ++b)
-        {
+    static void value(const double (&coords)[2], double (&N)[numSupportPoints]) {
+      for (int a = 0; a < LagrangeBasis6GL::numSupportPoints; ++a) {
+        for (int b = 0; b < LagrangeBasis6GL::numSupportPoints; ++b) {
           const int lindex = a + LagrangeBasis6GL::numSupportPoints * b;
-          N[lindex] = LagrangeBasis6GL::value(a, coords[0]) *
-                      LagrangeBasis6GL::value(b, coords[1]);
+          N[lindex] = LagrangeBasis6GL::value(a, coords[0]) * LagrangeBasis6GL::value(b, coords[1]);
         }
       }
     }
   };
 
-  struct TensorProduct3D
-  {
-    constexpr static int numSupportPoints1D =
-        LagrangeBasis6GL::numSupportPoints;
-    constexpr static int numSupportPoints = numSupportPoints1D *
-                                            numSupportPoints1D *
-                                            numSupportPoints1D;  // 7^3 = 343
+  struct TensorProduct3D {
+    constexpr static int numSupportPoints1D = LagrangeBasis6GL::numSupportPoints;
+    constexpr static int numSupportPoints = numSupportPoints1D * numSupportPoints1D * numSupportPoints1D;  // 7^3 = 343
 
-    constexpr static int linearIndex(const int i, const int j, const int k)
-    {
-      return i + numSupportPoints1D * j +
-             numSupportPoints1D * numSupportPoints1D * k;
+    constexpr static int linearIndex(const int i, const int j, const int k) {
+      return i + numSupportPoints1D * j + numSupportPoints1D * numSupportPoints1D * k;
     }
 
-    constexpr static void multiIndex(const int linearIndex, int& i0, int& i1,
-                                     int& i2)
-    {
+    constexpr static void multiIndex(const int linearIndex, int& i0, int& i1, int& i2) {
       i2 = linearIndex / (numSupportPoints1D * numSupportPoints1D);
-      i1 = (linearIndex % (numSupportPoints1D * numSupportPoints1D)) /
-           numSupportPoints1D;
+      i1 = (linearIndex % (numSupportPoints1D * numSupportPoints1D)) / numSupportPoints1D;
       i0 = linearIndex % numSupportPoints1D;
     }
 
-    static void value(const double (&coords)[3], double (&N)[numSupportPoints])
-    {
-      for (int a = 0; a < LagrangeBasis6GL::numSupportPoints; ++a)
-      {
-        for (int b = 0; b < LagrangeBasis6GL::numSupportPoints; ++b)
-        {
-          for (int c = 0; c < LagrangeBasis6GL::numSupportPoints; ++c)
-          {
+    static void value(const double (&coords)[3], double (&N)[numSupportPoints]) {
+      for (int a = 0; a < LagrangeBasis6GL::numSupportPoints; ++a) {
+        for (int b = 0; b < LagrangeBasis6GL::numSupportPoints; ++b) {
+          for (int c = 0; c < LagrangeBasis6GL::numSupportPoints; ++c) {
             const int lindex = a + LagrangeBasis6GL::numSupportPoints * b +
-                               LagrangeBasis6GL::numSupportPoints *
-                                   LagrangeBasis6GL::numSupportPoints * c;
-            N[lindex] = LagrangeBasis6GL::value(a, coords[0]) *
-                        LagrangeBasis6GL::value(b, coords[1]) *
+                               LagrangeBasis6GL::numSupportPoints * LagrangeBasis6GL::numSupportPoints * c;
+            N[lindex] = LagrangeBasis6GL::value(a, coords[0]) * LagrangeBasis6GL::value(b, coords[1]) *
                         LagrangeBasis6GL::value(c, coords[2]);
           }
         }

--- a/src/discretization/fe/makutu/include/LagrangeBasis7GL.h
+++ b/src/discretization/fe/makutu/include/LagrangeBasis7GL.h
@@ -13,8 +13,7 @@
  *   lambda2 = 0.5917001814331423
  *   lambda3 = 0.2092992179024789
  */
-class LagrangeBasis7GL
-{
+class LagrangeBasis7GL {
  public:
   constexpr static int numSupportPoints = 8;
 
@@ -30,10 +29,8 @@ class LagrangeBasis7GL
   /**
    * @brief GLL quadrature weight for node q.
    */
-  constexpr static double weight(const int q)
-  {
-    switch (q)
-    {
+  constexpr static double weight(const int q) {
+    switch (q) {
       case 1:
       case 6:
         return 0.2107042271435060;
@@ -51,10 +48,8 @@ class LagrangeBasis7GL
   /**
    * @brief Parent coordinate of support point @p supportPointIndex.
    */
-  constexpr static double parentSupportCoord(const int supportPointIndex)
-  {
-    switch (supportPointIndex)
-    {
+  constexpr static double parentSupportCoord(const int supportPointIndex) {
+    switch (supportPointIndex) {
       case 0:
         return -1.0;
       case 1:
@@ -79,10 +74,8 @@ class LagrangeBasis7GL
   /**
    * @brief Value of basis function @p index at @p xi.
    */
-  constexpr static double value(const int index, const double xi)
-  {
-    switch (index)
-    {
+  constexpr static double value(const int index, const double xi) {
+    switch (index) {
       case 0:
         return value0(xi);
       case 1:
@@ -107,112 +100,80 @@ class LagrangeBasis7GL
   /**
    * @brief Basis function for support point 0.
    */
-  constexpr static double value0(const double xi)
-  {
-    return -3.3515625 * xi * xi * xi * xi * xi * xi * xi +
-           3.3515625 * xi * xi * xi * xi * xi * xi +
-           3.8671875 * xi * xi * xi * xi * xi - 3.8671875 * xi * xi * xi * xi -
-           1.0546875 * xi * xi * xi + 1.0546875 * xi * xi + 0.0390625 * xi -
-           0.0390625;
+  constexpr static double value0(const double xi) {
+    return -3.3515625 * xi * xi * xi * xi * xi * xi * xi + 3.3515625 * xi * xi * xi * xi * xi * xi +
+           3.8671875 * xi * xi * xi * xi * xi - 3.8671875 * xi * xi * xi * xi - 1.0546875 * xi * xi * xi +
+           1.0546875 * xi * xi + 0.0390625 * xi - 0.0390625;
   }
 
   /**
    * @brief Basis function for support point 1.
    */
-  constexpr static double value1(const double xi)
-  {
-    return 8.14072271825387 * xi * xi * xi * xi * xi * xi * xi -
-           7.09659483138615 * xi * xi * xi * xi * xi * xi -
-           11.347477684014 * xi * xi * xi * xi * xi +
-           9.89205188147183 * xi * xi * xi * xi +
-           3.33160871212585 * xi * xi * xi - 2.90429707348449 * xi * xi -
-           0.124853746365692 * xi + 0.108840023398809;
+  constexpr static double value1(const double xi) {
+    return 8.14072271825387 * xi * xi * xi * xi * xi * xi * xi - 7.09659483138615 * xi * xi * xi * xi * xi * xi -
+           11.347477684014 * xi * xi * xi * xi * xi + 9.89205188147183 * xi * xi * xi * xi +
+           3.33160871212585 * xi * xi * xi - 2.90429707348449 * xi * xi - 0.124853746365692 * xi + 0.108840023398809;
   }
 
   /**
    * @brief Basis function for support point 2.
    */
-  constexpr static double value2(const double xi)
-  {
-    return -10.3581368289505 * xi * xi * xi * xi * xi * xi * xi +
-           6.12891144099929 * xi * xi * xi * xi * xi * xi +
-           18.6833551584202 * xi * xi * xi * xi * xi -
-           11.0549446370171 * xi * xi * xi * xi -
-           8.67003714121216 * xi * xi * xi + 5.13006254948732 * xi * xi +
-           0.34481881174243 * xi - 0.204029353469556;
+  constexpr static double value2(const double xi) {
+    return -10.3581368289505 * xi * xi * xi * xi * xi * xi * xi + 6.12891144099929 * xi * xi * xi * xi * xi * xi +
+           18.6833551584202 * xi * xi * xi * xi * xi - 11.0549446370171 * xi * xi * xi * xi -
+           8.67003714121216 * xi * xi * xi + 5.13006254948732 * xi * xi + 0.34481881174243 * xi - 0.204029353469556;
   }
 
   /**
    * @brief Basis function for support point 3.
    */
-  constexpr static double value3(const double xi)
-  {
-    return 11.3898137484866 * xi * xi * xi * xi * xi * xi * xi -
-           2.38387910961314 * xi * xi * xi * xi * xi * xi -
-           24.0329625019858 * xi * xi * xi * xi * xi +
-           5.03008025554523 * xi * xi * xi * xi +
-           15.6735080468926 * xi * xi * xi - 3.28045297600283 * xi * xi -
-           3.0303592933934 * xi + 0.634251830070747;
+  constexpr static double value3(const double xi) {
+    return 11.3898137484866 * xi * xi * xi * xi * xi * xi * xi - 2.38387910961314 * xi * xi * xi * xi * xi * xi -
+           24.0329625019858 * xi * xi * xi * xi * xi + 5.03008025554523 * xi * xi * xi * xi +
+           15.6735080468926 * xi * xi * xi - 3.28045297600283 * xi * xi - 3.0303592933934 * xi + 0.634251830070747;
   }
 
   /**
    * @brief Basis function for support point 4.
    */
-  constexpr static double value4(const double xi)
-  {
-    return -11.3898137484866 * xi * xi * xi * xi * xi * xi * xi -
-           2.38387910961314 * xi * xi * xi * xi * xi * xi +
-           24.0329625019858 * xi * xi * xi * xi * xi +
-           5.03008025554523 * xi * xi * xi * xi -
-           15.6735080468926 * xi * xi * xi - 3.28045297600283 * xi * xi +
-           3.0303592933934 * xi + 0.634251830070747;
+  constexpr static double value4(const double xi) {
+    return -11.3898137484866 * xi * xi * xi * xi * xi * xi * xi - 2.38387910961314 * xi * xi * xi * xi * xi * xi +
+           24.0329625019858 * xi * xi * xi * xi * xi + 5.03008025554523 * xi * xi * xi * xi -
+           15.6735080468926 * xi * xi * xi - 3.28045297600283 * xi * xi + 3.0303592933934 * xi + 0.634251830070747;
   }
 
   /**
    * @brief Basis function for support point 5.
    */
-  constexpr static double value5(const double xi)
-  {
-    return 10.3581368289505 * xi * xi * xi * xi * xi * xi * xi +
-           6.12891144099929 * xi * xi * xi * xi * xi * xi -
-           18.6833551584202 * xi * xi * xi * xi * xi -
-           11.0549446370171 * xi * xi * xi * xi +
-           8.67003714121216 * xi * xi * xi + 5.13006254948732 * xi * xi -
-           0.34481881174243 * xi - 0.204029353469556;
+  constexpr static double value5(const double xi) {
+    return 10.3581368289505 * xi * xi * xi * xi * xi * xi * xi + 6.12891144099929 * xi * xi * xi * xi * xi * xi -
+           18.6833551584202 * xi * xi * xi * xi * xi - 11.0549446370171 * xi * xi * xi * xi +
+           8.67003714121216 * xi * xi * xi + 5.13006254948732 * xi * xi - 0.34481881174243 * xi - 0.204029353469556;
   }
 
   /**
    * @brief Basis function for support point 6.
    */
-  constexpr static double value6(const double xi)
-  {
-    return -8.14072271825387 * xi * xi * xi * xi * xi * xi * xi -
-           7.09659483138615 * xi * xi * xi * xi * xi * xi +
-           11.347477684014 * xi * xi * xi * xi * xi +
-           9.89205188147183 * xi * xi * xi * xi -
-           3.33160871212585 * xi * xi * xi - 2.90429707348449 * xi * xi +
-           0.124853746365692 * xi + 0.108840023398809;
+  constexpr static double value6(const double xi) {
+    return -8.14072271825387 * xi * xi * xi * xi * xi * xi * xi - 7.09659483138615 * xi * xi * xi * xi * xi * xi +
+           11.347477684014 * xi * xi * xi * xi * xi + 9.89205188147183 * xi * xi * xi * xi -
+           3.33160871212585 * xi * xi * xi - 2.90429707348449 * xi * xi + 0.124853746365692 * xi + 0.108840023398809;
   }
 
   /**
    * @brief Basis function for support point 7.
    */
-  constexpr static double value7(const double xi)
-  {
-    return 3.3515625 * xi * xi * xi * xi * xi * xi * xi +
-           3.3515625 * xi * xi * xi * xi * xi * xi -
-           3.8671875 * xi * xi * xi * xi * xi - 3.8671875 * xi * xi * xi * xi +
-           1.0546875 * xi * xi * xi + 1.0546875 * xi * xi - 0.0390625 * xi -
-           0.0390625;
+  constexpr static double value7(const double xi) {
+    return 3.3515625 * xi * xi * xi * xi * xi * xi * xi + 3.3515625 * xi * xi * xi * xi * xi * xi -
+           3.8671875 * xi * xi * xi * xi * xi - 3.8671875 * xi * xi * xi * xi + 1.0546875 * xi * xi * xi +
+           1.0546875 * xi * xi - 0.0390625 * xi - 0.0390625;
   }
 
   /**
    * @brief Gradient of basis function @p index at @p xi.
    */
-  constexpr static double gradient(const int index, const double xi)
-  {
-    switch (index)
-    {
+  constexpr static double gradient(const int index, const double xi) {
+    switch (index) {
       case 0:
         return gradient0(xi);
       case 1:
@@ -237,95 +198,71 @@ class LagrangeBasis7GL
   /**
    * @brief Gradient of basis function for support point 0.
    */
-  constexpr static double gradient0(const double xi)
-  {
-    return -23.4609375 * xi * xi * xi * xi * xi * xi +
-           20.109375 * xi * xi * xi * xi * xi + 19.3359375 * xi * xi * xi * xi -
-           15.46875 * xi * xi * xi - 3.1640625 * xi * xi + 2.109375 * xi +
-           0.0390625;
+  constexpr static double gradient0(const double xi) {
+    return -23.4609375 * xi * xi * xi * xi * xi * xi + 20.109375 * xi * xi * xi * xi * xi +
+           19.3359375 * xi * xi * xi * xi - 15.46875 * xi * xi * xi - 3.1640625 * xi * xi + 2.109375 * xi + 0.0390625;
   }
 
   /**
    * @brief Gradient of basis function for support point 1.
    */
-  constexpr static double gradient1(const double xi)
-  {
-    return 56.9850590277771 * xi * xi * xi * xi * xi * xi -
-           42.5795689883169 * xi * xi * xi * xi * xi -
-           56.7373884200701 * xi * xi * xi * xi +
-           39.5682075258873 * xi * xi * xi + 9.99482613637756 * xi * xi -
+  constexpr static double gradient1(const double xi) {
+    return 56.9850590277771 * xi * xi * xi * xi * xi * xi - 42.5795689883169 * xi * xi * xi * xi * xi -
+           56.7373884200701 * xi * xi * xi * xi + 39.5682075258873 * xi * xi * xi + 9.99482613637756 * xi * xi -
            5.80859414696897 * xi - 0.124853746365692;
   }
 
   /**
    * @brief Gradient of basis function for support point 2.
    */
-  constexpr static double gradient2(const double xi)
-  {
-    return -72.5069578026532 * xi * xi * xi * xi * xi * xi +
-           36.7734686459958 * xi * xi * xi * xi * xi +
-           93.4167757921009 * xi * xi * xi * xi -
-           44.2197785480682 * xi * xi * xi - 26.0101114236365 * xi * xi +
+  constexpr static double gradient2(const double xi) {
+    return -72.5069578026532 * xi * xi * xi * xi * xi * xi + 36.7734686459958 * xi * xi * xi * xi * xi +
+           93.4167757921009 * xi * xi * xi * xi - 44.2197785480682 * xi * xi * xi - 26.0101114236365 * xi * xi +
            10.2601250989746 * xi + 0.34481881174243;
   }
 
   /**
    * @brief Gradient of basis function for support point 3.
    */
-  constexpr static double gradient3(const double xi)
-  {
-    return 79.7286962394062 * xi * xi * xi * xi * xi * xi -
-           14.3032746576789 * xi * xi * xi * xi * xi -
-           120.164812509929 * xi * xi * xi * xi +
-           20.1203210221809 * xi * xi * xi + 47.0205241406778 * xi * xi -
+  constexpr static double gradient3(const double xi) {
+    return 79.7286962394062 * xi * xi * xi * xi * xi * xi - 14.3032746576789 * xi * xi * xi * xi * xi -
+           120.164812509929 * xi * xi * xi * xi + 20.1203210221809 * xi * xi * xi + 47.0205241406778 * xi * xi -
            6.56090595200567 * xi - 3.0303592933934;
   }
 
   /**
    * @brief Gradient of basis function for support point 4.
    */
-  constexpr static double gradient4(const double xi)
-  {
-    return -79.7286962394062 * xi * xi * xi * xi * xi * xi -
-           14.3032746576789 * xi * xi * xi * xi * xi +
-           120.164812509929 * xi * xi * xi * xi +
-           20.1203210221809 * xi * xi * xi - 47.0205241406778 * xi * xi -
+  constexpr static double gradient4(const double xi) {
+    return -79.7286962394062 * xi * xi * xi * xi * xi * xi - 14.3032746576789 * xi * xi * xi * xi * xi +
+           120.164812509929 * xi * xi * xi * xi + 20.1203210221809 * xi * xi * xi - 47.0205241406778 * xi * xi -
            6.56090595200567 * xi + 3.0303592933934;
   }
 
   /**
    * @brief Gradient of basis function for support point 5.
    */
-  constexpr static double gradient5(const double xi)
-  {
-    return 72.5069578026532 * xi * xi * xi * xi * xi * xi +
-           36.7734686459958 * xi * xi * xi * xi * xi -
-           93.4167757921010 * xi * xi * xi * xi -
-           44.2197785480682 * xi * xi * xi + 26.0101114236365 * xi * xi +
+  constexpr static double gradient5(const double xi) {
+    return 72.5069578026532 * xi * xi * xi * xi * xi * xi + 36.7734686459958 * xi * xi * xi * xi * xi -
+           93.4167757921010 * xi * xi * xi * xi - 44.2197785480682 * xi * xi * xi + 26.0101114236365 * xi * xi +
            10.2601250989746 * xi - 0.34481881174243;
   }
 
   /**
    * @brief Gradient of basis function for support point 6.
    */
-  constexpr static double gradient6(const double xi)
-  {
-    return -56.9850590277771 * xi * xi * xi * xi * xi * xi -
-           42.5795689883169 * xi * xi * xi * xi * xi +
-           56.7373884200701 * xi * xi * xi * xi +
-           39.5682075258873 * xi * xi * xi - 9.99482613637755 * xi * xi -
+  constexpr static double gradient6(const double xi) {
+    return -56.9850590277771 * xi * xi * xi * xi * xi * xi - 42.5795689883169 * xi * xi * xi * xi * xi +
+           56.7373884200701 * xi * xi * xi * xi + 39.5682075258873 * xi * xi * xi - 9.99482613637755 * xi * xi -
            5.80859414696897 * xi + 0.124853746365692;
   }
 
   /**
    * @brief Gradient of basis function for support point 7.
    */
-  constexpr static double gradient7(const double xi)
-  {
-    return 23.4609375 * xi * xi * xi * xi * xi * xi +
-           20.109375 * xi * xi * xi * xi * xi - 19.3359375 * xi * xi * xi * xi -
-           15.46875 * xi * xi * xi + 3.1640625 * xi * xi + 2.109375 * xi -
-           0.0390625;
+  constexpr static double gradient7(const double xi) {
+    return 23.4609375 * xi * xi * xi * xi * xi * xi + 20.109375 * xi * xi * xi * xi * xi -
+           19.3359375 * xi * xi * xi * xi - 15.46875 * xi * xi * xi + 3.1640625 * xi * xi + 2.109375 * xi - 0.0390625;
   }
 
   /**
@@ -333,13 +270,10 @@ class LagrangeBasis7GL
    * Full 8x8 table computed via computGL.py.
    * Anti-symmetry: gradientAt(q,p) == -gradientAt(7-q, 7-p).
    */
-  constexpr static double gradientAt(const int q, const int p)
-  {
-    switch (q)
-    {
+  constexpr static double gradientAt(const int q, const int p) {
+    switch (q) {
       case 0:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return -14.0000000000000000;
           case 1:
@@ -359,8 +293,7 @@ class LagrangeBasis7GL
         }
         break;
       case 1:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return 18.9375986071174012;
           case 1:
@@ -380,8 +313,7 @@ class LagrangeBasis7GL
         }
         break;
       case 2:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return -7.5692898193484837;
           case 1:
@@ -401,8 +333,7 @@ class LagrangeBasis7GL
         }
         break;
       case 3:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return 4.2979081642651522;
           case 1:
@@ -422,8 +353,7 @@ class LagrangeBasis7GL
         }
         break;
       case 4:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return -2.8101889892579237;
           case 1:
@@ -443,8 +373,7 @@ class LagrangeBasis7GL
         }
         break;
       case 5:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return 1.9416594255441169;
           case 1:
@@ -464,8 +393,7 @@ class LagrangeBasis7GL
         }
         break;
       case 6:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return -1.2976873883202629;
           case 1:
@@ -485,8 +413,7 @@ class LagrangeBasis7GL
         }
         break;
       case 7:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return 0.5000000000000000;
           case 1:
@@ -510,74 +437,48 @@ class LagrangeBasis7GL
   }
 
   /* Tensor product helpers (2D / 3D) */
-  struct TensorProduct2D
-  {
-    constexpr static int numSupportPoints1D =
-        LagrangeBasis7GL::numSupportPoints;
-    constexpr static int numSupportPoints =
-        numSupportPoints1D * numSupportPoints1D;  // 8*8 = 64
+  struct TensorProduct2D {
+    constexpr static int numSupportPoints1D = LagrangeBasis7GL::numSupportPoints;
+    constexpr static int numSupportPoints = numSupportPoints1D * numSupportPoints1D;  // 8*8 = 64
 
-    constexpr static int linearIndex(const int i, const int j)
-    {
-      return i + numSupportPoints1D * j;
-    }
+    constexpr static int linearIndex(const int i, const int j) { return i + numSupportPoints1D * j; }
 
-    constexpr static void multiIndex(const int linearIndex, int& i0, int& i1)
-    {
+    constexpr static void multiIndex(const int linearIndex, int& i0, int& i1) {
       i1 = linearIndex / numSupportPoints1D;
       i0 = linearIndex % numSupportPoints1D;
     }
 
-    static void value(const double (&coords)[2], double (&N)[numSupportPoints])
-    {
-      for (int a = 0; a < LagrangeBasis7GL::numSupportPoints; ++a)
-      {
-        for (int b = 0; b < LagrangeBasis7GL::numSupportPoints; ++b)
-        {
+    static void value(const double (&coords)[2], double (&N)[numSupportPoints]) {
+      for (int a = 0; a < LagrangeBasis7GL::numSupportPoints; ++a) {
+        for (int b = 0; b < LagrangeBasis7GL::numSupportPoints; ++b) {
           const int lindex = a + LagrangeBasis7GL::numSupportPoints * b;
-          N[lindex] = LagrangeBasis7GL::value(a, coords[0]) *
-                      LagrangeBasis7GL::value(b, coords[1]);
+          N[lindex] = LagrangeBasis7GL::value(a, coords[0]) * LagrangeBasis7GL::value(b, coords[1]);
         }
       }
     }
   };
 
-  struct TensorProduct3D
-  {
-    constexpr static int numSupportPoints1D =
-        LagrangeBasis7GL::numSupportPoints;
-    constexpr static int numSupportPoints = numSupportPoints1D *
-                                            numSupportPoints1D *
-                                            numSupportPoints1D;  // 8^3 = 512
+  struct TensorProduct3D {
+    constexpr static int numSupportPoints1D = LagrangeBasis7GL::numSupportPoints;
+    constexpr static int numSupportPoints = numSupportPoints1D * numSupportPoints1D * numSupportPoints1D;  // 8^3 = 512
 
-    constexpr static int linearIndex(const int i, const int j, const int k)
-    {
-      return i + numSupportPoints1D * j +
-             numSupportPoints1D * numSupportPoints1D * k;
+    constexpr static int linearIndex(const int i, const int j, const int k) {
+      return i + numSupportPoints1D * j + numSupportPoints1D * numSupportPoints1D * k;
     }
 
-    constexpr static void multiIndex(const int linearIndex, int& i0, int& i1,
-                                     int& i2)
-    {
+    constexpr static void multiIndex(const int linearIndex, int& i0, int& i1, int& i2) {
       i2 = linearIndex / (numSupportPoints1D * numSupportPoints1D);
-      i1 = (linearIndex % (numSupportPoints1D * numSupportPoints1D)) /
-           numSupportPoints1D;
+      i1 = (linearIndex % (numSupportPoints1D * numSupportPoints1D)) / numSupportPoints1D;
       i0 = linearIndex % numSupportPoints1D;
     }
 
-    static void value(const double (&coords)[3], double (&N)[numSupportPoints])
-    {
-      for (int a = 0; a < LagrangeBasis7GL::numSupportPoints; ++a)
-      {
-        for (int b = 0; b < LagrangeBasis7GL::numSupportPoints; ++b)
-        {
-          for (int c = 0; c < LagrangeBasis7GL::numSupportPoints; ++c)
-          {
+    static void value(const double (&coords)[3], double (&N)[numSupportPoints]) {
+      for (int a = 0; a < LagrangeBasis7GL::numSupportPoints; ++a) {
+        for (int b = 0; b < LagrangeBasis7GL::numSupportPoints; ++b) {
+          for (int c = 0; c < LagrangeBasis7GL::numSupportPoints; ++c) {
             const int lindex = a + LagrangeBasis7GL::numSupportPoints * b +
-                               LagrangeBasis7GL::numSupportPoints *
-                                   LagrangeBasis7GL::numSupportPoints * c;
-            N[lindex] = LagrangeBasis7GL::value(a, coords[0]) *
-                        LagrangeBasis7GL::value(b, coords[1]) *
+                               LagrangeBasis7GL::numSupportPoints * LagrangeBasis7GL::numSupportPoints * c;
+            N[lindex] = LagrangeBasis7GL::value(a, coords[0]) * LagrangeBasis7GL::value(b, coords[1]) *
                         LagrangeBasis7GL::value(c, coords[2]);
           }
         }

--- a/src/discretization/fe/makutu/include/LagrangeBasis8GL.h
+++ b/src/discretization/fe/makutu/include/LagrangeBasis8GL.h
@@ -12,8 +12,7 @@
  * 1 } lambda1 = 0.8997579954114602 lambda2 = 0.6771862795107377 lambda3 =
  * 0.3631174638261782
  */
-class LagrangeBasis8GL
-{
+class LagrangeBasis8GL {
  public:
   constexpr static int numSupportPoints = 9;
 
@@ -29,10 +28,8 @@ class LagrangeBasis8GL
   /**
    * @brief GLL quadrature weight for node q.
    */
-  constexpr static double weight(const int q)
-  {
-    switch (q)
-    {
+  constexpr static double weight(const int q) {
+    switch (q) {
       case 1:
       case 7:
         return 0.1654953615608056;
@@ -52,10 +49,8 @@ class LagrangeBasis8GL
   /**
    * @brief Parent coordinate of support point @p supportPointIndex.
    */
-  constexpr static double parentSupportCoord(const int supportPointIndex)
-  {
-    switch (supportPointIndex)
-    {
+  constexpr static double parentSupportCoord(const int supportPointIndex) {
+    switch (supportPointIndex) {
       case 0:
         return -1.0;
       case 1:
@@ -82,10 +77,8 @@ class LagrangeBasis8GL
   /**
    * @brief Value of basis function @p index at @p xi.
    */
-  constexpr static double value(const int index, const double xi)
-  {
-    switch (index)
-    {
+  constexpr static double value(const int index, const double xi) {
+    switch (index) {
       case 0:
         return value0(xi);
       case 1:
@@ -112,128 +105,94 @@ class LagrangeBasis8GL
   /**
    * @brief Basis function for support point 0.
    */
-  constexpr static double value0(const double xi)
-  {
-    return 5.5859375 * xi * xi * xi * xi * xi * xi * xi * xi -
-           5.5859375 * xi * xi * xi * xi * xi * xi * xi -
-           7.8203125 * xi * xi * xi * xi * xi * xi +
-           7.8203125 * xi * xi * xi * xi * xi + 3.0078125 * xi * xi * xi * xi -
-           3.0078125 * xi * xi * xi - 0.2734375 * xi * xi + 0.2734375 * xi;
+  constexpr static double value0(const double xi) {
+    return 5.5859375 * xi * xi * xi * xi * xi * xi * xi * xi - 5.5859375 * xi * xi * xi * xi * xi * xi * xi -
+           7.8203125 * xi * xi * xi * xi * xi * xi + 7.8203125 * xi * xi * xi * xi * xi +
+           3.0078125 * xi * xi * xi * xi - 3.0078125 * xi * xi * xi - 0.2734375 * xi * xi + 0.2734375 * xi;
   }
 
   /**
    * @brief Basis function for support point 1.
    */
-  constexpr static double value1(const double xi)
-  {
+  constexpr static double value1(const double xi) {
     return -13.6345320004901 * xi * xi * xi * xi * xi * xi * xi * xi +
-           12.2677791811344 * xi * xi * xi * xi * xi * xi * xi +
-           21.6848443970084 * xi * xi * xi * xi * xi * xi -
-           19.5111121254617 * xi * xi * xi * xi * xi -
-           8.87473674361952 * xi * xi * xi * xi +
-           7.98511534224353 * xi * xi * xi + 0.824424347101285 * xi * xi -
-           0.741782397916255 * xi;
+           12.2677791811344 * xi * xi * xi * xi * xi * xi * xi + 21.6848443970084 * xi * xi * xi * xi * xi * xi -
+           19.5111121254617 * xi * xi * xi * xi * xi - 8.87473674361952 * xi * xi * xi * xi +
+           7.98511534224353 * xi * xi * xi + 0.824424347101285 * xi * xi - 0.741782397916255 * xi;
   }
 
   /**
    * @brief Basis function for support point 2.
    */
-  constexpr static double value2(const double xi)
-  {
+  constexpr static double value2(const double xi) {
     return 17.5609949844537 * xi * xi * xi * xi * xi * xi * xi * xi -
-           11.8920648580289 * xi * xi * xi * xi * xi * xi * xi -
-           34.0932448057799 * xi * xi * xi * xi * xi * xi +
-           23.0874776064749 * xi * xi * xi * xi * xi +
-           18.4067902908633 * xi * xi * xi * xi -
-           12.4648258348041 * xi * xi * xi - 1.87454046953711 * xi * xi +
-           1.26941308635815 * xi;
+           11.8920648580289 * xi * xi * xi * xi * xi * xi * xi - 34.0932448057799 * xi * xi * xi * xi * xi * xi +
+           23.0874776064749 * xi * xi * xi * xi * xi + 18.4067902908633 * xi * xi * xi * xi -
+           12.4648258348041 * xi * xi * xi - 1.87454046953711 * xi * xi + 1.26941308635815 * xi;
   }
 
   /**
    * @brief Basis function for support point 3.
    */
-  constexpr static double value3(const double xi)
-  {
+  constexpr static double value3(const double xi) {
     return -19.7266861982493 * xi * xi * xi * xi * xi * xi * xi * xi +
-           7.16310426200316 * xi * xi * xi * xi * xi * xi * xi +
-           44.7429986230572 * xi * xi * xi * xi * xi * xi -
-           16.2469641839827 * xi * xi * xi * xi * xi -
-           32.3398660472438 * xi * xi * xi * xi +
-           11.7431701395535 * xi * xi * xi + 7.32355362243583 * xi * xi -
-           2.65931021757392 * xi;
+           7.16310426200316 * xi * xi * xi * xi * xi * xi * xi + 44.7429986230572 * xi * xi * xi * xi * xi * xi -
+           16.2469641839827 * xi * xi * xi * xi * xi - 32.3398660472438 * xi * xi * xi * xi +
+           11.7431701395535 * xi * xi * xi + 7.32355362243583 * xi * xi - 2.65931021757392 * xi;
   }
 
   /**
    * @brief Basis function for support point 4 (centre node, even polynomial).
    */
-  constexpr static double value4(const double xi)
-  {
-    return 20.4285714285714 * xi * xi * xi * xi * xi * xi * xi * xi -
-           49.0285714285714 * xi * xi * xi * xi * xi * xi +
+  constexpr static double value4(const double xi) {
+    return 20.4285714285714 * xi * xi * xi * xi * xi * xi * xi * xi - 49.0285714285714 * xi * xi * xi * xi * xi * xi +
            39.6 * xi * xi * xi * xi - 12.0 * xi * xi + 1.0;
   }
 
   /**
    * @brief Basis function for support point 5.
    */
-  constexpr static double value5(const double xi)
-  {
+  constexpr static double value5(const double xi) {
     return -19.7266861982493 * xi * xi * xi * xi * xi * xi * xi * xi -
-           7.16310426200316 * xi * xi * xi * xi * xi * xi * xi +
-           44.7429986230572 * xi * xi * xi * xi * xi * xi +
-           16.2469641839827 * xi * xi * xi * xi * xi -
-           32.3398660472438 * xi * xi * xi * xi -
-           11.7431701395535 * xi * xi * xi + 7.32355362243583 * xi * xi +
-           2.65931021757392 * xi;
+           7.16310426200316 * xi * xi * xi * xi * xi * xi * xi + 44.7429986230572 * xi * xi * xi * xi * xi * xi +
+           16.2469641839827 * xi * xi * xi * xi * xi - 32.3398660472438 * xi * xi * xi * xi -
+           11.7431701395535 * xi * xi * xi + 7.32355362243583 * xi * xi + 2.65931021757392 * xi;
   }
 
   /**
    * @brief Basis function for support point 6.
    */
-  constexpr static double value6(const double xi)
-  {
+  constexpr static double value6(const double xi) {
     return 17.5609949844537 * xi * xi * xi * xi * xi * xi * xi * xi +
-           11.8920648580289 * xi * xi * xi * xi * xi * xi * xi -
-           34.0932448057799 * xi * xi * xi * xi * xi * xi -
-           23.0874776064749 * xi * xi * xi * xi * xi +
-           18.4067902908633 * xi * xi * xi * xi +
-           12.4648258348041 * xi * xi * xi - 1.87454046953711 * xi * xi -
-           1.26941308635815 * xi;
+           11.8920648580289 * xi * xi * xi * xi * xi * xi * xi - 34.0932448057799 * xi * xi * xi * xi * xi * xi -
+           23.0874776064749 * xi * xi * xi * xi * xi + 18.4067902908633 * xi * xi * xi * xi +
+           12.4648258348041 * xi * xi * xi - 1.87454046953711 * xi * xi - 1.26941308635815 * xi;
   }
 
   /**
    * @brief Basis function for support point 7.
    */
-  constexpr static double value7(const double xi)
-  {
+  constexpr static double value7(const double xi) {
     return -13.6345320004901 * xi * xi * xi * xi * xi * xi * xi * xi -
-           12.2677791811344 * xi * xi * xi * xi * xi * xi * xi +
-           21.6848443970084 * xi * xi * xi * xi * xi * xi +
-           19.5111121254617 * xi * xi * xi * xi * xi -
-           8.87473674361952 * xi * xi * xi * xi -
-           7.98511534224353 * xi * xi * xi + 0.824424347101285 * xi * xi +
-           0.741782397916255 * xi;
+           12.2677791811344 * xi * xi * xi * xi * xi * xi * xi + 21.6848443970084 * xi * xi * xi * xi * xi * xi +
+           19.5111121254617 * xi * xi * xi * xi * xi - 8.87473674361952 * xi * xi * xi * xi -
+           7.98511534224353 * xi * xi * xi + 0.824424347101285 * xi * xi + 0.741782397916255 * xi;
   }
 
   /**
    * @brief Basis function for support point 8.
    */
-  constexpr static double value8(const double xi)
-  {
-    return 5.5859375 * xi * xi * xi * xi * xi * xi * xi * xi +
-           5.5859375 * xi * xi * xi * xi * xi * xi * xi -
-           7.8203125 * xi * xi * xi * xi * xi * xi -
-           7.8203125 * xi * xi * xi * xi * xi + 3.0078125 * xi * xi * xi * xi +
-           3.0078125 * xi * xi * xi - 0.2734375 * xi * xi - 0.2734375 * xi;
+  constexpr static double value8(const double xi) {
+    return 5.5859375 * xi * xi * xi * xi * xi * xi * xi * xi + 5.5859375 * xi * xi * xi * xi * xi * xi * xi -
+           7.8203125 * xi * xi * xi * xi * xi * xi - 7.8203125 * xi * xi * xi * xi * xi +
+           3.0078125 * xi * xi * xi * xi + 3.0078125 * xi * xi * xi - 0.2734375 * xi * xi - 0.2734375 * xi;
   }
 
   /**
    * @brief Gradient of basis function @p index at @p xi.
    */
-  constexpr static double gradient(const int index, const double xi)
-  {
-    switch (index)
-    {
+  constexpr static double gradient(const int index, const double xi) {
+    switch (index) {
       case 0:
         return gradient0(xi);
       case 1:
@@ -260,114 +219,82 @@ class LagrangeBasis8GL
   /**
    * @brief Gradient of basis function for support point 0.
    */
-  constexpr static double gradient0(const double xi)
-  {
-    return 44.6875 * xi * xi * xi * xi * xi * xi * xi -
-           39.1015625 * xi * xi * xi * xi * xi * xi -
-           46.921875 * xi * xi * xi * xi * xi + 39.1015625 * xi * xi * xi * xi +
-           12.03125 * xi * xi * xi - 9.0234375 * xi * xi - 0.546875 * xi +
-           0.2734375;
+  constexpr static double gradient0(const double xi) {
+    return 44.6875 * xi * xi * xi * xi * xi * xi * xi - 39.1015625 * xi * xi * xi * xi * xi * xi -
+           46.921875 * xi * xi * xi * xi * xi + 39.1015625 * xi * xi * xi * xi + 12.03125 * xi * xi * xi -
+           9.0234375 * xi * xi - 0.546875 * xi + 0.2734375;
   }
 
   /**
    * @brief Gradient of basis function for support point 1.
    */
-  constexpr static double gradient1(const double xi)
-  {
-    return -109.076256003921 * xi * xi * xi * xi * xi * xi * xi +
-           85.8744542679408 * xi * xi * xi * xi * xi * xi +
-           130.10906638205 * xi * xi * xi * xi * xi -
-           97.5555606273084 * xi * xi * xi * xi -
-           35.4989469744781 * xi * xi * xi + 23.9553460267306 * xi * xi +
-           1.64884869420257 * xi - 0.741782397916255;
+  constexpr static double gradient1(const double xi) {
+    return -109.076256003921 * xi * xi * xi * xi * xi * xi * xi + 85.8744542679408 * xi * xi * xi * xi * xi * xi +
+           130.10906638205 * xi * xi * xi * xi * xi - 97.5555606273084 * xi * xi * xi * xi -
+           35.4989469744781 * xi * xi * xi + 23.9553460267306 * xi * xi + 1.64884869420257 * xi - 0.741782397916255;
   }
 
   /**
    * @brief Gradient of basis function for support point 2.
    */
-  constexpr static double gradient2(const double xi)
-  {
-    return 140.48795987563 * xi * xi * xi * xi * xi * xi * xi -
-           83.2444540062024 * xi * xi * xi * xi * xi * xi -
-           204.559468834679 * xi * xi * xi * xi * xi +
-           115.437388032374 * xi * xi * xi * xi +
-           73.6271611634532 * xi * xi * xi - 37.3944775044123 * xi * xi -
-           3.74908093907423 * xi + 1.26941308635815;
+  constexpr static double gradient2(const double xi) {
+    return 140.48795987563 * xi * xi * xi * xi * xi * xi * xi - 83.2444540062024 * xi * xi * xi * xi * xi * xi -
+           204.559468834679 * xi * xi * xi * xi * xi + 115.437388032374 * xi * xi * xi * xi +
+           73.6271611634532 * xi * xi * xi - 37.3944775044123 * xi * xi - 3.74908093907423 * xi + 1.26941308635815;
   }
 
   /**
    * @brief Gradient of basis function for support point 3.
    */
-  constexpr static double gradient3(const double xi)
-  {
-    return -157.813489585994 * xi * xi * xi * xi * xi * xi * xi +
-           50.1417298340221 * xi * xi * xi * xi * xi * xi +
-           268.457991738343 * xi * xi * xi * xi * xi -
-           81.2348209199137 * xi * xi * xi * xi -
-           129.359464188975 * xi * xi * xi + 35.2295104186605 * xi * xi +
-           14.6471072448717 * xi - 2.65931021757392;
+  constexpr static double gradient3(const double xi) {
+    return -157.813489585994 * xi * xi * xi * xi * xi * xi * xi + 50.1417298340221 * xi * xi * xi * xi * xi * xi +
+           268.457991738343 * xi * xi * xi * xi * xi - 81.2348209199137 * xi * xi * xi * xi -
+           129.359464188975 * xi * xi * xi + 35.2295104186605 * xi * xi + 14.6471072448717 * xi - 2.65931021757392;
   }
 
   /**
    * @brief Gradient of basis function for support point 4 (centre node, odd
    * polynomial).
    */
-  constexpr static double gradient4(const double xi)
-  {
-    return 163.428571428571 * xi * xi * xi * xi * xi * xi * xi -
-           294.171428571428 * xi * xi * xi * xi * xi + 158.4 * xi * xi * xi -
-           24.0 * xi;
+  constexpr static double gradient4(const double xi) {
+    return 163.428571428571 * xi * xi * xi * xi * xi * xi * xi - 294.171428571428 * xi * xi * xi * xi * xi +
+           158.4 * xi * xi * xi - 24.0 * xi;
   }
 
   /**
    * @brief Gradient of basis function for support point 5.
    */
-  constexpr static double gradient5(const double xi)
-  {
-    return -157.813489585994 * xi * xi * xi * xi * xi * xi * xi -
-           50.1417298340221 * xi * xi * xi * xi * xi * xi +
-           268.457991738343 * xi * xi * xi * xi * xi +
-           81.2348209199137 * xi * xi * xi * xi -
-           129.359464188975 * xi * xi * xi - 35.2295104186605 * xi * xi +
-           14.6471072448717 * xi + 2.65931021757392;
+  constexpr static double gradient5(const double xi) {
+    return -157.813489585994 * xi * xi * xi * xi * xi * xi * xi - 50.1417298340221 * xi * xi * xi * xi * xi * xi +
+           268.457991738343 * xi * xi * xi * xi * xi + 81.2348209199137 * xi * xi * xi * xi -
+           129.359464188975 * xi * xi * xi - 35.2295104186605 * xi * xi + 14.6471072448717 * xi + 2.65931021757392;
   }
 
   /**
    * @brief Gradient of basis function for support point 6.
    */
-  constexpr static double gradient6(const double xi)
-  {
-    return 140.48795987563 * xi * xi * xi * xi * xi * xi * xi +
-           83.2444540062024 * xi * xi * xi * xi * xi * xi -
-           204.559468834679 * xi * xi * xi * xi * xi -
-           115.437388032374 * xi * xi * xi * xi +
-           73.6271611634532 * xi * xi * xi + 37.3944775044123 * xi * xi -
-           3.74908093907423 * xi - 1.26941308635815;
+  constexpr static double gradient6(const double xi) {
+    return 140.48795987563 * xi * xi * xi * xi * xi * xi * xi + 83.2444540062024 * xi * xi * xi * xi * xi * xi -
+           204.559468834679 * xi * xi * xi * xi * xi - 115.437388032374 * xi * xi * xi * xi +
+           73.6271611634532 * xi * xi * xi + 37.3944775044123 * xi * xi - 3.74908093907423 * xi - 1.26941308635815;
   }
 
   /**
    * @brief Gradient of basis function for support point 7.
    */
-  constexpr static double gradient7(const double xi)
-  {
-    return -109.076256003921 * xi * xi * xi * xi * xi * xi * xi -
-           85.8744542679408 * xi * xi * xi * xi * xi * xi +
-           130.10906638205 * xi * xi * xi * xi * xi +
-           97.5555606273084 * xi * xi * xi * xi -
-           35.4989469744781 * xi * xi * xi - 23.9553460267306 * xi * xi +
-           1.64884869420257 * xi + 0.741782397916255;
+  constexpr static double gradient7(const double xi) {
+    return -109.076256003921 * xi * xi * xi * xi * xi * xi * xi - 85.8744542679408 * xi * xi * xi * xi * xi * xi +
+           130.10906638205 * xi * xi * xi * xi * xi + 97.5555606273084 * xi * xi * xi * xi -
+           35.4989469744781 * xi * xi * xi - 23.9553460267306 * xi * xi + 1.64884869420257 * xi + 0.741782397916255;
   }
 
   /**
    * @brief Gradient of basis function for support point 8.
    */
-  constexpr static double gradient8(const double xi)
-  {
-    return 44.6875 * xi * xi * xi * xi * xi * xi * xi +
-           39.1015625 * xi * xi * xi * xi * xi * xi -
-           46.921875 * xi * xi * xi * xi * xi - 39.1015625 * xi * xi * xi * xi +
-           12.03125 * xi * xi * xi + 9.0234375 * xi * xi - 0.546875 * xi -
-           0.2734375;
+  constexpr static double gradient8(const double xi) {
+    return 44.6875 * xi * xi * xi * xi * xi * xi * xi + 39.1015625 * xi * xi * xi * xi * xi * xi -
+           46.921875 * xi * xi * xi * xi * xi - 39.1015625 * xi * xi * xi * xi + 12.03125 * xi * xi * xi +
+           9.0234375 * xi * xi - 0.546875 * xi - 0.2734375;
   }
 
   /**
@@ -376,13 +303,10 @@ class LagrangeBasis8GL
    * Anti-symmetry: gradientAt(q,p) == -gradientAt(8-q, 8-p).
    * Corner formulas: gradientAt(0,0) = -N*(N-1)/4 = -18, gradientAt(8,8) = +18.
    */
-  constexpr static double gradientAt(const int q, const int p)
-  {
-    switch (q)
-    {
+  constexpr static double gradientAt(const int q, const int p) {
+    switch (q) {
       case 0:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return -18.0000000000000000;
           case 1:
@@ -404,8 +328,7 @@ class LagrangeBasis8GL
         }
         break;
       case 1:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return 24.3497451715930495;
           case 1:
@@ -427,8 +350,7 @@ class LagrangeBasis8GL
         }
         break;
       case 2:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return -9.7387016572115428;
           case 1:
@@ -450,8 +372,7 @@ class LagrangeBasis8GL
         }
         break;
       case 3:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return 5.5449639069493628;
           case 1:
@@ -473,8 +394,7 @@ class LagrangeBasis8GL
         }
         break;
       case 4:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return -3.6571428571431284;
           case 1:
@@ -496,8 +416,7 @@ class LagrangeBasis8GL
         }
         break;
       case 5:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return 2.5907456765594290;
           case 1:
@@ -519,8 +438,7 @@ class LagrangeBasis8GL
         }
         break;
       case 6:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return -1.8744408734470359;
           case 1:
@@ -542,8 +460,7 @@ class LagrangeBasis8GL
         }
         break;
       case 7:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return 1.2848306326995953;
           case 1:
@@ -565,8 +482,7 @@ class LagrangeBasis8GL
         }
         break;
       case 8:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return -0.5;
           case 1:
@@ -592,74 +508,48 @@ class LagrangeBasis8GL
   }
 
   /* Tensor product helpers (2D / 3D) */
-  struct TensorProduct2D
-  {
-    constexpr static int numSupportPoints1D =
-        LagrangeBasis8GL::numSupportPoints;
-    constexpr static int numSupportPoints =
-        numSupportPoints1D * numSupportPoints1D;  // 9*9 = 81
+  struct TensorProduct2D {
+    constexpr static int numSupportPoints1D = LagrangeBasis8GL::numSupportPoints;
+    constexpr static int numSupportPoints = numSupportPoints1D * numSupportPoints1D;  // 9*9 = 81
 
-    constexpr static int linearIndex(const int i, const int j)
-    {
-      return i + numSupportPoints1D * j;
-    }
+    constexpr static int linearIndex(const int i, const int j) { return i + numSupportPoints1D * j; }
 
-    constexpr static void multiIndex(const int linearIndex, int& i0, int& i1)
-    {
+    constexpr static void multiIndex(const int linearIndex, int& i0, int& i1) {
       i1 = linearIndex / numSupportPoints1D;
       i0 = linearIndex % numSupportPoints1D;
     }
 
-    static void value(const double (&coords)[2], double (&N)[numSupportPoints])
-    {
-      for (int a = 0; a < LagrangeBasis8GL::numSupportPoints; ++a)
-      {
-        for (int b = 0; b < LagrangeBasis8GL::numSupportPoints; ++b)
-        {
+    static void value(const double (&coords)[2], double (&N)[numSupportPoints]) {
+      for (int a = 0; a < LagrangeBasis8GL::numSupportPoints; ++a) {
+        for (int b = 0; b < LagrangeBasis8GL::numSupportPoints; ++b) {
           const int lindex = a + LagrangeBasis8GL::numSupportPoints * b;
-          N[lindex] = LagrangeBasis8GL::value(a, coords[0]) *
-                      LagrangeBasis8GL::value(b, coords[1]);
+          N[lindex] = LagrangeBasis8GL::value(a, coords[0]) * LagrangeBasis8GL::value(b, coords[1]);
         }
       }
     }
   };
 
-  struct TensorProduct3D
-  {
-    constexpr static int numSupportPoints1D =
-        LagrangeBasis8GL::numSupportPoints;
-    constexpr static int numSupportPoints = numSupportPoints1D *
-                                            numSupportPoints1D *
-                                            numSupportPoints1D;  // 9^3 = 729
+  struct TensorProduct3D {
+    constexpr static int numSupportPoints1D = LagrangeBasis8GL::numSupportPoints;
+    constexpr static int numSupportPoints = numSupportPoints1D * numSupportPoints1D * numSupportPoints1D;  // 9^3 = 729
 
-    constexpr static int linearIndex(const int i, const int j, const int k)
-    {
-      return i + numSupportPoints1D * j +
-             numSupportPoints1D * numSupportPoints1D * k;
+    constexpr static int linearIndex(const int i, const int j, const int k) {
+      return i + numSupportPoints1D * j + numSupportPoints1D * numSupportPoints1D * k;
     }
 
-    constexpr static void multiIndex(const int linearIndex, int& i0, int& i1,
-                                     int& i2)
-    {
+    constexpr static void multiIndex(const int linearIndex, int& i0, int& i1, int& i2) {
       i2 = linearIndex / (numSupportPoints1D * numSupportPoints1D);
-      i1 = (linearIndex % (numSupportPoints1D * numSupportPoints1D)) /
-           numSupportPoints1D;
+      i1 = (linearIndex % (numSupportPoints1D * numSupportPoints1D)) / numSupportPoints1D;
       i0 = linearIndex % numSupportPoints1D;
     }
 
-    static void value(const double (&coords)[3], double (&N)[numSupportPoints])
-    {
-      for (int a = 0; a < LagrangeBasis8GL::numSupportPoints; ++a)
-      {
-        for (int b = 0; b < LagrangeBasis8GL::numSupportPoints; ++b)
-        {
-          for (int c = 0; c < LagrangeBasis8GL::numSupportPoints; ++c)
-          {
+    static void value(const double (&coords)[3], double (&N)[numSupportPoints]) {
+      for (int a = 0; a < LagrangeBasis8GL::numSupportPoints; ++a) {
+        for (int b = 0; b < LagrangeBasis8GL::numSupportPoints; ++b) {
+          for (int c = 0; c < LagrangeBasis8GL::numSupportPoints; ++c) {
             const int lindex = a + LagrangeBasis8GL::numSupportPoints * b +
-                               LagrangeBasis8GL::numSupportPoints *
-                                   LagrangeBasis8GL::numSupportPoints * c;
-            N[lindex] = LagrangeBasis8GL::value(a, coords[0]) *
-                        LagrangeBasis8GL::value(b, coords[1]) *
+                               LagrangeBasis8GL::numSupportPoints * LagrangeBasis8GL::numSupportPoints * c;
+            N[lindex] = LagrangeBasis8GL::value(a, coords[0]) * LagrangeBasis8GL::value(b, coords[1]) *
                         LagrangeBasis8GL::value(c, coords[2]);
           }
         }

--- a/src/discretization/fe/makutu/include/LagrangeBasis9GL.h
+++ b/src/discretization/fe/makutu/include/LagrangeBasis9GL.h
@@ -15,8 +15,7 @@
  *   lambda3 = 0.4779249498104445
  *   lambda4 = 0.1652789576663870
  */
-class LagrangeBasis9GL
-{
+class LagrangeBasis9GL {
  public:
   constexpr static int numSupportPoints = 10;
 
@@ -35,10 +34,8 @@ class LagrangeBasis9GL
   /**
    * @brief GLL quadrature weight for node q.
    */
-  constexpr static double weight(const int q)
-  {
-    switch (q)
-    {
+  constexpr static double weight(const int q) {
+    switch (q) {
       case 1:
       case 8:
         return 0.1333059908510701;
@@ -59,10 +56,8 @@ class LagrangeBasis9GL
   /**
    * @brief Parent coordinate of support point @p supportPointIndex.
    */
-  constexpr static double parentSupportCoord(const int supportPointIndex)
-  {
-    switch (supportPointIndex)
-    {
+  constexpr static double parentSupportCoord(const int supportPointIndex) {
+    switch (supportPointIndex) {
       case 0:
         return -1.0;
       case 1:
@@ -91,10 +86,8 @@ class LagrangeBasis9GL
   /**
    * @brief Value of basis function @p index at @p xi.
    */
-  constexpr static double value(const int index, const double xi)
-  {
-    switch (index)
-    {
+  constexpr static double value(const int index, const double xi) {
+    switch (index) {
       case 0:
         return value0(xi);
       case 1:
@@ -123,158 +116,116 @@ class LagrangeBasis9GL
   /**
    * @brief Basis function for support point 0.
    */
-  constexpr static double value0(const double xi)
-  {
+  constexpr static double value0(const double xi) {
     return -9.49609375 * xi * xi * xi * xi * xi * xi * xi * xi * xi +
-           9.49609375 * xi * xi * xi * xi * xi * xi * xi * xi +
-           15.640625 * xi * xi * xi * xi * xi * xi * xi -
-           15.640625 * xi * xi * xi * xi * xi * xi -
-           7.8203125 * xi * xi * xi * xi * xi + 7.8203125 * xi * xi * xi * xi +
-           1.203125 * xi * xi * xi - 1.203125 * xi * xi - 0.02734375 * xi +
-           0.02734375;
+           9.49609375 * xi * xi * xi * xi * xi * xi * xi * xi + 15.640625 * xi * xi * xi * xi * xi * xi * xi -
+           15.640625 * xi * xi * xi * xi * xi * xi - 7.8203125 * xi * xi * xi * xi * xi +
+           7.8203125 * xi * xi * xi * xi + 1.203125 * xi * xi * xi - 1.203125 * xi * xi - 0.02734375 * xi + 0.02734375;
   }
 
   /**
    * @brief Basis function for support point 1.
    */
-  constexpr static double value1(const double xi)
-  {
+  constexpr static double value1(const double xi) {
     return 23.2581991069276 * xi * xi * xi * xi * xi * xi * xi * xi * xi -
            21.3867027217068 * xi * xi * xi * xi * xi * xi * xi * xi -
-           41.9000228289113 * xi * xi * xi * xi * xi * xi * xi +
-           38.5284917441326 * xi * xi * xi * xi * xi * xi +
-           22.033178498462 * xi * xi * xi * xi * xi -
-           20.26025473402 * xi * xi * xi * xi -
-           3.47055997155687 * xi * xi * xi + 3.19129757417176 * xi * xi +
-           0.0792051950785524 * xi - 0.0728318625776681;
+           41.9000228289113 * xi * xi * xi * xi * xi * xi * xi + 38.5284917441326 * xi * xi * xi * xi * xi * xi +
+           22.033178498462 * xi * xi * xi * xi * xi - 20.26025473402 * xi * xi * xi * xi -
+           3.47055997155687 * xi * xi * xi + 3.19129757417176 * xi * xi + 0.0792051950785524 * xi - 0.0728318625776681;
   }
 
   /**
    * @brief Basis function for support point 2.
    */
-  constexpr static double value2(const double xi)
-  {
+  constexpr static double value2(const double xi) {
     return -30.2089539641742 * xi * xi * xi * xi * xi * xi * xi * xi * xi +
            22.3175856809073 * xi * xi * xi * xi * xi * xi * xi * xi +
-           63.4772291071541 * xi * xi * xi * xi * xi * xi * xi -
-           46.8953178936799 * xi * xi * xi * xi * xi * xi -
-           39.9888510087652 * xi * xi * xi * xi * xi +
-           29.5427180208736 * xi * xi * xi * xi +
-           6.87995289293189 * xi * xi * xi - 5.0827293904551 * xi * xi -
-           0.159377027146516 * xi + 0.117743582354057;
+           63.4772291071541 * xi * xi * xi * xi * xi * xi * xi - 46.8953178936799 * xi * xi * xi * xi * xi * xi -
+           39.9888510087652 * xi * xi * xi * xi * xi + 29.5427180208736 * xi * xi * xi * xi +
+           6.87995289293189 * xi * xi * xi - 5.0827293904551 * xi * xi - 0.159377027146516 * xi + 0.117743582354057;
   }
 
   /**
    * @brief Basis function for support point 3.
    */
-  constexpr static double value3(const double xi)
-  {
+  constexpr static double value3(const double xi) {
     return 34.4250370034963 * xi * xi * xi * xi * xi * xi * xi * xi * xi -
            16.4525840821186 * xi * xi * xi * xi * xi * xi * xi * xi -
-           83.2619975287327 * xi * xi * xi * xi * xi * xi * xi +
-           39.7929859900369 * xi * xi * xi * xi * xi * xi +
-           66.0320305883065 * xi * xi * xi * xi * xi -
-           31.5583549047981 * xi * xi * xi * xi -
-           17.629048439256 * xi * xi * xi + 8.42536209053729 * xi * xi +
-           0.433978376185841 * xi - 0.207409093657436;
+           83.2619975287327 * xi * xi * xi * xi * xi * xi * xi + 39.7929859900369 * xi * xi * xi * xi * xi * xi +
+           66.0320305883065 * xi * xi * xi * xi * xi - 31.5583549047981 * xi * xi * xi * xi -
+           17.629048439256 * xi * xi * xi + 8.42536209053729 * xi * xi + 0.433978376185841 * xi - 0.207409093657436;
   }
 
   /**
    * @brief Basis function for support point 4.
    */
-  constexpr static double value4(const double xi)
-  {
+  constexpr static double value4(const double xi) {
     return -36.457196112531 * xi * xi * xi * xi * xi * xi * xi * xi * xi +
            6.02560737291818 * xi * xi * xi * xi * xi * xi * xi * xi +
-           95.5084365449144 * xi * xi * xi * xi * xi * xi * xi -
-           15.7855348404897 * xi * xi * xi * xi * xi * xi -
-           87.4617030627869 * xi * xi * xi * xi * xi +
-           14.4555791179445 * xi * xi * xi * xi +
-           32.2533814922412 * xi * xi * xi - 5.33080527425396 * xi * xi -
-           3.84291886183778 * xi + 0.635153623881047;
+           95.5084365449144 * xi * xi * xi * xi * xi * xi * xi - 15.7855348404897 * xi * xi * xi * xi * xi * xi -
+           87.4617030627869 * xi * xi * xi * xi * xi + 14.4555791179445 * xi * xi * xi * xi +
+           32.2533814922412 * xi * xi * xi - 5.33080527425396 * xi * xi - 3.84291886183778 * xi + 0.635153623881047;
   }
 
   /**
    * @brief Basis function for support point 5.
    */
-  constexpr static double value5(const double xi)
-  {
+  constexpr static double value5(const double xi) {
     return 36.457196112531 * xi * xi * xi * xi * xi * xi * xi * xi * xi +
            6.02560737291818 * xi * xi * xi * xi * xi * xi * xi * xi -
-           95.5084365449144 * xi * xi * xi * xi * xi * xi * xi -
-           15.7855348404897 * xi * xi * xi * xi * xi * xi +
-           87.4617030627869 * xi * xi * xi * xi * xi +
-           14.4555791179445 * xi * xi * xi * xi -
-           32.2533814922412 * xi * xi * xi - 5.33080527425395 * xi * xi +
-           3.84291886183778 * xi + 0.635153623881047;
+           95.5084365449144 * xi * xi * xi * xi * xi * xi * xi - 15.7855348404897 * xi * xi * xi * xi * xi * xi +
+           87.4617030627869 * xi * xi * xi * xi * xi + 14.4555791179445 * xi * xi * xi * xi -
+           32.2533814922412 * xi * xi * xi - 5.33080527425395 * xi * xi + 3.84291886183778 * xi + 0.635153623881047;
   }
 
   /**
    * @brief Basis function for support point 6.
    */
-  constexpr static double value6(const double xi)
-  {
+  constexpr static double value6(const double xi) {
     return -34.4250370034963 * xi * xi * xi * xi * xi * xi * xi * xi * xi -
            16.4525840821186 * xi * xi * xi * xi * xi * xi * xi * xi +
-           83.2619975287328 * xi * xi * xi * xi * xi * xi * xi +
-           39.7929859900369 * xi * xi * xi * xi * xi * xi -
-           66.0320305883065 * xi * xi * xi * xi * xi -
-           31.5583549047981 * xi * xi * xi * xi +
-           17.629048439256 * xi * xi * xi + 8.4253620905373 * xi * xi -
-           0.433978376185841 * xi - 0.207409093657436;
+           83.2619975287328 * xi * xi * xi * xi * xi * xi * xi + 39.7929859900369 * xi * xi * xi * xi * xi * xi -
+           66.0320305883065 * xi * xi * xi * xi * xi - 31.5583549047981 * xi * xi * xi * xi +
+           17.629048439256 * xi * xi * xi + 8.4253620905373 * xi * xi - 0.433978376185841 * xi - 0.207409093657436;
   }
 
   /**
    * @brief Basis function for support point 7.
    */
-  constexpr static double value7(const double xi)
-  {
+  constexpr static double value7(const double xi) {
     return 30.2089539641742 * xi * xi * xi * xi * xi * xi * xi * xi * xi +
            22.3175856809073 * xi * xi * xi * xi * xi * xi * xi * xi -
-           63.4772291071541 * xi * xi * xi * xi * xi * xi * xi -
-           46.8953178936799 * xi * xi * xi * xi * xi * xi +
-           39.9888510087652 * xi * xi * xi * xi * xi +
-           29.5427180208736 * xi * xi * xi * xi -
-           6.87995289293189 * xi * xi * xi - 5.0827293904551 * xi * xi +
-           0.159377027146516 * xi + 0.117743582354057;
+           63.4772291071541 * xi * xi * xi * xi * xi * xi * xi - 46.8953178936799 * xi * xi * xi * xi * xi * xi +
+           39.9888510087652 * xi * xi * xi * xi * xi + 29.5427180208736 * xi * xi * xi * xi -
+           6.87995289293189 * xi * xi * xi - 5.0827293904551 * xi * xi + 0.159377027146516 * xi + 0.117743582354057;
   }
 
   /**
    * @brief Basis function for support point 8.
    */
-  constexpr static double value8(const double xi)
-  {
+  constexpr static double value8(const double xi) {
     return -23.2581991069276 * xi * xi * xi * xi * xi * xi * xi * xi * xi -
            21.3867027217068 * xi * xi * xi * xi * xi * xi * xi * xi +
-           41.9000228289113 * xi * xi * xi * xi * xi * xi * xi +
-           38.5284917441326 * xi * xi * xi * xi * xi * xi -
-           22.033178498462 * xi * xi * xi * xi * xi -
-           20.26025473402 * xi * xi * xi * xi +
-           3.47055997155687 * xi * xi * xi + 3.19129757417176 * xi * xi -
-           0.0792051950785524 * xi - 0.0728318625776681;
+           41.9000228289113 * xi * xi * xi * xi * xi * xi * xi + 38.5284917441326 * xi * xi * xi * xi * xi * xi -
+           22.033178498462 * xi * xi * xi * xi * xi - 20.26025473402 * xi * xi * xi * xi +
+           3.47055997155687 * xi * xi * xi + 3.19129757417176 * xi * xi - 0.0792051950785524 * xi - 0.0728318625776681;
   }
 
   /**
    * @brief Basis function for support point 9.
    */
-  constexpr static double value9(const double xi)
-  {
+  constexpr static double value9(const double xi) {
     return 9.49609375 * xi * xi * xi * xi * xi * xi * xi * xi * xi +
-           9.49609375 * xi * xi * xi * xi * xi * xi * xi * xi -
-           15.640625 * xi * xi * xi * xi * xi * xi * xi -
-           15.640625 * xi * xi * xi * xi * xi * xi +
-           7.8203125 * xi * xi * xi * xi * xi + 7.8203125 * xi * xi * xi * xi -
-           1.203125 * xi * xi * xi - 1.203125 * xi * xi + 0.02734375 * xi +
-           0.02734375;
+           9.49609375 * xi * xi * xi * xi * xi * xi * xi * xi - 15.640625 * xi * xi * xi * xi * xi * xi * xi -
+           15.640625 * xi * xi * xi * xi * xi * xi + 7.8203125 * xi * xi * xi * xi * xi +
+           7.8203125 * xi * xi * xi * xi - 1.203125 * xi * xi * xi - 1.203125 * xi * xi + 0.02734375 * xi + 0.02734375;
   }
 
   /**
    * @brief Gradient of basis function @p index at @p xi.
    */
-  constexpr static double gradient(const int index, const double xi)
-  {
-    switch (index)
-    {
+  constexpr static double gradient(const int index, const double xi) {
+    switch (index) {
       case 0:
         return gradient0(xi);
       case 1:
@@ -303,139 +254,99 @@ class LagrangeBasis9GL
   /**
    * @brief Gradient of basis function for support point 0.
    */
-  constexpr static double gradient0(const double xi)
-  {
-    return -85.46484375 * xi * xi * xi * xi * xi * xi * xi * xi +
-           75.96875 * xi * xi * xi * xi * xi * xi * xi +
-           109.484375 * xi * xi * xi * xi * xi * xi -
-           93.84375 * xi * xi * xi * xi * xi - 39.1015625 * xi * xi * xi * xi +
-           31.28125 * xi * xi * xi + 3.609375 * xi * xi - 2.40625 * xi -
-           0.02734375;
+  constexpr static double gradient0(const double xi) {
+    return -85.46484375 * xi * xi * xi * xi * xi * xi * xi * xi + 75.96875 * xi * xi * xi * xi * xi * xi * xi +
+           109.484375 * xi * xi * xi * xi * xi * xi - 93.84375 * xi * xi * xi * xi * xi -
+           39.1015625 * xi * xi * xi * xi + 31.28125 * xi * xi * xi + 3.609375 * xi * xi - 2.40625 * xi - 0.02734375;
   }
 
   /**
    * @brief Gradient of basis function for support point 1.
    */
-  constexpr static double gradient1(const double xi)
-  {
+  constexpr static double gradient1(const double xi) {
     return 209.323791962348 * xi * xi * xi * xi * xi * xi * xi * xi -
-           171.093621773654 * xi * xi * xi * xi * xi * xi * xi -
-           293.300159802379 * xi * xi * xi * xi * xi * xi +
-           231.170950464796 * xi * xi * xi * xi * xi +
-           110.16589249231 * xi * xi * xi * xi -
-           81.0410189360798 * xi * xi * xi - 10.4116799146706 * xi * xi +
-           6.38259514834352 * xi + 0.0792051950785524;
+           171.093621773654 * xi * xi * xi * xi * xi * xi * xi - 293.300159802379 * xi * xi * xi * xi * xi * xi +
+           231.170950464796 * xi * xi * xi * xi * xi + 110.16589249231 * xi * xi * xi * xi -
+           81.0410189360798 * xi * xi * xi - 10.4116799146706 * xi * xi + 6.38259514834352 * xi + 0.0792051950785524;
   }
 
   /**
    * @brief Gradient of basis function for support point 2.
    */
-  constexpr static double gradient2(const double xi)
-  {
+  constexpr static double gradient2(const double xi) {
     return -271.880585677568 * xi * xi * xi * xi * xi * xi * xi * xi +
-           178.540685447258 * xi * xi * xi * xi * xi * xi * xi +
-           444.340603750078 * xi * xi * xi * xi * xi * xi -
-           281.371907362079 * xi * xi * xi * xi * xi -
-           199.944255043826 * xi * xi * xi * xi +
-           118.170872083495 * xi * xi * xi + 20.6398586787957 * xi * xi -
-           10.1654587809102 * xi - 0.159377027146516;
+           178.540685447258 * xi * xi * xi * xi * xi * xi * xi + 444.340603750078 * xi * xi * xi * xi * xi * xi -
+           281.371907362079 * xi * xi * xi * xi * xi - 199.944255043826 * xi * xi * xi * xi +
+           118.170872083495 * xi * xi * xi + 20.6398586787957 * xi * xi - 10.1654587809102 * xi - 0.159377027146516;
   }
 
   /**
    * @brief Gradient of basis function for support point 3.
    */
-  constexpr static double gradient3(const double xi)
-  {
+  constexpr static double gradient3(const double xi) {
     return 309.825333031467 * xi * xi * xi * xi * xi * xi * xi * xi -
-           131.620672656949 * xi * xi * xi * xi * xi * xi * xi -
-           582.833982701129 * xi * xi * xi * xi * xi * xi +
-           238.757915940222 * xi * xi * xi * xi * xi +
-           330.160152941533 * xi * xi * xi * xi -
-           126.233419619193 * xi * xi * xi - 52.8871453177679 * xi * xi +
-           16.8507241810746 * xi + 0.433978376185841;
+           131.620672656949 * xi * xi * xi * xi * xi * xi * xi - 582.833982701129 * xi * xi * xi * xi * xi * xi +
+           238.757915940222 * xi * xi * xi * xi * xi + 330.160152941533 * xi * xi * xi * xi -
+           126.233419619193 * xi * xi * xi - 52.8871453177679 * xi * xi + 16.8507241810746 * xi + 0.433978376185841;
   }
 
   /**
    * @brief Gradient of basis function for support point 4.
    */
-  constexpr static double gradient4(const double xi)
-  {
+  constexpr static double gradient4(const double xi) {
     return -328.114765012779 * xi * xi * xi * xi * xi * xi * xi * xi +
-           48.2048589833454 * xi * xi * xi * xi * xi * xi * xi +
-           668.559055814401 * xi * xi * xi * xi * xi * xi -
-           94.7132090429383 * xi * xi * xi * xi * xi -
-           437.308515313934 * xi * xi * xi * xi +
-           57.8223164717778 * xi * xi * xi + 96.7601444767235 * xi * xi -
-           10.6616105485079 * xi - 3.84291886183778;
+           48.2048589833454 * xi * xi * xi * xi * xi * xi * xi + 668.559055814401 * xi * xi * xi * xi * xi * xi -
+           94.7132090429383 * xi * xi * xi * xi * xi - 437.308515313934 * xi * xi * xi * xi +
+           57.8223164717778 * xi * xi * xi + 96.7601444767235 * xi * xi - 10.6616105485079 * xi - 3.84291886183778;
   }
 
   /**
    * @brief Gradient of basis function for support point 5.
    */
-  constexpr static double gradient5(const double xi)
-  {
+  constexpr static double gradient5(const double xi) {
     return 328.114765012779 * xi * xi * xi * xi * xi * xi * xi * xi +
-           48.2048589833454 * xi * xi * xi * xi * xi * xi * xi -
-           668.559055814401 * xi * xi * xi * xi * xi * xi -
-           94.7132090429383 * xi * xi * xi * xi * xi +
-           437.308515313934 * xi * xi * xi * xi +
-           57.8223164717778 * xi * xi * xi - 96.7601444767235 * xi * xi -
-           10.6616105485079 * xi + 3.84291886183778;
+           48.2048589833454 * xi * xi * xi * xi * xi * xi * xi - 668.559055814401 * xi * xi * xi * xi * xi * xi -
+           94.7132090429383 * xi * xi * xi * xi * xi + 437.308515313934 * xi * xi * xi * xi +
+           57.8223164717778 * xi * xi * xi - 96.7601444767235 * xi * xi - 10.6616105485079 * xi + 3.84291886183778;
   }
 
   /**
    * @brief Gradient of basis function for support point 6.
    */
-  constexpr static double gradient6(const double xi)
-  {
+  constexpr static double gradient6(const double xi) {
     return -309.825333031467 * xi * xi * xi * xi * xi * xi * xi * xi -
-           131.620672656949 * xi * xi * xi * xi * xi * xi * xi +
-           582.833982701129 * xi * xi * xi * xi * xi * xi +
-           238.757915940221 * xi * xi * xi * xi * xi -
-           330.160152941533 * xi * xi * xi * xi -
-           126.233419619193 * xi * xi * xi + 52.8871453177679 * xi * xi +
-           16.8507241810746 * xi - 0.433978376185841;
+           131.620672656949 * xi * xi * xi * xi * xi * xi * xi + 582.833982701129 * xi * xi * xi * xi * xi * xi +
+           238.757915940221 * xi * xi * xi * xi * xi - 330.160152941533 * xi * xi * xi * xi -
+           126.233419619193 * xi * xi * xi + 52.8871453177679 * xi * xi + 16.8507241810746 * xi - 0.433978376185841;
   }
 
   /**
    * @brief Gradient of basis function for support point 7.
    */
-  constexpr static double gradient7(const double xi)
-  {
+  constexpr static double gradient7(const double xi) {
     return 271.880585677568 * xi * xi * xi * xi * xi * xi * xi * xi +
-           178.540685447258 * xi * xi * xi * xi * xi * xi * xi -
-           444.340603750078 * xi * xi * xi * xi * xi * xi -
-           281.371907362079 * xi * xi * xi * xi * xi +
-           199.944255043826 * xi * xi * xi * xi +
-           118.170872083495 * xi * xi * xi - 20.6398586787957 * xi * xi -
-           10.1654587809102 * xi + 0.159377027146516;
+           178.540685447258 * xi * xi * xi * xi * xi * xi * xi - 444.340603750078 * xi * xi * xi * xi * xi * xi -
+           281.371907362079 * xi * xi * xi * xi * xi + 199.944255043826 * xi * xi * xi * xi +
+           118.170872083495 * xi * xi * xi - 20.6398586787957 * xi * xi - 10.1654587809102 * xi + 0.159377027146516;
   }
 
   /**
    * @brief Gradient of basis function for support point 8.
    */
-  constexpr static double gradient8(const double xi)
-  {
+  constexpr static double gradient8(const double xi) {
     return -209.323791962348 * xi * xi * xi * xi * xi * xi * xi * xi -
-           171.093621773654 * xi * xi * xi * xi * xi * xi * xi +
-           293.300159802379 * xi * xi * xi * xi * xi * xi +
-           231.170950464796 * xi * xi * xi * xi * xi -
-           110.16589249231 * xi * xi * xi * xi -
-           81.0410189360798 * xi * xi * xi + 10.4116799146706 * xi * xi +
-           6.38259514834352 * xi - 0.0792051950785524;
+           171.093621773654 * xi * xi * xi * xi * xi * xi * xi + 293.300159802379 * xi * xi * xi * xi * xi * xi +
+           231.170950464796 * xi * xi * xi * xi * xi - 110.16589249231 * xi * xi * xi * xi -
+           81.0410189360798 * xi * xi * xi + 10.4116799146706 * xi * xi + 6.38259514834352 * xi - 0.0792051950785524;
   }
 
   /**
    * @brief Gradient of basis function for support point 9.
    */
-  constexpr static double gradient9(const double xi)
-  {
-    return 85.46484375 * xi * xi * xi * xi * xi * xi * xi * xi +
-           75.96875 * xi * xi * xi * xi * xi * xi * xi -
-           109.484375 * xi * xi * xi * xi * xi * xi -
-           93.84375 * xi * xi * xi * xi * xi + 39.1015625 * xi * xi * xi * xi +
-           31.28125 * xi * xi * xi - 3.609375 * xi * xi - 2.40625 * xi +
-           0.02734375;
+  constexpr static double gradient9(const double xi) {
+    return 85.46484375 * xi * xi * xi * xi * xi * xi * xi * xi + 75.96875 * xi * xi * xi * xi * xi * xi * xi -
+           109.484375 * xi * xi * xi * xi * xi * xi - 93.84375 * xi * xi * xi * xi * xi +
+           39.1015625 * xi * xi * xi * xi + 31.28125 * xi * xi * xi - 3.609375 * xi * xi - 2.40625 * xi + 0.02734375;
   }
 
   /**
@@ -445,13 +356,10 @@ class LagrangeBasis9GL
    * Corner formulas: gradientAt(0,0) = -N*(N-1)/4 = -22.5, gradientAt(9,9) =
    * +22.5.
    */
-  constexpr static double gradientAt(const int q, const int p)
-  {
-    switch (q)
-    {
+  constexpr static double gradientAt(const int q, const int p) {
+    switch (q) {
       case 0:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return -22.5;
           case 1:
@@ -475,8 +383,7 @@ class LagrangeBasis9GL
         }
         break;
       case 1:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return 30.4381450292821043;
           case 1:
@@ -500,8 +407,7 @@ class LagrangeBasis9GL
         }
         break;
       case 2:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return -12.1779467074297827;
           case 1:
@@ -525,8 +431,7 @@ class LagrangeBasis9GL
         }
         break;
       case 3:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return 6.9437884851340499;
           case 1:
@@ -550,8 +455,7 @@ class LagrangeBasis9GL
         }
         break;
       case 4:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return -4.5993547611031005;
           case 1:
@@ -575,8 +479,7 @@ class LagrangeBasis9GL
         }
         break;
       case 5:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return 3.2946430337492529;
           case 1:
@@ -600,8 +503,7 @@ class LagrangeBasis9GL
         }
         break;
       case 6:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return -2.4528841754425912;
           case 1:
@@ -625,8 +527,7 @@ class LagrangeBasis9GL
         }
         break;
       case 7:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return 1.8295639319031682;
           case 1:
@@ -650,8 +551,7 @@ class LagrangeBasis9GL
         }
         break;
       case 8:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return -1.2759548360924953;
           case 1:
@@ -675,8 +575,7 @@ class LagrangeBasis9GL
         }
         break;
       case 9:
-        switch (p)
-        {
+        switch (p) {
           case 0:
             return 0.5;
           case 1:
@@ -704,74 +603,49 @@ class LagrangeBasis9GL
   }
 
   /* Tensor product helpers (2D / 3D) */
-  struct TensorProduct2D
-  {
-    constexpr static int numSupportPoints1D =
-        LagrangeBasis9GL::numSupportPoints;
-    constexpr static int numSupportPoints =
-        numSupportPoints1D * numSupportPoints1D;  // 10*10 = 100
+  struct TensorProduct2D {
+    constexpr static int numSupportPoints1D = LagrangeBasis9GL::numSupportPoints;
+    constexpr static int numSupportPoints = numSupportPoints1D * numSupportPoints1D;  // 10*10 = 100
 
-    constexpr static int linearIndex(const int i, const int j)
-    {
-      return i + numSupportPoints1D * j;
-    }
+    constexpr static int linearIndex(const int i, const int j) { return i + numSupportPoints1D * j; }
 
-    constexpr static void multiIndex(const int linearIndex, int& i0, int& i1)
-    {
+    constexpr static void multiIndex(const int linearIndex, int& i0, int& i1) {
       i1 = linearIndex / numSupportPoints1D;
       i0 = linearIndex % numSupportPoints1D;
     }
 
-    static void value(const double (&coords)[2], double (&N)[numSupportPoints])
-    {
-      for (int a = 0; a < LagrangeBasis9GL::numSupportPoints; ++a)
-      {
-        for (int b = 0; b < LagrangeBasis9GL::numSupportPoints; ++b)
-        {
+    static void value(const double (&coords)[2], double (&N)[numSupportPoints]) {
+      for (int a = 0; a < LagrangeBasis9GL::numSupportPoints; ++a) {
+        for (int b = 0; b < LagrangeBasis9GL::numSupportPoints; ++b) {
           const int lindex = a + LagrangeBasis9GL::numSupportPoints * b;
-          N[lindex] = LagrangeBasis9GL::value(a, coords[0]) *
-                      LagrangeBasis9GL::value(b, coords[1]);
+          N[lindex] = LagrangeBasis9GL::value(a, coords[0]) * LagrangeBasis9GL::value(b, coords[1]);
         }
       }
     }
   };
 
-  struct TensorProduct3D
-  {
-    constexpr static int numSupportPoints1D =
-        LagrangeBasis9GL::numSupportPoints;
-    constexpr static int numSupportPoints = numSupportPoints1D *
-                                            numSupportPoints1D *
-                                            numSupportPoints1D;  // 10^3 = 1000
+  struct TensorProduct3D {
+    constexpr static int numSupportPoints1D = LagrangeBasis9GL::numSupportPoints;
+    constexpr static int numSupportPoints =
+        numSupportPoints1D * numSupportPoints1D * numSupportPoints1D;  // 10^3 = 1000
 
-    constexpr static int linearIndex(const int i, const int j, const int k)
-    {
-      return i + numSupportPoints1D * j +
-             numSupportPoints1D * numSupportPoints1D * k;
+    constexpr static int linearIndex(const int i, const int j, const int k) {
+      return i + numSupportPoints1D * j + numSupportPoints1D * numSupportPoints1D * k;
     }
 
-    constexpr static void multiIndex(const int linearIndex, int& i0, int& i1,
-                                     int& i2)
-    {
+    constexpr static void multiIndex(const int linearIndex, int& i0, int& i1, int& i2) {
       i2 = linearIndex / (numSupportPoints1D * numSupportPoints1D);
-      i1 = (linearIndex % (numSupportPoints1D * numSupportPoints1D)) /
-           numSupportPoints1D;
+      i1 = (linearIndex % (numSupportPoints1D * numSupportPoints1D)) / numSupportPoints1D;
       i0 = linearIndex % numSupportPoints1D;
     }
 
-    static void value(const double (&coords)[3], double (&N)[numSupportPoints])
-    {
-      for (int a = 0; a < LagrangeBasis9GL::numSupportPoints; ++a)
-      {
-        for (int b = 0; b < LagrangeBasis9GL::numSupportPoints; ++b)
-        {
-          for (int c = 0; c < LagrangeBasis9GL::numSupportPoints; ++c)
-          {
+    static void value(const double (&coords)[3], double (&N)[numSupportPoints]) {
+      for (int a = 0; a < LagrangeBasis9GL::numSupportPoints; ++a) {
+        for (int b = 0; b < LagrangeBasis9GL::numSupportPoints; ++b) {
+          for (int c = 0; c < LagrangeBasis9GL::numSupportPoints; ++c) {
             const int lindex = a + LagrangeBasis9GL::numSupportPoints * b +
-                               LagrangeBasis9GL::numSupportPoints *
-                                   LagrangeBasis9GL::numSupportPoints * c;
-            N[lindex] = LagrangeBasis9GL::value(a, coords[0]) *
-                        LagrangeBasis9GL::value(b, coords[1]) *
+                               LagrangeBasis9GL::numSupportPoints * LagrangeBasis9GL::numSupportPoints * c;
+            N[lindex] = LagrangeBasis9GL::value(a, coords[0]) * LagrangeBasis9GL::value(b, coords[1]) *
                         LagrangeBasis9GL::value(c, coords[2]);
           }
         }

--- a/src/discretization/fe/makutu/include/Qk_Hexahedron_Lagrange_GaussLobatto.h
+++ b/src/discretization/fe/makutu/include/Qk_Hexahedron_Lagrange_GaussLobatto.h
@@ -25,8 +25,7 @@
  * this file.
  */
 template <typename GL_BASIS>
-class Qk_Hexahedron_Lagrange_GaussLobatto final
-{
+class Qk_Hexahedron_Lagrange_GaussLobatto final {
  public:
   // Expose the basis type for tests and external use
   using BasisType = GL_BASIS;
@@ -42,8 +41,7 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
   constexpr static int numNodes = GL_BASIS::TensorProduct3D::numSupportPoints;
 
   /// The number of nodes/support points per face
-  constexpr static int numNodesPerFace =
-      GL_BASIS::TensorProduct2D::numSupportPoints;
+  constexpr static int numNodesPerFace = GL_BASIS::TensorProduct2D::numSupportPoints;
 
   /// The maximum number of support points per element.
   constexpr static int maxSupportPoints = numNodes;
@@ -51,13 +49,11 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
   /// The number of quadrature points per element.
   constexpr static int numQuadraturePoints = numNodes;
 
-  struct TransformType
-  {
+  struct TransformType {
     float data[8][3];
   };
 
-  struct JacobianType
-  {
+  struct JacobianType {
     float data[3][3];
   };
 
@@ -70,9 +66,7 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    * @return The linear index in 3D
    */
   PROXY_HOST_DEVICE
-  constexpr static int linearIndex3DVal(const int qa, int const qb,
-                                        int const qc)
-  {
+  constexpr static int linearIndex3DVal(const int qa, int const qb, int const qc) {
     return qa + qb * num1dNodes + qc * numNodesPerFace;
   }
 
@@ -83,11 +77,8 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    * @return The linear index in 3D
    */
   PROXY_HOST_DEVICE
-  constexpr static int meshIndexToLinearIndex3D(int const k)
-  {
-    return linearIndex3DVal((num1dNodes - 1) * (k % 2),
-                            (num1dNodes - 1) * ((k % 4) / 2),
-                            (num1dNodes - 1) * (k / 4));
+  constexpr static int meshIndexToLinearIndex3D(int const k) {
+    return linearIndex3DVal((num1dNodes - 1) * (k % 2), (num1dNodes - 1) * ((k % 4) / 2), (num1dNodes - 1) * (k / 4));
   }
 
   /**
@@ -98,10 +89,7 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    * @return The linear index in 2D
    */
   PROXY_HOST_DEVICE
-  constexpr static int linearIndex2DVal(const int qa, const int qb)
-  {
-    return qa + qb * num1dNodes;
-  }
+  constexpr static int linearIndex2DVal(const int qa, const int qb) { return qa + qb * num1dNodes; }
 
   /**
    * @brief Converts from the index of the point in the mesh and the linear 2D
@@ -110,10 +98,8 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    * @return The linear index in 2D
    */
   PROXY_HOST_DEVICE
-  constexpr static int meshIndexToLinearIndex2D(int const k)
-  {
-    return linearIndex2DVal((num1dNodes - 1) * (k % 2),
-                            (num1dNodes - 1) * (k / 2));
+  constexpr static int meshIndexToLinearIndex2D(int const k) {
+    return linearIndex2DVal((num1dNodes - 1) * (k % 2), (num1dNodes - 1) * (k / 2));
   }
 
   PROXY_HOST_DEVICE
@@ -141,10 +127,7 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    * @param[out] N The shape function values.
    */
   PROXY_HOST_DEVICE
-  static void calcN(double const (&coords)[3], double (&N)[numNodes])
-  {
-    GL_BASIS::TensorProduct3D::value(coords, N);
-  }
+  static void calcN(double const (&coords)[3], double (&N)[numNodes]) { GL_BASIS::TensorProduct3D::value(coords, N); }
 
   /**
    * @brief Compute the interpolation coefficients of the q-th quadrature point
@@ -153,8 +136,7 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    * @param k the index of the interval endpoint (0 or 1)
    * @return The interpolation coefficient
    */
-  constexpr static real_t interpolationCoord(const int q, const int k)
-  {
+  constexpr static real_t interpolationCoord(const int q, const int k) {
     const real_t alpha = (GL_BASIS::parentSupportCoord(q) + 1.0) / 2.0;
     return k == 0 ? (1.0 - alpha) : alpha;
   }
@@ -167,16 +149,11 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    * @return The derivative value
    */
   PROXY_HOST_DEVICE
-  constexpr static real_t basisGradientAt(const int q, const int p)
-  {
-    if (p <= halfNodes)
-    {
+  constexpr static real_t basisGradientAt(const int q, const int p) {
+    if (p <= halfNodes) {
       return GL_BASIS::gradientAt(q, p);
-    }
-    else
-    {
-      return -GL_BASIS::gradientAt(GL_BASIS::numSupportPoints - 1 - q,
-                                   GL_BASIS::numSupportPoints - 1 - p);
+    } else {
+      return -GL_BASIS::gradientAt(GL_BASIS::numSupportPoints - 1 - q, GL_BASIS::numSupportPoints - 1 - p);
     }
   }
 
@@ -193,15 +170,10 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    * @return The value of the jacobian factor
    */
   PROXY_HOST_DEVICE
-  constexpr static real_t jacobianCoefficient1D(const int q, const int i,
-                                                const int k, const int dir)
-  {
-    if (i == dir)
-    {
+  constexpr static real_t jacobianCoefficient1D(const int q, const int i, const int k, const int dir) {
+    if (i == dir) {
       return k == 0 ? -1.0 / 2.0 : 1.0 / 2.0;
-    }
-    else
-    {
+    } else {
       return interpolationCoord(q, k);
     }
   }
@@ -215,10 +187,8 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    */
 
   PROXY_HOST_DEVICE
-  static void calcN(int const q, real_t (&N)[numNodes])
-  {
-    for (int a = 0; a < numNodes; ++a)
-    {
+  static void calcN(int const q, real_t (&N)[numNodes]) {
+    for (int a = 0; a < numNodes; ++a) {
       N[a] = 0;
     }
     N[q] = 1.0;
@@ -235,8 +205,7 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    */
 
   PROXY_HOST_DEVICE
-  static real_t calcGradN(int const q, real_t const (&X)[numNodes][3],
-                          real_t (&gradN)[numNodes][3]);
+  static real_t calcGradN(int const q, real_t const (&X)[numNodes][3], real_t (&gradN)[numNodes][3]);
   /**
    * @brief Calculate the shape functions derivatives wrt the physical
    *   coordinates at a single point.
@@ -249,9 +218,7 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    */
 
   PROXY_HOST_DEVICE
-  static real_t calcGradN(real_t const (&coords)[3],
-                          real_t const (&X)[numNodes][3],
-                          real_t (&gradN)[numNodes][3]);
+  static real_t calcGradN(real_t const (&coords)[3], real_t const (&X)[numNodes][3], real_t (&gradN)[numNodes][3]);
 
   /**
    * @brief Calculate the shape functions derivatives wrt the physical
@@ -264,8 +231,7 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    */
 
   PROXY_HOST_DEVICE
-  static real_t calcGradNWithCorners(int const q, real_t const (&X)[8][3],
-                                     real_t (&gradN)[numNodes][3]);
+  static real_t calcGradNWithCorners(int const q, real_t const (&X)[8][3], real_t (&gradN)[numNodes][3]);
   /**
    * @brief Calculate the shape functions derivatives wrt the physical
    *   coordinates at a single point.
@@ -278,9 +244,7 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    */
 
   PROXY_HOST_DEVICE
-  static real_t calcGradNWithCorners(real_t const (&coords)[3],
-                                     real_t const (&X)[8][3],
-                                     real_t (&gradN)[numNodes][3]);
+  static real_t calcGradNWithCorners(real_t const (&coords)[3], real_t const (&X)[8][3], real_t (&gradN)[numNodes][3]);
 
   /**
    * @brief Calculate the integration weights for a quadrature point.
@@ -290,8 +254,7 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    *   the parent/physical transformation matrix.
    */
   PROXY_HOST_DEVICE
-  static real_t transformedQuadratureWeight(int const q,
-                                            real_t const (&X)[numNodes][3]);
+  static real_t transformedQuadratureWeight(int const q, real_t const (&X)[numNodes][3]);
 
   /**
    * @brief Calculates the isoparametric "Jacobian" transformation
@@ -303,9 +266,7 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    * @param J Array to store the Jacobian transformation.
    */
   PROXY_HOST_DEVICE
-  static void jacobianTransformation2d(int const qa, int const qb,
-                                       real_t const (&X)[4][3],
-                                       real_t (&J)[3][2]);
+  static void jacobianTransformation2d(int const qa, int const qb, real_t const (&X)[4][3], real_t (&J)[3][2]);
 
   /**
    * @brief Calculates the isoparametric "Jacobian" transformation
@@ -318,10 +279,8 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    * @return The determinant of the Jacobian transformation matrix.
    */
   PROXY_HOST_DEVICE
-  static real_t invJacobianTransformation(int const qa, int const qb,
-                                          int const qc, real_t const (&X)[8][3],
-                                          real_t (&J)[3][3])
-  {
+  static real_t invJacobianTransformation(int const qa, int const qb, int const qc, real_t const (&X)[8][3],
+                                          real_t (&J)[3][3]) {
     jacobianTransformation(qa, qb, qc, X, J);
     return invert3x3(J);
   }
@@ -335,9 +294,7 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    * @return The determinant of the Jacobian transformation matrix.
    */
   PROXY_HOST_DEVICE
-  static real_t invJacobianTransformation(int const q, real_t const (&X)[8][3],
-                                          real_t (&J)[3][3])
-  {
+  static real_t invJacobianTransformation(int const q, real_t const (&X)[8][3], real_t (&J)[3][3]) {
     int qa, qb, qc;
     GL_BASIS::TensorProduct3D::multiIndex(q, qa, qb, qc);
     return invJacobianTransformation(qa, qb, qc, X, J);
@@ -354,8 +311,7 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    * @param grad The symmetric gradient in Voigt notation.
    */
   PROXY_HOST_DEVICE
-  static void symmetricGradient(int const q, real_t const (&invJ)[3][3],
-                                real_t const (&var)[numNodes][3],
+  static void symmetricGradient(int const q, real_t const (&invJ)[3][3], real_t const (&var)[numNodes][3],
                                 real_t (&grad)[6]);
 
   /**
@@ -374,8 +330,7 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    *
    */
   PROXY_HOST_DEVICE
-  static void gradient(int const q, real_t const (&invJ)[3][3],
-                       real_t const (&var)[numNodes][3], real_t (&grad)[3][3]);
+  static void gradient(int const q, real_t const (&invJ)[3][3], real_t const (&var)[numNodes][3], real_t (&grad)[3][3]);
 
   /**
    * @brief Calculates the isoparametric "Jacobian" transformation
@@ -387,8 +342,7 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    * @param J Array to store the Jacobian transformation.
    */
   PROXY_HOST_DEVICE
-  static void jacobianTransformation(int const qa, int const qb, int const qc,
-                                     real_t const (&X)[8][3],
+  static void jacobianTransformation(int const qa, int const qb, int const qc, real_t const (&X)[8][3],
                                      real_t (&J)[3][3]);
 
   /**
@@ -401,9 +355,7 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    * @param J Array to store the Jacobian transformation.
    */
   PROXY_HOST_DEVICE
-  static void jacobianTransformation(real_t const (&coords)[3],
-                                     real_t const (&X)[numNodes][3],
-                                     real_t (&J)[3][3]);
+  static void jacobianTransformation(real_t const (&coords)[3], real_t const (&X)[numNodes][3], real_t (&J)[3][3]);
 
   /**
    * @brief Calculates the isoparametric "Jacobian" transformation
@@ -416,9 +368,7 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    * @param J Array to store the Jacobian transformation.
    */
   PROXY_HOST_DEVICE
-  static void jacobianTransformationWithCorners(real_t const (&coords)[3],
-                                                real_t const (&X)[8][3],
-                                                real_t (&J)[3][3]);
+  static void jacobianTransformationWithCorners(real_t const (&coords)[3], real_t const (&X)[8][3], real_t (&J)[3][3]);
 
   /**
    * @brief performs a trilinear interpolation to determine the real-world
@@ -433,8 +383,7 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    * @param[out] coords Real-world coordinates of the interpolated point
    */
   PROXY_HOST_DEVICE
-  static void trilinearInterp(real_t const alpha, real_t const beta,
-                              real_t const gamma, real_t const (&X)[8][3],
+  static void trilinearInterp(real_t const alpha, real_t const beta, real_t const gamma, real_t const (&X)[8][3],
                               real_t (&coords)[3]);
 
   /**
@@ -444,8 +393,7 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    * @param[out] X Array containing the coordinates of the support points.
    */
   PROXY_HOST_DEVICE
-  static void computeLocalCoords(real_t const (&Xmesh)[8][3],
-                                 real_t (&X)[numNodes][3]);
+  static void computeLocalCoords(real_t const (&Xmesh)[8][3], real_t (&X)[numNodes][3]);
 
   /**
    * @brief computes the non-zero contributions of the d.o.f. indexd by q to the
@@ -455,8 +403,7 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    * @return The diagonal mass term associated to q
    */
   template <typename FUNC>
-  PROXY_HOST_DEVICE static void computeMassTerm(
-      TransformType const &transformData, FUNC &&func);
+  PROXY_HOST_DEVICE static void computeMassTerm(TransformType const &transformData, FUNC &&func);
 
   /**
    * @brief computes the non-zero contributions of the d.o.f. indexd by q to the
@@ -480,8 +427,7 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    * @param B Array to store the matrix B, in Voigt notation
    */
   PROXY_HOST_DEVICE
-  static void computeBMatrix(int const qa, int const qb, int const qc,
-                             real_t const (&X)[8][3], real_t (&J)[3][3],
+  static void computeBMatrix(int const qa, int const qb, int const qc, real_t const (&X)[8][3], real_t (&J)[3][3],
                              real_t (&B)[6]);
 
   /**
@@ -502,8 +448,7 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    * stiffness matrix itself.
    */
   template <typename FUNC1, typename FUNC2>
-  PROXY_HOST_DEVICE static void computeStiffnessTerm(
-      TransformType const &transformData, FUNC1 &&func1, FUNC2 &&func2);
+  PROXY_HOST_DEVICE static void computeStiffnessTerm(TransformType const &transformData, FUNC1 &&func1, FUNC2 &&func2);
 
   /**
    * @brief Acoustic stiffness K·p via sum factorization (3-pass algorithm).
@@ -526,9 +471,9 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    * @param get_inv_rho   Material callback returning 1/ρ per quad point.
    */
   template <typename FUNC_ALPHA>
-  PROXY_HOST_DEVICE static void computeStiffnessTermSumFact(
-      TransformType const &transformData, real_t const (&p_local)[numNodes],
-      real_t (&f_local)[numNodes], FUNC_ALPHA &&get_alpha);
+  PROXY_HOST_DEVICE static void computeStiffnessTermSumFact(TransformType const &transformData,
+                                                            real_t const (&p_local)[numNodes],
+                                                            real_t (&f_local)[numNodes], FUNC_ALPHA &&get_alpha);
 
   /**
    * @brief Computes the "Grad(Phi)*B*Grad(Phi)" coefficient of the stiffness
@@ -549,9 +494,7 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    * stiffness matrix itself.
    */
   template <int qa, int qb, int qc, typename FUNC1, typename FUNC2>
-  PROXY_HOST_DEVICE static void computeGradPhiBGradPhi(real_t const (&B)[6],
-                                                       FUNC1 &&func1,
-                                                       FUNC2 &&func2);
+  PROXY_HOST_DEVICE static void computeGradPhiBGradPhi(real_t const (&B)[6], FUNC1 &&func1, FUNC2 &&func2);
 
   /**
    * @brief Computes the "Grad(Phi)*Grad(Phi)" coefficient of the stiffness
@@ -574,9 +517,7 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    * processing
    */
   template <int qa, int qb, int qc, typename FUNC1, typename FUNC2>
-  PROXY_HOST_DEVICE static void computeGradPhiGradPhi(JacobianType &J,
-                                                      FUNC1 &&func1,
-                                                      FUNC2 &&func2);
+  PROXY_HOST_DEVICE static void computeGradPhiGradPhi(JacobianType &J, FUNC1 &&func1, FUNC2 &&func2);
 
   /**
    * @brief Computes the non-zero contributions of the d.o.f. indexed by q to
@@ -594,8 +535,8 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    * stiffness matrix contributions
    */
   template <typename FUNC1, typename FUNC2>
-  PROXY_HOST_DEVICE static void computeStiffNessTermwithJac(
-      TransformType const &transformData, FUNC1 &&func1, FUNC2 &&func2);
+  PROXY_HOST_DEVICE static void computeStiffNessTermwithJac(TransformType const &transformData, FUNC1 &&func1,
+                                                            FUNC2 &&func2);
 
   /**
    * @brief Sum-factorized elastic stiffness kernel (O(N^4)).
@@ -626,9 +567,9 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    *                       caller, the kernel remains physics-free.
    */
   template <typename FUNC1>
-  PROXY_HOST_DEVICE static void computeElasticStiffnessSumFact(
-      TransformType const &transformData, real_t const (&u_local)[3][numNodes],
-      real_t (&f_local)[3][numNodes], FUNC1 &&func1);
+  PROXY_HOST_DEVICE static void computeElasticStiffnessSumFact(TransformType const &transformData,
+                                                               real_t const (&u_local)[3][numNodes],
+                                                               real_t (&f_local)[3][numNodes], FUNC1 &&func1);
 
   /**
    * @brief Apply a Jacobian transformation matrix from the parent space to the
@@ -640,8 +581,8 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    *   support points at the coordinates of the quadrature point @p q.
    */
   PROXY_HOST_DEVICE
-  static void applyTransformationToParentGradients(
-      int const q, real_t const (&invJ)[3][3], real_t (&gradN)[numNodes][3]);
+  static void applyTransformationToParentGradients(int const q, real_t const (&invJ)[3][3],
+                                                   real_t (&gradN)[numNodes][3]);
 
   /**
    * @brief Apply a Jacobian transformation matrix from the parent space to the
@@ -653,18 +594,15 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    *   support points at the coordinates of the quadrature point @p q.
    */
   PROXY_HOST_DEVICE
-  static void applyTransformationToParentGradients(
-      real_t const (&coords)[3], real_t const (&invJ)[3][3],
-      real_t (&gradN)[numNodes][3]);
+  static void applyTransformationToParentGradients(real_t const (&coords)[3], real_t const (&invJ)[3][3],
+                                                   real_t (&gradN)[numNodes][3]);
 
  private:
   /// The length of one dimension of the parent element.
-  constexpr static real_t parentLength =
-      GL_BASIS::parentSupportCoord(1) - GL_BASIS::parentSupportCoord(0);
+  constexpr static real_t parentLength = GL_BASIS::parentSupportCoord(1) - GL_BASIS::parentSupportCoord(0);
 
   /// The volume of the element in the parent configuration.
-  constexpr static real_t parentVolume =
-      parentLength * parentLength * parentLength;
+  constexpr static real_t parentVolume = parentLength * parentLength * parentLength;
   /**
    * @brief Applies a function inside a generic loop in over the tensor product
    *   indices.
@@ -676,8 +614,7 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    * @param params The parameters to pass to @p func.
    */
   template <typename FUNC, typename... PARAMS>
-  PROXY_HOST_DEVICE static void supportLoop(real_t const (&coords)[3],
-                                            FUNC &&func, PARAMS &&...params);
+  PROXY_HOST_DEVICE static void supportLoop(real_t const (&coords)[3], FUNC &&func, PARAMS &&...params);
   /**
    * @brief Applies a function over the (3N-2) nodes with non-zero parent
    *   gradient at quadrature point @p q.
@@ -702,31 +639,22 @@ class Qk_Hexahedron_Lagrange_GaussLobatto final
    */
   template <typename FUNC, typename... PARAMS>
 
-  PROXY_HOST_DEVICE static void supportLoop(int const q, FUNC &&func,
-                                            PARAMS &&...params);
+  PROXY_HOST_DEVICE static void supportLoop(int const q, FUNC &&func, PARAMS &&...params);
 };
 
 /// @cond Doxygen_Suppress
 
 template <typename GL_BASIS>
 template <typename FUNC, typename... PARAMS>
-PROXY_HOST_DEVICE void
-Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::supportLoop(
-    real_t const (&coords)[3], FUNC &&func, PARAMS &&...params)
-{
-  for (int c = 0; c < num1dNodes; ++c)
-  {
-    for (int b = 0; b < num1dNodes; ++b)
-    {
-      for (int a = 0; a < num1dNodes; ++a)
-      {
+PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::supportLoop(real_t const (&coords)[3],
+                                                                                  FUNC &&func, PARAMS &&...params) {
+  for (int c = 0; c < num1dNodes; ++c) {
+    for (int b = 0; b < num1dNodes; ++b) {
+      for (int a = 0; a < num1dNodes; ++a) {
         real_t const dNdXi[3] = {
-            GL_BASIS::gradient(a, coords[0]) * GL_BASIS::value(b, coords[1]) *
-                GL_BASIS::value(c, coords[2]),
-            GL_BASIS::value(a, coords[0]) * GL_BASIS::gradient(b, coords[1]) *
-                GL_BASIS::value(c, coords[2]),
-            GL_BASIS::value(a, coords[0]) * GL_BASIS::value(b, coords[1]) *
-                GL_BASIS::gradient(c, coords[2])};
+            GL_BASIS::gradient(a, coords[0]) * GL_BASIS::value(b, coords[1]) * GL_BASIS::value(c, coords[2]),
+            GL_BASIS::value(a, coords[0]) * GL_BASIS::gradient(b, coords[1]) * GL_BASIS::value(c, coords[2]),
+            GL_BASIS::value(a, coords[0]) * GL_BASIS::value(b, coords[1]) * GL_BASIS::gradient(c, coords[2])};
 
         int const nodeIndex = GL_BASIS::TensorProduct3D::linearIndex(a, b, c);
 
@@ -738,36 +666,29 @@ Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::supportLoop(
 
 template <typename GL_BASIS>
 template <typename FUNC, typename... PARAMS>
-PROXY_HOST_DEVICE void
-Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::supportLoop(int const q,
-                                                           FUNC &&func,
-                                                           PARAMS &&...params)
-{
+PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::supportLoop(int const q, FUNC &&func,
+                                                                                  PARAMS &&...params) {
   int qa, qb, qc;
   GL_BASIS::TensorProduct3D::multiIndex(q, qa, qb, qc);
 
   // ξ-line: b=qb, c=qc, a varies.
   // The center node (qa,qb,qc) is processed here with all three non-zero
   // components; the other nodes on this line have only dNdXi[0] non-zero.
-  for (int a = 0; a < num1dNodes; ++a)
-  {
-    real_t const dNdXi[3] = {basisGradientAt(a, qa),
-                             (a == qa) ? basisGradientAt(qb, qb) : real_t(0),
+  for (int a = 0; a < num1dNodes; ++a) {
+    real_t const dNdXi[3] = {basisGradientAt(a, qa), (a == qa) ? basisGradientAt(qb, qb) : real_t(0),
                              (a == qa) ? basisGradientAt(qc, qc) : real_t(0)};
     int const nodeIndex = linearIndex3DVal(a, qb, qc);
     func(dNdXi, nodeIndex, std::forward<PARAMS>(params)...);
   }
   // η-line: a=qa, c=qc, b varies — skip b=qb (center, already processed above).
-  for (int b = 0; b < num1dNodes; ++b)
-  {
+  for (int b = 0; b < num1dNodes; ++b) {
     if (b == qb) continue;
     real_t const dNdXi[3] = {real_t(0), basisGradientAt(b, qb), real_t(0)};
     int const nodeIndex = linearIndex3DVal(qa, b, qc);
     func(dNdXi, nodeIndex, std::forward<PARAMS>(params)...);
   }
   // ζ-line: a=qa, b=qb, c varies — skip c=qc (center, already processed above).
-  for (int c = 0; c < num1dNodes; ++c)
-  {
+  for (int c = 0; c < num1dNodes; ++c) {
     if (c == qc) continue;
     real_t const dNdXi[3] = {real_t(0), real_t(0), basisGradientAt(c, qc)};
     int const nodeIndex = linearIndex3DVal(qa, qb, c);
@@ -778,18 +699,15 @@ Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::supportLoop(int const q,
 //*************************************************************************************************
 
 template <typename GL_BASIS>
-PROXY_HOST_DEVICE real_t
-Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::calcGradN(
-    int const q, real_t const (&X)[numNodes][3], real_t (&gradN)[numNodes][3])
-{
+PROXY_HOST_DEVICE real_t Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::calcGradN(int const q,
+                                                                                  real_t const (&X)[numNodes][3],
+                                                                                  real_t (&gradN)[numNodes][3]) {
   int qa, qb, qc;
   GL_BASIS::TensorProduct3D::multiIndex(q, qa, qb, qc);
   real_t Xmesh[8][3] = {{0}};
-  for (int k = 0; k < 8; k++)
-  {
+  for (int k = 0; k < 8; k++) {
     const int nodeIndex = meshIndexToLinearIndex3D(k);
-    for (int i = 0; i < 3; i++)
-    {
+    for (int i = 0; i < 3; i++) {
       Xmesh[k][i] = X[nodeIndex][i];
     }
   }
@@ -808,10 +726,8 @@ template <typename GL_BASIS>
 PROXY_HOST_DEVICE
 
     real_t
-    Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::calcGradN(
-        real_t const (&coords)[3], real_t const (&X)[numNodes][3],
-        real_t (&gradN)[numNodes][3])
-{
+    Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::calcGradN(real_t const (&coords)[3], real_t const (&X)[numNodes][3],
+                                                             real_t (&gradN)[numNodes][3]) {
   real_t J[3][3] = {{0}};
 
   jacobianTransformation(coords, X, J);
@@ -823,10 +739,8 @@ PROXY_HOST_DEVICE
   return detJ;
 }
 template <typename GL_BASIS>
-PROXY_HOST_DEVICE real_t
-Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::calcGradNWithCorners(
-    int const q, real_t const (&X)[8][3], real_t (&gradN)[numNodes][3])
-{
+PROXY_HOST_DEVICE real_t Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::calcGradNWithCorners(
+    int const q, real_t const (&X)[8][3], real_t (&gradN)[numNodes][3]) {
   int qa, qb, qc;
   GL_BASIS::TensorProduct3D::multiIndex(q, qa, qb, qc);
 
@@ -842,11 +756,8 @@ Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::calcGradNWithCorners(
 }
 //*************************************************************************************************
 template <typename GL_BASIS>
-PROXY_HOST_DEVICE real_t
-Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::calcGradNWithCorners(
-    real_t const (&coords)[3], real_t const (&X)[8][3],
-    real_t (&gradN)[numNodes][3])
-{
+PROXY_HOST_DEVICE real_t Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::calcGradNWithCorners(
+    real_t const (&coords)[3], real_t const (&X)[8][3], real_t (&gradN)[numNodes][3]) {
   real_t J[3][3] = {{0}};
 
   jacobianTransformationWithCorners(coords, X, J);
@@ -873,8 +784,7 @@ Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::calcGradNWithCorners(
  * std::integral_constant<int, I> as argument.
  */
 template <int N, typename F, int... Is>
-constexpr void for_constexpr_impl(F &&f, std::integer_sequence<int, Is...>)
-{
+constexpr void for_constexpr_impl(F &&f, std::integer_sequence<int, Is...>) {
   (f(std::integral_constant<int, Is>{}), ...);
 }
 
@@ -883,10 +793,8 @@ constexpr void for_constexpr_impl(F &&f, std::integer_sequence<int, Is...>)
  * std::integral_constant<int, I> as argument.
  */
 template <int N, typename F>
-constexpr void for_constexpr(F &&f)
-{
-  for_constexpr_impl<N>(std::forward<F>(f),
-                        std::make_integer_sequence<int, N>{});
+constexpr void for_constexpr(F &&f) {
+  for_constexpr_impl<N>(std::forward<F>(f), std::make_integer_sequence<int, N>{});
 }
 
 /*
@@ -896,33 +804,24 @@ constexpr void for_constexpr(F &&f)
  */
 
 template <int BoundI, int BoundJ, int BoundK, typename Lambda>
-constexpr void triple_loop(Lambda &&lambda)
-{
-  for_constexpr<BoundI>([&](auto I) {
-    for_constexpr<BoundJ>([&](auto J) {
-      for_constexpr<BoundK>([&](auto K) { lambda(I, J, K); });
-    });
-  });
+constexpr void triple_loop(Lambda &&lambda) {
+  for_constexpr<BoundI>(
+      [&](auto I) { for_constexpr<BoundJ>([&](auto J) { for_constexpr<BoundK>([&](auto K) { lambda(I, J, K); }); }); });
 }
 
 template <typename GL_BASIS>
-PROXY_HOST_DEVICE void
-Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::jacobianTransformation(
-    int const qa, int const qb, int const qc, real_t const (&X)[8][3],
-    real_t (&J)[3][3])
-{
-  for (int k = 0; k < 8; k++)
-  {
+PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::jacobianTransformation(int const qa, int const qb,
+                                                                                             int const qc,
+                                                                                             real_t const (&X)[8][3],
+                                                                                             real_t (&J)[3][3]) {
+  for (int k = 0; k < 8; k++) {
     const int ka = k % 2;
     const int kb = (k % 4) / 2;
     const int kc = k / 4;
-    for (int j = 0; j < 3; j++)
-    {
-      real_t jacCoeff = jacobianCoefficient1D(qa, 0, ka, j) *
-                        jacobianCoefficient1D(qb, 1, kb, j) *
+    for (int j = 0; j < 3; j++) {
+      real_t jacCoeff = jacobianCoefficient1D(qa, 0, ka, j) * jacobianCoefficient1D(qb, 1, kb, j) *
                         jacobianCoefficient1D(qc, 2, kc, j);
-      for (int i = 0; i < 3; i++)
-      {
+      for (int i = 0; i < 3; i++) {
         J[i][j] += jacCoeff * X[k][i];
       }
     }
@@ -930,20 +829,14 @@ Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::jacobianTransformation(
 }
 
 template <typename GL_BASIS>
-PROXY_HOST_DEVICE void
-Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::jacobianTransformation(
-    real_t const (&coords)[3], real_t const (&X)[numNodes][3],
-    real_t (&J)[3][3])
-{
+PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::jacobianTransformation(
+    real_t const (&coords)[3], real_t const (&X)[numNodes][3], real_t (&J)[3][3]) {
   supportLoop(
       coords,
-      [](real_t const(&dNdXi)[3], int const nodeIndex,
-         real_t const(&X)[numNodes][3], real_t(&J)[3][3]) {
+      [](real_t const(&dNdXi)[3], int const nodeIndex, real_t const(&X)[numNodes][3], real_t(&J)[3][3]) {
         real_t const *Xnode = X[nodeIndex];
-        for (int i = 0; i < 3; ++i)
-        {
-          for (int j = 0; j < 3; ++j)
-          {
+        for (int i = 0; i < 3; ++i) {
+          for (int j = 0; j < 3; ++j) {
             J[i][j] = J[i][j] + dNdXi[j] * Xnode[i];
           }
         }
@@ -952,15 +845,11 @@ Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::jacobianTransformation(
 }
 
 template <typename GL_BASIS>
-PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<
-    GL_BASIS>::jacobianTransformationWithCorners(real_t const (&coords)[3],
-                                                 real_t const (&X)[8][3],
-                                                 real_t (&J)[3][3])
-{
+PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::jacobianTransformationWithCorners(
+    real_t const (&coords)[3], real_t const (&X)[8][3], real_t (&J)[3][3]) {
   supportLoop(
       coords,
-      [](real_t const(&dNdXi)[3], int const nodeIndex, real_t const(&X)[8][3],
-         real_t(&J)[3][3]) {
+      [](real_t const(&dNdXi)[3], int const nodeIndex, real_t const(&X)[8][3], real_t(&J)[3][3]) {
         int qa, qb, qc;
         GL_BASIS::TensorProduct3D::multiIndex(nodeIndex, qa, qb, qc);
         real_t Xnode[3];
@@ -968,10 +857,8 @@ PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<
         real_t beta = (GL_BASIS::parentSupportCoord(qb) + 1.0) / 2.0;
         real_t gamma = (GL_BASIS::parentSupportCoord(qc) + 1.0) / 2.0;
         trilinearInterp(alpha, beta, gamma, X, Xnode);
-        for (int i = 0; i < 3; ++i)
-        {
-          for (int j = 0; j < 3; ++j)
-          {
+        for (int i = 0; i < 3; ++i) {
+          for (int j = 0; j < 3; ++j) {
             J[i][j] = J[i][j] + dNdXi[j] * Xnode[i];
           }
         }
@@ -980,32 +867,22 @@ PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<
 }
 
 template <typename GL_BASIS>
-PROXY_HOST_DEVICE void
-Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::trilinearInterp(
-    real_t const alpha, real_t const beta, real_t const gamma,
-    real_t const (&X)[8][3], real_t (&coords)[3])
-{
-  for (int i = 0; i < 3; i++)
-  {
+PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::trilinearInterp(
+    real_t const alpha, real_t const beta, real_t const gamma, real_t const (&X)[8][3], real_t (&coords)[3]) {
+  for (int i = 0; i < 3; i++) {
     coords[i] = X[0][i] * (1.0 - alpha) * (1.0 - beta) * (1.0 - gamma) +
-                X[1][i] * alpha * (1.0 - beta) * (1.0 - gamma) +
-                X[2][i] * (1.0 - alpha) * beta * (1.0 - gamma) +
-                X[3][i] * alpha * beta * (1.0 - gamma) +
-                X[4][i] * (1.0 - alpha) * (1.0 - beta) * gamma +
-                X[5][i] * alpha * (1.0 - beta) * gamma +
-                X[6][i] * (1.0 - alpha) * beta * gamma +
+                X[1][i] * alpha * (1.0 - beta) * (1.0 - gamma) + X[2][i] * (1.0 - alpha) * beta * (1.0 - gamma) +
+                X[3][i] * alpha * beta * (1.0 - gamma) + X[4][i] * (1.0 - alpha) * (1.0 - beta) * gamma +
+                X[5][i] * alpha * (1.0 - beta) * gamma + X[6][i] * (1.0 - alpha) * beta * gamma +
                 X[7][i] * alpha * beta * gamma;
   }
 }
 
 template <typename GL_BASIS>
-PROXY_HOST_DEVICE void
-Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeLocalCoords(
-    real_t const (&Xmesh)[8][3], real_t (&X)[numNodes][3])
-{
+PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeLocalCoords(real_t const (&Xmesh)[8][3],
+                                                                                         real_t (&X)[numNodes][3]) {
   int qa, qb, qc;
-  for (int q = 0; q < numNodes; q++)
-  {
+  for (int q = 0; q < numNodes; q++) {
     GL_BASIS::TensorProduct3D::multiIndex(q, qa, qb, qc);
     real_t alpha = (GL_BASIS::parentSupportCoord(qa) + 1.0) / 2.0;
     real_t beta = (GL_BASIS::parentSupportCoord(qb) + 1.0) / 2.0;
@@ -1015,20 +892,16 @@ Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeLocalCoords(
 }
 
 template <typename GL_BASIS>
-PROXY_HOST_DEVICE void
-Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::jacobianTransformation2d(
-    int const qa, int const qb, real_t const (&X)[4][3], real_t (&J)[3][2])
-{
-  for (int k = 0; k < 4; k++)
-  {
+PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::jacobianTransformation2d(int const qa,
+                                                                                               int const qb,
+                                                                                               real_t const (&X)[4][3],
+                                                                                               real_t (&J)[3][2]) {
+  for (int k = 0; k < 4; k++) {
     int ka = k % 2;
     int kb = k / 2;
-    for (int j = 0; j < 2; j++)
-    {
-      real_t jacCoeff = jacobianCoefficient1D(qa, 0, ka, j) *
-                        jacobianCoefficient1D(qb, 1, kb, j);
-      for (int i = 0; i < 3; i++)
-      {
+    for (int j = 0; j < 2; j++) {
+      real_t jacCoeff = jacobianCoefficient1D(qa, 0, ka, j) * jacobianCoefficient1D(qb, 1, kb, j);
+      for (int i = 0; i < 3; i++) {
         J[i][j] += jacCoeff * X[k][i];
       }
     }
@@ -1037,18 +910,15 @@ Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::jacobianTransformation2d(
 
 template <typename GL_BASIS>
 template <typename FUNC>
-PROXY_HOST_DEVICE void
-Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeMassTerm(
-    TransformType const &transformData, FUNC &&func)
-{
+PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeMassTerm(
+    TransformType const &transformData, FUNC &&func) {
   constexpr int N = num1dNodes;
   triple_loop<N, N, N>([&](auto const icqa, auto const icqb, auto const icqc) {
     constexpr int qa = decltype(icqa)::value;
     constexpr int qb = decltype(icqb)::value;
     constexpr int qc = decltype(icqc)::value;
     constexpr int q = GL_BASIS::TensorProduct3D::linearIndex(qa, qb, qc);
-    constexpr real_t w3D =
-        GL_BASIS::weight(qa) * GL_BASIS::weight(qb) * GL_BASIS::weight(qc);
+    constexpr real_t w3D = GL_BASIS::weight(qa) * GL_BASIS::weight(qb) * GL_BASIS::weight(qc);
     real_t J[3][3] = {{0}};
     float const(&X)[8][3] = transformData.data;
     jacobianTransformation(qa, qb, qc, X, J);
@@ -1058,10 +928,8 @@ Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeMassTerm(
 }
 
 template <typename GL_BASIS>
-PROXY_HOST_DEVICE real_t
-Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeDampingTerm(
-    int const q, real_t const (&X)[4][3])
-{
+PROXY_HOST_DEVICE real_t Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeDampingTerm(int const q,
+                                                                                           real_t const (&X)[4][3]) {
   int qa, qb;
   GL_BASIS::TensorProduct2D::multiIndex(q, qa, qb);
   const real_t w2D = GL_BASIS::weight(qa) * GL_BASIS::weight(qb);
@@ -1076,11 +944,8 @@ Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeDampingTerm(
 }
 
 template <typename GL_BASIS>
-PROXY_HOST_DEVICE void
-Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeBMatrix(
-    int const qa, int const qb, int const qc, real_t const (&X)[8][3],
-    real_t (&J)[3][3], real_t (&B)[6])
-{
+PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeBMatrix(
+    int const qa, int const qb, int const qc, real_t const (&X)[8][3], real_t (&J)[3][3], real_t (&B)[6]) {
   jacobianTransformation(qa, qb, qc, X, J);
   real_t const detJ = determinant(J);
   real_t const invDetJ = 1.0 / detJ;
@@ -1099,23 +964,19 @@ Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeBMatrix(
 
 template <typename GL_BASIS>
 template <int qa, int qb, int qc, typename FUNC1, typename FUNC2>
-PROXY_HOST_DEVICE void
-Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeGradPhiBGradPhi(
-    real_t const (&B)[6], FUNC1 &&func1, FUNC2 &&func2)
-{
-  const real_t w =
-      GL_BASIS::weight(qa) * GL_BASIS::weight(qb) * GL_BASIS::weight(qc);
+PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeGradPhiBGradPhi(real_t const (&B)[6],
+                                                                                             FUNC1 &&func1,
+                                                                                             FUNC2 &&func2) {
+  const real_t w = GL_BASIS::weight(qa) * GL_BASIS::weight(qb) * GL_BASIS::weight(qc);
   func1(qa, qb, qc);
-  for (int i = 0; i < num1dNodes; i++)
-  {
+  for (int i = 0; i < num1dNodes; i++) {
     const int ibc = GL_BASIS::TensorProduct3D::linearIndex(i, qb, qc);
     const int aic = GL_BASIS::TensorProduct3D::linearIndex(qa, i, qc);
     const int abi = GL_BASIS::TensorProduct3D::linearIndex(qa, qb, i);
     const real_t gia = basisGradientAt(i, qa);
     const real_t gib = basisGradientAt(i, qb);
     const real_t gic = basisGradientAt(i, qc);
-    for (int j = 0; j < num1dNodes; j++)
-    {
+    for (int j = 0; j < num1dNodes; j++) {
       const int jbc = GL_BASIS::TensorProduct3D::linearIndex(j, qb, qc);
       const int ajc = GL_BASIS::TensorProduct3D::linearIndex(qa, j, qc);
       const int abj = GL_BASIS::TensorProduct3D::linearIndex(qa, qb, j);
@@ -1145,30 +1006,25 @@ Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeGradPhiBGradPhi(
 
 template <typename GL_BASIS>
 template <typename FUNC1, typename FUNC2>
-PROXY_HOST_DEVICE void
-Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeStiffnessTerm(
-    TransformType const &transformData, FUNC1 &&func1, FUNC2 &&func2)
-{
-  triple_loop<num1dNodes, num1dNodes, num1dNodes>(
-      [&](auto const icqa, auto const icqb, auto const icqc) {
-        constexpr int qa = decltype(icqa)::value;
-        constexpr int qb = decltype(icqb)::value;
-        constexpr int qc = decltype(icqc)::value;
-        real_t B[6] = {0};
-        real_t J[3][3] = {{0}};
-        float const(&X)[8][3] = transformData.data;
-        computeBMatrix(qa, qb, qc, X, J, B);
-        computeGradPhiBGradPhi<qa, qb, qc>(B, func1, func2);
-      });
+PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeStiffnessTerm(
+    TransformType const &transformData, FUNC1 &&func1, FUNC2 &&func2) {
+  triple_loop<num1dNodes, num1dNodes, num1dNodes>([&](auto const icqa, auto const icqb, auto const icqc) {
+    constexpr int qa = decltype(icqa)::value;
+    constexpr int qb = decltype(icqb)::value;
+    constexpr int qc = decltype(icqc)::value;
+    real_t B[6] = {0};
+    real_t J[3][3] = {{0}};
+    float const(&X)[8][3] = transformData.data;
+    computeBMatrix(qa, qb, qc, X, J, B);
+    computeGradPhiBGradPhi<qa, qb, qc>(B, func1, func2);
+  });
 }
 
 template <typename GL_BASIS>
 template <typename FUNC_ALPHA>
-PROXY_HOST_DEVICE void
-Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeStiffnessTermSumFact(
-    TransformType const &transformData, real_t const (&u_local)[numNodes],
-    real_t (&v_local)[numNodes], FUNC_ALPHA &&get_alpha)
-{
+PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeStiffnessTermSumFact(
+    TransformType const &transformData, real_t const (&u_local)[numNodes], real_t (&v_local)[numNodes],
+    FUNC_ALPHA &&get_alpha) {
   float const(&X)[8][3] = transformData.data;
 
   // Flux pondérés G^{ξ,η,ζ}[q] = w_q * alpha_q * M(B_q) · ∇_ξ u_q
@@ -1178,46 +1034,42 @@ Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeStiffnessTermSumFact(
 
   // Pass 1+2 fused: gradient de u, puis application de la métrique, de alpha et
   // du poids
-  triple_loop<num1dNodes, num1dNodes, num1dNodes>(
-      [&](auto const icqa, auto const icqb, auto const icqc) {
-        constexpr int qa = decltype(icqa)::value;
-        constexpr int qb = decltype(icqb)::value;
-        constexpr int qc = decltype(icqc)::value;
-        constexpr int q = GL_BASIS::TensorProduct3D::linearIndex(qa, qb, qc);
+  triple_loop<num1dNodes, num1dNodes, num1dNodes>([&](auto const icqa, auto const icqb, auto const icqc) {
+    constexpr int qa = decltype(icqa)::value;
+    constexpr int qb = decltype(icqb)::value;
+    constexpr int qc = decltype(icqc)::value;
+    constexpr int q = GL_BASIS::TensorProduct3D::linearIndex(qa, qb, qc);
 
-        // La gestion des poids de quadrature est interne à la bibliothèque
-        // mathématique
-        constexpr real_t w =
-            GL_BASIS::weight(qa) * GL_BASIS::weight(qb) * GL_BASIS::weight(qc);
+    // La gestion des poids de quadrature est interne à la bibliothèque
+    // mathématique
+    constexpr real_t w = GL_BASIS::weight(qa) * GL_BASIS::weight(qb) * GL_BASIS::weight(qc);
 
-        real_t dxi_q = 0, deta_q = 0, dzeta_q = 0;
-        for_constexpr<num1dNodes>([&](auto ici) {
-          constexpr int i = decltype(ici)::value;
-          constexpr int ibc = GL_BASIS::TensorProduct3D::linearIndex(i, qb, qc);
-          constexpr int aic = GL_BASIS::TensorProduct3D::linearIndex(qa, i, qc);
-          constexpr int abi = GL_BASIS::TensorProduct3D::linearIndex(qa, qb, i);
+    real_t dxi_q = 0, deta_q = 0, dzeta_q = 0;
+    for_constexpr<num1dNodes>([&](auto ici) {
+      constexpr int i = decltype(ici)::value;
+      constexpr int ibc = GL_BASIS::TensorProduct3D::linearIndex(i, qb, qc);
+      constexpr int aic = GL_BASIS::TensorProduct3D::linearIndex(qa, i, qc);
+      constexpr int abi = GL_BASIS::TensorProduct3D::linearIndex(qa, qb, i);
 
-          dxi_q += basisGradientAt(i, qa) * u_local[ibc];
-          deta_q += basisGradientAt(i, qb) * u_local[aic];
-          dzeta_q += basisGradientAt(i, qc) * u_local[abi];
-        });
+      dxi_q += basisGradientAt(i, qa) * u_local[ibc];
+      deta_q += basisGradientAt(i, qb) * u_local[aic];
+      dzeta_q += basisGradientAt(i, qc) * u_local[abi];
+    });
 
-        real_t J[3][3] = {{0}};
-        real_t B[6] = {0};
-        computeBMatrix(qa, qb, qc, X, J, B);
+    real_t J[3][3] = {{0}};
+    real_t B[6] = {0};
+    computeBMatrix(qa, qb, qc, X, J, B);
 
-        // 'scale' fusionne la physique (alpha) et la quadrature (w)
-        real_t const scale = w * get_alpha(qa, qb, qc);
+    // 'scale' fusionne la physique (alpha) et la quadrature (w)
+    real_t const scale = w * get_alpha(qa, qb, qc);
 
-        G_xi[q] = scale * (B[0] * dxi_q + B[5] * deta_q + B[4] * dzeta_q);
-        G_eta[q] = scale * (B[5] * dxi_q + B[1] * deta_q + B[3] * dzeta_q);
-        G_zeta[q] = scale * (B[4] * dxi_q + B[3] * deta_q + B[2] * dzeta_q);
-      });
+    G_xi[q] = scale * (B[0] * dxi_q + B[5] * deta_q + B[4] * dzeta_q);
+    G_eta[q] = scale * (B[5] * dxi_q + B[1] * deta_q + B[3] * dzeta_q);
+    G_zeta[q] = scale * (B[4] * dxi_q + B[3] * deta_q + B[2] * dzeta_q);
+  });
 
   // Pass 3: divergence — v_{ia,ib,ic} += D^T·G^ξ + D^T·G^η + D^T·G^ζ
-  triple_loop<num1dNodes, num1dNodes, num1dNodes>([&](auto const icia,
-                                                      auto const icib,
-                                                      auto const icic) {
+  triple_loop<num1dNodes, num1dNodes, num1dNodes>([&](auto const icia, auto const icib, auto const icic) {
     constexpr int ia = decltype(icia)::value;
     constexpr int ib = decltype(icib)::value;
     constexpr int ic = decltype(icic)::value;
@@ -1246,28 +1098,23 @@ Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeStiffnessTermSumFact(
 
 template <typename GL_BASIS>
 template <typename FUNC1, typename FUNC2>
-PROXY_HOST_DEVICE void
-Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeStiffNessTermwithJac(
-    TransformType const &transformData, FUNC1 &&func1, FUNC2 &&func2)
-{
-  triple_loop<num1dNodes, num1dNodes, num1dNodes>(
-      [&](auto const icqa, auto const icqb, auto const icqc) {
-        constexpr int qa = decltype(icqa)::value;
-        constexpr int qb = decltype(icqb)::value;
-        constexpr int qc = decltype(icqc)::value;
-        JacobianType J = {{0}};
-        jacobianTransformation(qa, qb, qc, transformData.data, J.data);
-        computeGradPhiGradPhi<qa, qb, qc>(J, func1, func2);
-      });
+PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeStiffNessTermwithJac(
+    TransformType const &transformData, FUNC1 &&func1, FUNC2 &&func2) {
+  triple_loop<num1dNodes, num1dNodes, num1dNodes>([&](auto const icqa, auto const icqb, auto const icqc) {
+    constexpr int qa = decltype(icqa)::value;
+    constexpr int qb = decltype(icqb)::value;
+    constexpr int qc = decltype(icqc)::value;
+    JacobianType J = {{0}};
+    jacobianTransformation(qa, qb, qc, transformData.data, J.data);
+    computeGradPhiGradPhi<qa, qb, qc>(J, func1, func2);
+  });
 }
 
 template <typename GL_BASIS>
 template <typename FUNC1>
-PROXY_HOST_DEVICE void
-Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeElasticStiffnessSumFact(
-    TransformType const &transformData, real_t const (&u_local)[3][numNodes],
-    real_t (&f_local)[3][numNodes], FUNC1 &&func1)
-{
+PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeElasticStiffnessSumFact(
+    TransformType const &transformData, real_t const (&u_local)[3][numNodes], real_t (&f_local)[3][numNodes],
+    FUNC1 &&func1) {
   // 9 flux arrays: F_xi/F_eta/F_zeta[force_comp][quad_point]
   real_t F_xi[3][numNodes] = {{0}};
   real_t F_eta[3][numNodes] = {{0}};
@@ -1277,63 +1124,58 @@ Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeElasticStiffnessSumFact(
   // For each quad point: compute reference gradients of all 3 displacement
   // components, invert the Jacobian, delegate the constitutive computation to
   // func1, then scale and store into the flux arrays.
-  triple_loop<num1dNodes, num1dNodes, num1dNodes>(
-      [&](auto const icqa, auto const icqb, auto const icqc) {
-        constexpr int qa = decltype(icqa)::value;
-        constexpr int qb = decltype(icqb)::value;
-        constexpr int qc = decltype(icqc)::value;
-        constexpr int q = GL_BASIS::TensorProduct3D::linearIndex(qa, qb, qc);
-        constexpr real_t w =
-            GL_BASIS::weight(qa) * GL_BASIS::weight(qb) * GL_BASIS::weight(qc);
+  triple_loop<num1dNodes, num1dNodes, num1dNodes>([&](auto const icqa, auto const icqb, auto const icqc) {
+    constexpr int qa = decltype(icqa)::value;
+    constexpr int qb = decltype(icqb)::value;
+    constexpr int qc = decltype(icqc)::value;
+    constexpr int q = GL_BASIS::TensorProduct3D::linearIndex(qa, qb, qc);
+    constexpr real_t w = GL_BASIS::weight(qa) * GL_BASIS::weight(qb) * GL_BASIS::weight(qc);
 
-        // Reference gradients of each displacement component along ξ, η, ζ.
-        // grad_u_ref[r][s] = ∂u_s/∂ξ_r
-        real_t grad_u_ref[3][3] = {{0}};
-        for_constexpr<num1dNodes>([&](auto ici) {
-          constexpr int i = decltype(ici)::value;
-          constexpr int ibc = GL_BASIS::TensorProduct3D::linearIndex(i, qb, qc);
-          constexpr int aic = GL_BASIS::TensorProduct3D::linearIndex(qa, i, qc);
-          constexpr int abi = GL_BASIS::TensorProduct3D::linearIndex(qa, qb, i);
-          const real_t gxi = basisGradientAt(i, qa);
-          const real_t geta = basisGradientAt(i, qb);
-          const real_t gzeta = basisGradientAt(i, qc);
-          for (int s = 0; s < 3; ++s)
-          {
-            grad_u_ref[0][s] += gxi * u_local[s][ibc];
-            grad_u_ref[1][s] += geta * u_local[s][aic];
-            grad_u_ref[2][s] += gzeta * u_local[s][abi];
-          }
-        });
+    // Reference gradients of each displacement component along ξ, η, ζ.
+    // grad_u_ref[r][s] = ∂u_s/∂ξ_r
+    real_t grad_u_ref[3][3] = {{0}};
+    for_constexpr<num1dNodes>([&](auto ici) {
+      constexpr int i = decltype(ici)::value;
+      constexpr int ibc = GL_BASIS::TensorProduct3D::linearIndex(i, qb, qc);
+      constexpr int aic = GL_BASIS::TensorProduct3D::linearIndex(qa, i, qc);
+      constexpr int abi = GL_BASIS::TensorProduct3D::linearIndex(qa, qb, i);
+      const real_t gxi = basisGradientAt(i, qa);
+      const real_t geta = basisGradientAt(i, qb);
+      const real_t gzeta = basisGradientAt(i, qc);
+      for (int s = 0; s < 3; ++s) {
+        grad_u_ref[0][s] += gxi * u_local[s][ibc];
+        grad_u_ref[1][s] += geta * u_local[s][aic];
+        grad_u_ref[2][s] += gzeta * u_local[s][abi];
+      }
+    });
 
-        // Jacobian (inverted in-place, returns det).
-        JacobianType J = {{0}};
-        jacobianTransformation(qa, qb, qc, transformData.data, J.data);
-        real_t const detJ = invert3x3(J.data);
-        const real_t scale = w * detJ;
+    // Jacobian (inverted in-place, returns det).
+    JacobianType J = {{0}};
+    jacobianTransformation(qa, qb, qc, transformData.data, J.data);
+    real_t const detJ = invert3x3(J.data);
+    const real_t scale = w * detJ;
 
-        // flux[p][f] = unscaled flux contribution for test direction p and
-        // force component f — filled by the constitutive callback.
-        real_t flux[3][3] = {{0}};
-        func1(qa, qb, qc, J.data, grad_u_ref, flux);
+    // flux[p][f] = unscaled flux contribution for test direction p and
+    // force component f — filled by the constitutive callback.
+    real_t flux[3][3] = {{0}};
+    func1(qa, qb, qc, J.data, grad_u_ref, flux);
 
-        F_xi[0][q] = scale * flux[0][0];
-        F_xi[1][q] = scale * flux[0][1];
-        F_xi[2][q] = scale * flux[0][2];
-        F_eta[0][q] = scale * flux[1][0];
-        F_eta[1][q] = scale * flux[1][1];
-        F_eta[2][q] = scale * flux[1][2];
-        F_zeta[0][q] = scale * flux[2][0];
-        F_zeta[1][q] = scale * flux[2][1];
-        F_zeta[2][q] = scale * flux[2][2];
-      });
+    F_xi[0][q] = scale * flux[0][0];
+    F_xi[1][q] = scale * flux[0][1];
+    F_xi[2][q] = scale * flux[0][2];
+    F_eta[0][q] = scale * flux[1][0];
+    F_eta[1][q] = scale * flux[1][1];
+    F_eta[2][q] = scale * flux[1][2];
+    F_zeta[0][q] = scale * flux[2][0];
+    F_zeta[1][q] = scale * flux[2][1];
+    F_zeta[2][q] = scale * flux[2][2];
+  });
 
   // Pass 3: divergence — f_{ia,ib,ic} += D^T·F^ξ + D^T·F^η + D^T·F^ζ
   // The gradient coefficient (basisGradientAt) is independent of force
   // component f, so it is computed once and the short f-loop is kept innermost
   // to expose it for vectorization.
-  triple_loop<num1dNodes, num1dNodes, num1dNodes>([&](auto const icia,
-                                                      auto const icib,
-                                                      auto const icic) {
+  triple_loop<num1dNodes, num1dNodes, num1dNodes>([&](auto const icia, auto const icib, auto const icic) {
     constexpr int ia = decltype(icia)::value;
     constexpr int ib = decltype(icib)::value;
     constexpr int ic = decltype(icic)::value;
@@ -1364,17 +1206,14 @@ Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeElasticStiffnessSumFact(
 
 template <typename GL_BASIS>
 template <int qa, int qb, int qc, typename FUNC1, typename FUNC2>
-PROXY_HOST_DEVICE void
-Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeGradPhiGradPhi(
-    JacobianType &J, FUNC1 &&func1, FUNC2 &&func2)
-{
+PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeGradPhiGradPhi(JacobianType &J,
+                                                                                            FUNC1 &&func1,
+                                                                                            FUNC2 &&func2) {
   real_t const detJ = invert3x3(J.data);
-  const real_t w =
-      GL_BASIS::weight(qa) * GL_BASIS::weight(qb) * GL_BASIS::weight(qc);
+  const real_t w = GL_BASIS::weight(qa) * GL_BASIS::weight(qb) * GL_BASIS::weight(qc);
   func1(qa, qb, qc, J.data);
 #pragma unroll 1
-  for (int i = 0; i < num1dNodes; i++)
-  {
+  for (int i = 0; i < num1dNodes; i++) {
     const int ibc = GL_BASIS::TensorProduct3D::linearIndex(i, qb, qc);
     const int aic = GL_BASIS::TensorProduct3D::linearIndex(qa, i, qc);
     const int abi = GL_BASIS::TensorProduct3D::linearIndex(qa, qb, i);
@@ -1382,8 +1221,7 @@ Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeGradPhiGradPhi(
     const real_t gib = basisGradientAt(i, qb);
     const real_t gic = basisGradientAt(i, qc);
 #pragma unroll 1
-    for (int j = 0; j < num1dNodes; j++)
-    {
+    for (int j = 0; j < num1dNodes; j++) {
       const int jbc = GL_BASIS::TensorProduct3D::linearIndex(j, qb, qc);
       const int ajc = GL_BASIS::TensorProduct3D::linearIndex(qa, j, qc);
       const int abj = GL_BASIS::TensorProduct3D::linearIndex(qa, qb, j);
@@ -1414,60 +1252,43 @@ Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeGradPhiGradPhi(
 //*************************************************************************************************
 template <typename GL_BASIS>
 
-PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::
-    applyTransformationToParentGradients(int const q,
-                                         real_t const (&invJ)[3][3],
-                                         real_t (&gradN)[numNodes][3])
-{
+PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::applyTransformationToParentGradients(
+    int const q, real_t const (&invJ)[3][3], real_t (&gradN)[numNodes][3]) {
   // The sparse supportLoop only visits the 3N-2 non-zero nodes; off-line
   // entries must be zeroed explicitly since this function assigns (not
   // accumulates) gradN[nodeIndex].
-  for (int node = 0; node < numNodes; ++node)
-  {
+  for (int node = 0; node < numNodes; ++node) {
     gradN[node][0] = gradN[node][1] = gradN[node][2] = real_t(0);
   }
   supportLoop(
       q,
-      [](real_t const(&dNdXi)[3], int const nodeIndex,
-         real_t const(&invJ)[3][3], real_t(&gradN)[numNodes][3]) {
+      [](real_t const(&dNdXi)[3], int const nodeIndex, real_t const(&invJ)[3][3], real_t(&gradN)[numNodes][3]) {
         // smaller register footprint by manually unrolling the for loops.
-        gradN[nodeIndex][0] = dNdXi[0] * invJ[0][0] + dNdXi[1] * invJ[1][0] +
-                              dNdXi[2] * invJ[2][0];
-        gradN[nodeIndex][1] = dNdXi[0] * invJ[0][1] + dNdXi[1] * invJ[1][1] +
-                              dNdXi[2] * invJ[2][1];
-        gradN[nodeIndex][2] = dNdXi[0] * invJ[0][2] + dNdXi[1] * invJ[1][2] +
-                              dNdXi[2] * invJ[2][2];
+        gradN[nodeIndex][0] = dNdXi[0] * invJ[0][0] + dNdXi[1] * invJ[1][0] + dNdXi[2] * invJ[2][0];
+        gradN[nodeIndex][1] = dNdXi[0] * invJ[0][1] + dNdXi[1] * invJ[1][1] + dNdXi[2] * invJ[2][1];
+        gradN[nodeIndex][2] = dNdXi[0] * invJ[0][2] + dNdXi[1] * invJ[1][2] + dNdXi[2] * invJ[2][2];
       },
       invJ, gradN);
 }
 
 //*************************************************************************************************
 template <typename GL_BASIS>
-PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::
-    applyTransformationToParentGradients(real_t const (&coords)[3],
-                                         real_t const (&invJ)[3][3],
-                                         real_t (&gradN)[numNodes][3])
-{
+PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::applyTransformationToParentGradients(
+    real_t const (&coords)[3], real_t const (&invJ)[3][3], real_t (&gradN)[numNodes][3]) {
   supportLoop(
       coords,
-      [](real_t const(&dNdXi)[3], int const nodeIndex,
-         real_t const(&invJ)[3][3], real_t(&gradN)[numNodes][3]) {
-        gradN[nodeIndex][0] = dNdXi[0] * invJ[0][0] + dNdXi[1] * invJ[1][0] +
-                              dNdXi[2] * invJ[2][0];
-        gradN[nodeIndex][1] = dNdXi[0] * invJ[0][1] + dNdXi[1] * invJ[1][1] +
-                              dNdXi[2] * invJ[2][1];
-        gradN[nodeIndex][2] = dNdXi[0] * invJ[0][2] + dNdXi[1] * invJ[1][2] +
-                              dNdXi[2] * invJ[2][2];
+      [](real_t const(&dNdXi)[3], int const nodeIndex, real_t const(&invJ)[3][3], real_t(&gradN)[numNodes][3]) {
+        gradN[nodeIndex][0] = dNdXi[0] * invJ[0][0] + dNdXi[1] * invJ[1][0] + dNdXi[2] * invJ[2][0];
+        gradN[nodeIndex][1] = dNdXi[0] * invJ[0][1] + dNdXi[1] * invJ[1][1] + dNdXi[2] * invJ[2][1];
+        gradN[nodeIndex][2] = dNdXi[0] * invJ[0][2] + dNdXi[1] * invJ[1][2] + dNdXi[2] * invJ[2][2];
       },
       invJ, gradN);
 }
 
 template <typename GL_BASIS>
 
-PROXY_HOST_DEVICE real_t
-Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::transformedQuadratureWeight(
-    int const q, real_t const (&X)[numNodes][3])
-{
+PROXY_HOST_DEVICE real_t Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::transformedQuadratureWeight(
+    int const q, real_t const (&X)[numNodes][3]) {
   int qa, qb, qc;
   GL_BASIS::TensorProduct3D::multiIndex(q, qa, qb, qc);
   real_t J[3][3] = {{0}};
@@ -1479,21 +1300,15 @@ Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::transformedQuadratureWeight(
 
 template <typename GL_BASIS>
 
-PROXY_HOST_DEVICE void
-Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::symmetricGradient(
-    int const q, real_t const (&invJ)[3][3], real_t const (&var)[numNodes][3],
-    real_t (&grad)[6])
-{
+PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::symmetricGradient(
+    int const q, real_t const (&invJ)[3][3], real_t const (&var)[numNodes][3], real_t (&grad)[6]) {
   supportLoop(
       q,
-      [](real_t const(&dNdXi)[3], int const nodeIndex,
-         real_t const(&invJ)[3][3], real_t const(&var)[numNodes][3],
+      [](real_t const(&dNdXi)[3], int const nodeIndex, real_t const(&invJ)[3][3], real_t const(&var)[numNodes][3],
          real_t(&grad)[6]) {
         real_t gradN[3] = {0, 0, 0};
-        for (int i = 0; i < 3; ++i)
-        {
-          for (int j = 0; j < 3; ++j)
-          {
+        for (int i = 0; i < 3; ++i) {
+          for (int j = 0; j < 3; ++j) {
             gradN[i] = gradN[i] + dNdXi[j] * invJ[j][i];
           }
         }
@@ -1501,36 +1316,28 @@ Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::symmetricGradient(
         grad[0] = grad[0] + gradN[0] * var[nodeIndex][0];
         grad[1] = grad[1] + gradN[1] * var[nodeIndex][1];
         grad[2] = grad[2] + gradN[2] * var[nodeIndex][2];
-        grad[3] = grad[3] + gradN[2] * var[nodeIndex][1] +
-                  gradN[1] * var[nodeIndex][2];
-        grad[4] = grad[4] + gradN[2] * var[nodeIndex][0] +
-                  gradN[0] * var[nodeIndex][2];
-        grad[5] = grad[5] + gradN[1] * var[nodeIndex][0] +
-                  gradN[0] * var[nodeIndex][1];
+        grad[3] = grad[3] + gradN[2] * var[nodeIndex][1] + gradN[1] * var[nodeIndex][2];
+        grad[4] = grad[4] + gradN[2] * var[nodeIndex][0] + gradN[0] * var[nodeIndex][2];
+        grad[5] = grad[5] + gradN[1] * var[nodeIndex][0] + gradN[0] * var[nodeIndex][1];
       },
       invJ, var, grad);
 }
 
 template <typename GL_BASIS>
-PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::gradient(
-    int const q, real_t const (&invJ)[3][3], real_t const (&var)[numNodes][3],
-    real_t (&grad)[3][3])
-{
+PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::gradient(int const q, real_t const (&invJ)[3][3],
+                                                                               real_t const (&var)[numNodes][3],
+                                                                               real_t (&grad)[3][3]) {
   supportLoop(
       q,
-      [](real_t const(&dNdXi)[3], int const nodeIndex,
-         real_t const(&invJ)[3][3], real_t const(&var)[numNodes][3],
+      [](real_t const(&dNdXi)[3], int const nodeIndex, real_t const(&invJ)[3][3], real_t const(&var)[numNodes][3],
          real_t(&grad)[3][3]) {
-        for (int i = 0; i < 3; ++i)
-        {
+        for (int i = 0; i < 3; ++i) {
           real_t gradN = 0.0;
           ;
-          for (int j = 0; j < 3; ++j)
-          {
+          for (int j = 0; j < 3; ++j) {
             gradN = gradN + dNdXi[j] * invJ[j][i];
           }
-          for (int k = 0; k < 3; ++k)
-          {
+          for (int k = 0; k < 3; ++k) {
             grad[k][i] = grad[k][i] + gradN * var[nodeIndex][k];
           }
         }
@@ -1539,85 +1346,67 @@ PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::gradient(
 }
 
 //*************************************************************************************************
-using Q1_Hexahedron_Lagrange_GaussLobatto =
-    Qk_Hexahedron_Lagrange_GaussLobatto<LagrangeBasis1>;
+using Q1_Hexahedron_Lagrange_GaussLobatto = Qk_Hexahedron_Lagrange_GaussLobatto<LagrangeBasis1>;
 
-using Q2_Hexahedron_Lagrange_GaussLobatto =
-    Qk_Hexahedron_Lagrange_GaussLobatto<LagrangeBasis2>;
+using Q2_Hexahedron_Lagrange_GaussLobatto = Qk_Hexahedron_Lagrange_GaussLobatto<LagrangeBasis2>;
 
-using Q3_Hexahedron_Lagrange_GaussLobatto =
-    Qk_Hexahedron_Lagrange_GaussLobatto<LagrangeBasis3GL>;
+using Q3_Hexahedron_Lagrange_GaussLobatto = Qk_Hexahedron_Lagrange_GaussLobatto<LagrangeBasis3GL>;
 
-using Q4_Hexahedron_Lagrange_GaussLobatto =
-    Qk_Hexahedron_Lagrange_GaussLobatto<LagrangeBasis4GL>;
+using Q4_Hexahedron_Lagrange_GaussLobatto = Qk_Hexahedron_Lagrange_GaussLobatto<LagrangeBasis4GL>;
 
-using Q5_Hexahedron_Lagrange_GaussLobatto =
-    Qk_Hexahedron_Lagrange_GaussLobatto<LagrangeBasis5GL>;
+using Q5_Hexahedron_Lagrange_GaussLobatto = Qk_Hexahedron_Lagrange_GaussLobatto<LagrangeBasis5GL>;
 
-using Q6_Hexahedron_Lagrange_GaussLobatto =
-    Qk_Hexahedron_Lagrange_GaussLobatto<LagrangeBasis6GL>;
+using Q6_Hexahedron_Lagrange_GaussLobatto = Qk_Hexahedron_Lagrange_GaussLobatto<LagrangeBasis6GL>;
 
-using Q7_Hexahedron_Lagrange_GaussLobatto =
-    Qk_Hexahedron_Lagrange_GaussLobatto<LagrangeBasis7GL>;
+using Q7_Hexahedron_Lagrange_GaussLobatto = Qk_Hexahedron_Lagrange_GaussLobatto<LagrangeBasis7GL>;
 
-using Q8_Hexahedron_Lagrange_GaussLobatto =
-    Qk_Hexahedron_Lagrange_GaussLobatto<LagrangeBasis8GL>;
+using Q8_Hexahedron_Lagrange_GaussLobatto = Qk_Hexahedron_Lagrange_GaussLobatto<LagrangeBasis8GL>;
 
-using Q9_Hexahedron_Lagrange_GaussLobatto =
-    Qk_Hexahedron_Lagrange_GaussLobatto<LagrangeBasis9GL>;
+using Q9_Hexahedron_Lagrange_GaussLobatto = Qk_Hexahedron_Lagrange_GaussLobatto<LagrangeBasis9GL>;
 
 template <int ORDER>
 struct Qk_Hexahedron_Lagrange_GaussLobatto_Selector;
 
 template <>
-struct Qk_Hexahedron_Lagrange_GaussLobatto_Selector<1>
-{
+struct Qk_Hexahedron_Lagrange_GaussLobatto_Selector<1> {
   using type = Q1_Hexahedron_Lagrange_GaussLobatto;
 };
 
 template <>
-struct Qk_Hexahedron_Lagrange_GaussLobatto_Selector<2>
-{
+struct Qk_Hexahedron_Lagrange_GaussLobatto_Selector<2> {
   using type = Q2_Hexahedron_Lagrange_GaussLobatto;
 };
 
 template <>
-struct Qk_Hexahedron_Lagrange_GaussLobatto_Selector<3>
-{
+struct Qk_Hexahedron_Lagrange_GaussLobatto_Selector<3> {
   using type = Q3_Hexahedron_Lagrange_GaussLobatto;
 };
 
 template <>
-struct Qk_Hexahedron_Lagrange_GaussLobatto_Selector<4>
-{
+struct Qk_Hexahedron_Lagrange_GaussLobatto_Selector<4> {
   using type = Q4_Hexahedron_Lagrange_GaussLobatto;
 };
 
 template <>
-struct Qk_Hexahedron_Lagrange_GaussLobatto_Selector<5>
-{
+struct Qk_Hexahedron_Lagrange_GaussLobatto_Selector<5> {
   using type = Q5_Hexahedron_Lagrange_GaussLobatto;
 };
 
 template <>
-struct Qk_Hexahedron_Lagrange_GaussLobatto_Selector<6>
-{
+struct Qk_Hexahedron_Lagrange_GaussLobatto_Selector<6> {
   using type = Q6_Hexahedron_Lagrange_GaussLobatto;
 };
 
 template <>
-struct Qk_Hexahedron_Lagrange_GaussLobatto_Selector<7>
-{
+struct Qk_Hexahedron_Lagrange_GaussLobatto_Selector<7> {
   using type = Q7_Hexahedron_Lagrange_GaussLobatto;
 };
 template <>
-struct Qk_Hexahedron_Lagrange_GaussLobatto_Selector<8>
-{
+struct Qk_Hexahedron_Lagrange_GaussLobatto_Selector<8> {
   using type = Q8_Hexahedron_Lagrange_GaussLobatto;
 };
 template <>
-struct Qk_Hexahedron_Lagrange_GaussLobatto_Selector<9>
-{
+struct Qk_Hexahedron_Lagrange_GaussLobatto_Selector<9> {
   using type = Q9_Hexahedron_Lagrange_GaussLobatto;
 };
 #if __GNUC__

--- a/src/discretization/fe/makutu/include/tensorops.h
+++ b/src/discretization/fe/makutu/include/tensorops.h
@@ -12,11 +12,9 @@ template <typename T>
 PROXY_HOST_DEVICE T invert3x3(T (&J)[3][3]);
 
 template <typename T>
-PROXY_HOST_DEVICE T invert3x3(T (&J)[3][3])
-{
+PROXY_HOST_DEVICE T invert3x3(T (&J)[3][3]) {
   // Compute the determinant
-  T det = J[0][0] * (J[1][1] * J[2][2] - J[1][2] * J[2][1]) -
-          J[0][1] * (J[1][0] * J[2][2] - J[1][2] * J[2][0]) +
+  T det = J[0][0] * (J[1][1] * J[2][2] - J[1][2] * J[2][1]) - J[0][1] * (J[1][0] * J[2][2] - J[1][2] * J[2][0]) +
           J[0][2] * (J[1][0] * J[2][1] - J[1][1] * J[2][0]);
 
   T invDet = 1.0 / det;
@@ -55,14 +53,12 @@ template <typename T>
 PROXY_HOST_DEVICE auto invert3x3(T (&Jinv)[3][3], T (&J)[3][3]);
 
 template <typename T>
-PROXY_HOST_DEVICE auto invert3x3(T (&Jinv)[3][3], T (&J)[3][3])
-{
+PROXY_HOST_DEVICE auto invert3x3(T (&Jinv)[3][3], T (&J)[3][3]) {
   Jinv[0][0] = J[1][1] * J[2][2] - J[1][2] * J[2][1];
   Jinv[0][1] = J[0][2] * J[2][1] - J[0][1] * J[2][2];
   Jinv[0][2] = J[0][1] * J[1][2] - J[0][2] * J[1][1];
 
-  auto const det =
-      J[0][0] * Jinv[0][0] + J[1][0] * Jinv[0][1] + J[2][0] * Jinv[0][2];
+  auto const det = J[0][0] * Jinv[0][0] + J[1][0] * Jinv[0][1] + J[2][0] * Jinv[0][2];
 
   auto const invDet = T(1) / det;
 
@@ -97,8 +93,7 @@ template <int N, typename T>
 PROXY_HOST_DEVICE T symDeterminant(T (&B)[3]);
 
 template <typename T>
-PROXY_HOST_DEVICE T symDeterminant<2>(T (&B)[3])
-{
+PROXY_HOST_DEVICE T symDeterminant<2>(T (&B)[3]) {
   return B[0] * B[1] - B[2] * B[2];
 }
 
@@ -106,10 +101,8 @@ template <int N, typename T>
 PROXY_HOST_DEVICE T symDeterminant(T (&B)[6]);
 
 template <typename T>
-PROXY_HOST_DEVICE T symDeterminant<3>(T (&B)[6])
-{
-  return B[0] * B[1] * B[2] + B[5] * B[4] * B[3] * 2 - B[0] * B[3] * B[3] -
-         B[1] * B[4] * B[4] - B[2] * B[5] * B[5];
+PROXY_HOST_DEVICE T symDeterminant<3>(T (&B)[6]) {
+  return B[0] * B[1] * B[2] + B[5] * B[4] * B[3] * 2 - B[0] * B[3] * B[3] - B[1] * B[4] * B[4] - B[2] * B[5] * B[5];
 }
 
 /**
@@ -123,8 +116,7 @@ PROXY_HOST_DEVICE T symDeterminant<3>(T (&B)[6])
  * values.
  */
 template <typename T>
-PROXY_HOST_DEVICE static auto symInvert(T (&dst)[6], T const (&J)[6])
-{
+PROXY_HOST_DEVICE static auto symInvert(T (&dst)[6], T const (&J)[6]) {
   using FloatingPoint = std::decay_t<decltype(dst[0])>;
 
   dst[0] = J[1] * J[2] - J[3] * J[3];
@@ -145,8 +137,7 @@ PROXY_HOST_DEVICE static auto symInvert(T (&dst)[6], T const (&J)[6])
 }
 
 template <typename T>
-PROXY_HOST_DEVICE static auto symInvert(T (&J)[6])
-{
+PROXY_HOST_DEVICE static auto symInvert(T (&J)[6]) {
   std::remove_reference_t<decltype(J[0])> temp[6];
   auto const det = symInvert(temp, J);
   // std::copy< 6 >( J, temp );

--- a/src/gradient/api/include/differentiator.h
+++ b/src/gradient/api/include/differentiator.h
@@ -3,8 +3,7 @@
 
 #include "model.h"
 
-namespace gradient
-{
+namespace gradient {
 
 /**
  * @brief Abstract interface for gradient computation.
@@ -22,13 +21,11 @@ namespace gradient
  *   differentiator->compute(mesh, data, dt);
  *   auto grad_kappa = data.getGradient(0);
  */
-class Differentiator
-{
+class Differentiator {
  public:
   virtual ~Differentiator() = default;
 
-  struct DataStruct
-  {
+  struct DataStruct {
     virtual ~DataStruct() = default;
     virtual void print() const = 0;
   };
@@ -43,8 +40,7 @@ class Differentiator
    * @param data  Structure with required input fields and computed gradients
    * @param dt    Time step size (for acoustic and elastic time derivatives)
    */
-  virtual void compute(model::ModelApi<float, int>& mesh, DataStruct& data,
-                       float dt) const = 0;
+  virtual void compute(model::ModelApi<float, int>& mesh, DataStruct& data, float dt) const = 0;
 
   /**
    * @brief Get polynomial order of this computation.

--- a/src/gradient/api/include/gradient.h
+++ b/src/gradient/api/include/gradient.h
@@ -5,14 +5,12 @@
 
 #include "data_type.h"
 
-namespace gradient
-{
+namespace gradient {
 
 /**
  * @brief Base Gradient data structure.
  */
-class Gradient
-{
+class Gradient {
  public:
   virtual ~Gradient() = default;
 

--- a/src/gradient/api/include/physics_traits.h
+++ b/src/gradient/api/include/physics_traits.h
@@ -3,8 +3,7 @@
 
 #include "sem_enums.h"
 
-namespace gradient
-{
+namespace gradient {
 
 /**
  * @brief Compile-time properties for each gradient physics type.
@@ -24,8 +23,7 @@ namespace gradient
  *   - physics_traits_elastic.h
  */
 template <utils::enums::physicType PHYSICS>
-struct PhysicsTraits
-{
+struct PhysicsTraits {
   static constexpr const char* kName = "";
   using WavefieldViewForwardType = void;
   using WavefieldViewBackwardType = void;

--- a/src/gradient/api/include/wavefield_view.h
+++ b/src/gradient/api/include/wavefield_view.h
@@ -5,8 +5,7 @@
 
 #include "data_type.h"
 
-namespace gradient
-{
+namespace gradient {
 
 /**
  * @brief Abstract interface for read-only wavefield views (aka snapshots) in
@@ -22,8 +21,7 @@ namespace gradient
  * This design allows the Differentiator to operate on abstract wavefield views,
  * decoupling it from solver internals and enabling flexible data management.
  */
-class WavefieldView
-{
+class WavefieldView {
  public:
   virtual ~WavefieldView() = default;
 

--- a/src/gradient/impl/acoustic/include/differentiator_acoustic.h
+++ b/src/gradient/impl/acoustic/include/differentiator_acoustic.h
@@ -7,8 +7,7 @@
 #include "differentiator_data_acoustic.h"
 #include "model.h"
 
-namespace gradient
-{
+namespace gradient {
 
 /**
  * @brief Acoustic gradient computation for independent use.
@@ -23,15 +22,12 @@ namespace gradient
  *   MESH_TYPE             - Mesh topology (e.g., Cartesian)
  *   IS_MODEL_ON_NODES     - Model discretization (true=nodes, false=elements)
  */
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-class DifferentiatorAcoustic : public Differentiator
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+class DifferentiatorAcoustic : public Differentiator {
  public:
   static constexpr int kOrder = ORDER;
   static constexpr bool kIsModelOnNodes = IS_MODEL_ON_NODES;
-  static constexpr int kPointsPerElement =
-      (ORDER + 1) * (ORDER + 1) * (ORDER + 1);
+  static constexpr int kPointsPerElement = (ORDER + 1) * (ORDER + 1) * (ORDER + 1);
 
   KOKKOS_DEFAULTED_FUNCTION ~DifferentiatorAcoustic() override = default;
 
@@ -42,8 +38,7 @@ class DifferentiatorAcoustic : public Differentiator
    *   grad_kappa   = ∑_elements ∑_quadrature q_dt² * p * mass_term
    *   grad_buoyancy = ∑_elements ∑_stiffness stiffness_term * q * p
    */
-  void compute(model::ModelApi<float, int>& mesh, DataStruct& data,
-               float dt) const override;
+  void compute(model::ModelApi<float, int>& mesh, DataStruct& data, float dt) const override;
 
   int getOrder() const override;
   bool isModelOnNodes() const override;
@@ -54,12 +49,9 @@ class DifferentiatorAcoustic : public Differentiator
    *
    * Computes qdt2 = (qnPrevPrev - 2*qnPrev + qn) / dt² on the fly.
    */
-  void computeOnElements(MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const pn,
-                         VECTOR_REAL_VIEW const qn,
-                         VECTOR_REAL_VIEW const qnPrev,
-                         VECTOR_REAL_VIEW const qnPrevPrev,
-                         VECTOR_REAL_VIEW const gradKappa,
-                         VECTOR_REAL_VIEW const gradBuoyancy) const;
+  void computeOnElements(MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const pn, VECTOR_REAL_VIEW const qn,
+                         VECTOR_REAL_VIEW const qnPrev, VECTOR_REAL_VIEW const qnPrevPrev,
+                         VECTOR_REAL_VIEW const gradKappa, VECTOR_REAL_VIEW const gradBuoyancy) const;
 
   /**
    * @brief Multiple elements share boundary nodes — ATOMICADD required.
@@ -68,11 +60,9 @@ class DifferentiatorAcoustic : public Differentiator
    * Gradients are normalized by the mass matrix diagonal to account for
    * multiple elements sharing nodes at the domain interior.
    */
-  void computeOnNodes(MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const pn,
-                      VECTOR_REAL_VIEW const qn, VECTOR_REAL_VIEW const qnPrev,
-                      VECTOR_REAL_VIEW const qnPrevPrev,
-                      VECTOR_REAL_VIEW const gradKappa,
-                      VECTOR_REAL_VIEW const gradBuoyancy) const;
+  void computeOnNodes(MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const pn, VECTOR_REAL_VIEW const qn,
+                      VECTOR_REAL_VIEW const qnPrev, VECTOR_REAL_VIEW const qnPrevPrev,
+                      VECTOR_REAL_VIEW const gradKappa, VECTOR_REAL_VIEW const gradBuoyancy) const;
 };
 
 }  // namespace gradient
@@ -84,13 +74,11 @@ class DifferentiatorAcoustic : public Differentiator
 #include "model_struct.h"
 #include "model_unstruct.h"
 
-#define DECLARE_EXTERN_DIFF_ACOUSTIC(ORDER, MESH_TYPE)                         \
-  extern template class gradient::DifferentiatorAcoustic<                      \
-      ORDER, typename IntegralTypeSelector<ORDER, IntegralType::MAKUTU>::type, \
-      MESH_TYPE, true>;                                                        \
-  extern template class gradient::DifferentiatorAcoustic<                      \
-      ORDER, typename IntegralTypeSelector<ORDER, IntegralType::MAKUTU>::type, \
-      MESH_TYPE, false>;
+#define DECLARE_EXTERN_DIFF_ACOUSTIC(ORDER, MESH_TYPE)                                           \
+  extern template class gradient::DifferentiatorAcoustic<                                        \
+      ORDER, typename IntegralTypeSelector<ORDER, IntegralType::MAKUTU>::type, MESH_TYPE, true>; \
+  extern template class gradient::DifferentiatorAcoustic<                                        \
+      ORDER, typename IntegralTypeSelector<ORDER, IntegralType::MAKUTU>::type, MESH_TYPE, false>;
 
 #define DECLARE_EXTERN_DIFF_ACOUSTIC_ALL_ORDERS(MESH_TYPE_MACRO) \
   DECLARE_EXTERN_DIFF_ACOUSTIC(1, MESH_TYPE_MACRO(1))            \

--- a/src/gradient/impl/acoustic/include/differentiator_acoustic_impl.h
+++ b/src/gradient/impl/acoustic/include/differentiator_acoustic_impl.h
@@ -6,16 +6,11 @@
 
 #include "differentiator_acoustic.h"
 
-namespace gradient
-{
+namespace gradient {
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-void DifferentiatorAcoustic<
-    ORDER, INTEGRAL_TYPE, MESH_TYPE,
-    IS_MODEL_ON_NODES>::compute(model::ModelApi<float, int>& mesh,
-                                DataStruct& data, float dt) const
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::compute(
+    model::ModelApi<float, int>& mesh, DataStruct& data, float dt) const {
   auto& myData = dynamic_cast<DifferentiatorDataAcoustic&>(data);
   auto& myMesh = dynamic_cast<MESH_TYPE&>(mesh);
 
@@ -27,59 +22,39 @@ void DifferentiatorAcoustic<
   VECTOR_REAL_VIEW const gradBuoyancy = myData.getGradient(1);
 
   if constexpr (!IS_MODEL_ON_NODES)
-    computeOnElements(myMesh, dt, pn, qn, qnPrev, qnPrevPrev, gradKappa,
-                      gradBuoyancy);
+    computeOnElements(myMesh, dt, pn, qn, qnPrev, qnPrevPrev, gradKappa, gradBuoyancy);
   else
-    computeOnNodes(myMesh, dt, pn, qn, qnPrev, qnPrevPrev, gradKappa,
-                   gradBuoyancy);
+    computeOnNodes(myMesh, dt, pn, qn, qnPrev, qnPrevPrev, gradKappa, gradBuoyancy);
   Kokkos::fence();
 }
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-int DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
-                           IS_MODEL_ON_NODES>::getOrder() const
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+int DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::getOrder() const {
   return kOrder;
 }
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-bool DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
-                            IS_MODEL_ON_NODES>::isModelOnNodes() const
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+bool DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::isModelOnNodes() const {
   return kIsModelOnNodes;
 }
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
-                            IS_MODEL_ON_NODES>::print() const
-{
-  std::cout << "DifferentiatorAcoustic<ORDER=" << kOrder
-            << ", INTEGRAL_TYPE=" << typeid(INTEGRAL_TYPE).name()
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::print() const {
+  std::cout << "DifferentiatorAcoustic<ORDER=" << kOrder << ", INTEGRAL_TYPE=" << typeid(INTEGRAL_TYPE).name()
             << ", MESH_TYPE=" << typeid(MESH_TYPE).name()
-            << ", IS_MODEL_ON_NODES=" << (kIsModelOnNodes ? "true" : "false")
-            << ">\n";
+            << ", IS_MODEL_ON_NODES=" << (kIsModelOnNodes ? "true" : "false") << ">\n";
 }
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
-                            IS_MODEL_ON_NODES>::
-    computeOnElements(MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const pn,
-                      VECTOR_REAL_VIEW const qn, VECTOR_REAL_VIEW const qnPrev,
-                      VECTOR_REAL_VIEW const qnPrevPrev,
-                      VECTOR_REAL_VIEW const gradKappa,
-                      VECTOR_REAL_VIEW const gradBuoyancy) const
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::computeOnElements(
+    MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const pn, VECTOR_REAL_VIEW const qn, VECTOR_REAL_VIEW const qnPrev,
+    VECTOR_REAL_VIEW const qnPrevPrev, VECTOR_REAL_VIEW const gradKappa, VECTOR_REAL_VIEW const gradBuoyancy) const {
   constexpr int nPerElem = kPointsPerElement;
   float const invDt2 = 1.0f / (dt * dt);
 
   Kokkos::parallel_for(
       "Compute Acoustic Gradient on Elements",
-      Kokkos::RangePolicy<
-          Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(
+      Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(
           0, mesh.getNumberOfElements()),
       KOKKOS_LAMBDA(const int elementNumber) {
         if (elementNumber >= mesh.getNumberOfElements()) return;
@@ -92,22 +67,18 @@ void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
           int I = 0;
           for (int kv = 0; kv < 2; ++kv)
             for (int jv = 0; jv < 2; ++jv)
-              for (int iv = 0; iv < 2; ++iv)
-              {
-                auto const vertexIndex =
-                    mesh.globalVertexIndex(elementIndex, iv, jv, kv);
+              for (int iv = 0; iv < 2; ++iv) {
+                auto const vertexIndex = mesh.globalVertexIndex(elementIndex, iv, jv, kv);
                 mesh.vertexCoords(vertexIndex, transformData.data[I]);
                 ++I;
               }
         }
 
-        Kokkos::Array<float, nPerElem> localPn, localQn, localQnPrev,
-            localQnPrevPrev;
+        Kokkos::Array<float, nPerElem> localPn, localQn, localQnPrev, localQnPrevPrev;
 
         for (int i = 0; i < dim; ++i)
           for (int j = 0; j < dim; ++j)
-            for (int k = 0; k < dim; ++k)
-            {
+            for (int k = 0; k < dim; ++k) {
               int const gIdx = mesh.globalNodeIndex(elementNumber, i, j, k);
               int const lIdx = i + j * dim + k * dim * dim;
               localPn[lIdx] = pn(gIdx);
@@ -119,36 +90,24 @@ void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
         float const invDt2 = 1.0f / (dt * dt);
 
         float localGradKappa = 0.0f;
-        INTEGRAL_TYPE::computeMassTerm(
-            transformData, [&](const int q, const real_t val) {
-              float const qdt2 =
-                  (localQnPrevPrev[q] - 2.0f * localQnPrev[q] + localQn[q]) *
-                  invDt2;
-              localGradKappa += qdt2 * localPn[q] * val;
-            });
+        INTEGRAL_TYPE::computeMassTerm(transformData, [&](const int q, const real_t val) {
+          float const qdt2 = (localQnPrevPrev[q] - 2.0f * localQnPrev[q] + localQn[q]) * invDt2;
+          localGradKappa += qdt2 * localPn[q] * val;
+        });
         gradKappa(elementNumber) += localGradKappa;
 
         float localGradBuoyancy = 0.0f;
         INTEGRAL_TYPE::computeStiffnessTerm(
-            transformData,
-            [&](const int /*qa*/, const int /*qb*/, const int /*qc*/) {},
-            [&](const int i, const int j, const real_t val) {
-              localGradBuoyancy += val * localQn[j] * localPn[i];
-            });
+            transformData, [&](const int /*qa*/, const int /*qb*/, const int /*qc*/) {},
+            [&](const int i, const int j, const real_t val) { localGradBuoyancy += val * localQn[j] * localPn[i]; });
         gradBuoyancy(elementNumber) += localGradBuoyancy;
       });
 }
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
-                            IS_MODEL_ON_NODES>::
-    computeOnNodes(MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const pn,
-                   VECTOR_REAL_VIEW const qn, VECTOR_REAL_VIEW const qnPrev,
-                   VECTOR_REAL_VIEW const qnPrevPrev,
-                   VECTOR_REAL_VIEW const gradKappa,
-                   VECTOR_REAL_VIEW const gradBuoyancy) const
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::computeOnNodes(
+    MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const pn, VECTOR_REAL_VIEW const qn, VECTOR_REAL_VIEW const qnPrev,
+    VECTOR_REAL_VIEW const qnPrevPrev, VECTOR_REAL_VIEW const gradKappa, VECTOR_REAL_VIEW const gradBuoyancy) const {
   // Get number of nodes
   int const nNodes = mesh.getNumberOfNodes();
 
@@ -165,8 +124,7 @@ void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
   // could be precomputed and reused across iterations for efficiency.
   Kokkos::parallel_for(
       "Compute Mass Matrix Diagonal",
-      Kokkos::RangePolicy<
-          Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(
+      Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(
           0, mesh.getNumberOfElements()),
       KOKKOS_LAMBDA(const int elementNumber) {
         if (elementNumber >= mesh.getNumberOfElements()) return;
@@ -179,10 +137,8 @@ void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
           int I = 0;
           for (int kv = 0; kv < 2; ++kv)
             for (int jv = 0; jv < 2; ++jv)
-              for (int iv = 0; iv < 2; ++iv)
-              {
-                auto const vertexIndex =
-                    mesh.globalVertexIndex(elementIndex, iv, jv, kv);
+              for (int iv = 0; iv < 2; ++iv) {
+                auto const vertexIndex = mesh.globalVertexIndex(elementIndex, iv, jv, kv);
                 mesh.vertexCoords(vertexIndex, transformData.data[I]);
                 ++I;
               }
@@ -191,8 +147,7 @@ void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
         int localGIdx[nPerElem] = {0};
         for (int i = 0; i < dim; ++i)
           for (int j = 0; j < dim; ++j)
-            for (int k = 0; k < dim; ++k)
-            {
+            for (int k = 0; k < dim; ++k) {
               int const gIdx = mesh.globalNodeIndex(elementNumber, i, j, k);
               int const lIdx = i + j * dim + k * dim * dim;
               localGIdx[lIdx] = gIdx;
@@ -200,9 +155,7 @@ void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
 
         // Accumulate mass matrix diagonal: M_ii = sum_K val_i
         INTEGRAL_TYPE::computeMassTerm(transformData,
-                                       [&](const int q, const real_t val) {
-                                         ATOMICADD(massDiag(localGIdx[q]), val);
-                                       });
+                                       [&](const int q, const real_t val) { ATOMICADD(massDiag(localGIdx[q]), val); });
       });
 
   Kokkos::fence();  // Ensure mass diagonal computation is complete before
@@ -213,8 +166,7 @@ void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
   // =====================================================
   Kokkos::parallel_for(
       "Compute and Distribute Element Gradients to Nodes",
-      Kokkos::RangePolicy<
-          Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(
+      Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(
           0, mesh.getNumberOfElements()),
       KOKKOS_LAMBDA(const int elementNumber) {
         if (elementNumber >= mesh.getNumberOfElements()) return;
@@ -227,10 +179,8 @@ void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
           int I = 0;
           for (int kv = 0; kv < 2; ++kv)
             for (int jv = 0; jv < 2; ++jv)
-              for (int iv = 0; iv < 2; ++iv)
-              {
-                auto const vertexIndex =
-                    mesh.globalVertexIndex(elementIndex, iv, jv, kv);
+              for (int iv = 0; iv < 2; ++iv) {
+                auto const vertexIndex = mesh.globalVertexIndex(elementIndex, iv, jv, kv);
                 mesh.vertexCoords(vertexIndex, transformData.data[I]);
                 ++I;
               }
@@ -244,8 +194,7 @@ void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
 
         for (int i = 0; i < dim; ++i)
           for (int j = 0; j < dim; ++j)
-            for (int k = 0; k < dim; ++k)
-            {
+            for (int k = 0; k < dim; ++k) {
               int const gIdx = mesh.globalNodeIndex(elementNumber, i, j, k);
               int const lIdx = i + j * dim + k * dim * dim;
               localGIdx[lIdx] = gIdx;
@@ -261,49 +210,41 @@ void DifferentiatorAcoustic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
         // Compute element gradient for kappa
         // =====================================================
         float localGradKappa = 0.0f;
-        INTEGRAL_TYPE::computeMassTerm(
-            transformData, [&](const int q, const real_t val) {
-              float const qdt2 =
-                  (localQnPrevPrev[q] - 2.0f * localQnPrev[q] + localQn[q]) *
-                  invDt2;
-              localGradKappa += qdt2 * localPn[q] * val;
-            });
+        INTEGRAL_TYPE::computeMassTerm(transformData, [&](const int q, const real_t val) {
+          float const qdt2 = (localQnPrevPrev[q] - 2.0f * localQnPrev[q] + localQn[q]) * invDt2;
+          localGradKappa += qdt2 * localPn[q] * val;
+        });
 
         // =====================================================
         // Distribute kappa gradient to nodes, weighted by mass matrix
         // =====================================================
-        INTEGRAL_TYPE::computeMassTerm(
-            transformData, [&](const int q, const real_t val) {
-              int const gIdx = localGIdx[q];
-              // Weight: local mass value / global mass diagonal (ensures proper
-              // normalization)
-              float const weight = val / massDiag(gIdx);
-              float const contrib = localGradKappa * weight;
-              ATOMICADD(gradKappa(gIdx), contrib);
-            });
+        INTEGRAL_TYPE::computeMassTerm(transformData, [&](const int q, const real_t val) {
+          int const gIdx = localGIdx[q];
+          // Weight: local mass value / global mass diagonal (ensures proper
+          // normalization)
+          float const weight = val / massDiag(gIdx);
+          float const contrib = localGradKappa * weight;
+          ATOMICADD(gradKappa(gIdx), contrib);
+        });
 
         // =====================================================
         // Compute element gradient for buoyancy
         // =====================================================
         float localGradBuoyancy = 0.0f;
         INTEGRAL_TYPE::computeStiffnessTerm(
-            transformData,
-            [&](const int /*qa*/, const int /*qb*/, const int /*qc*/) {},
-            [&](const int i, const int j, const real_t val) {
-              localGradBuoyancy += val * localQn[j] * localPn[i];
-            });
+            transformData, [&](const int /*qa*/, const int /*qb*/, const int /*qc*/) {},
+            [&](const int i, const int j, const real_t val) { localGradBuoyancy += val * localQn[j] * localPn[i]; });
 
         // =====================================================
         // Distribute buoyancy gradient to nodes
         // For buoyancy, use the mass matrix weights of the test function nodes
         // =====================================================
-        INTEGRAL_TYPE::computeMassTerm(
-            transformData, [&](const int q, const real_t val) {
-              int const gIdx = localGIdx[q];
-              float const weight = val / massDiag(gIdx);
-              float const contrib = localGradBuoyancy * weight;
-              ATOMICADD(gradBuoyancy(gIdx), contrib);
-            });
+        INTEGRAL_TYPE::computeMassTerm(transformData, [&](const int q, const real_t val) {
+          int const gIdx = localGIdx[q];
+          float const weight = val / massDiag(gIdx);
+          float const contrib = localGradBuoyancy * weight;
+          ATOMICADD(gradBuoyancy(gIdx), contrib);
+        });
       });
 }
 

--- a/src/gradient/impl/acoustic/include/differentiator_data_acoustic.h
+++ b/src/gradient/impl/acoustic/include/differentiator_data_acoustic.h
@@ -5,8 +5,7 @@
 #include "differentiator.h"
 #include "physics_traits_acoustic.h"
 
-namespace gradient
-{
+namespace gradient {
 
 /**
  * @brief Acoustic data container for differentiator computation.
@@ -21,8 +20,7 @@ namespace gradient
  *   differentiator->compute(mesh, data, dt);
  *   auto kappa = data.getGradient(0);
  */
-struct DifferentiatorDataAcoustic : public Differentiator::DataStruct
-{
+struct DifferentiatorDataAcoustic : public Differentiator::DataStruct {
   using Traits = PhysicsTraits<utils::enums::physicType::kAcoustic>;
 
   using WavefieldViewForwardType = typename Traits::WavefieldViewForwardType;
@@ -36,12 +34,9 @@ struct DifferentiatorDataAcoustic : public Differentiator::DataStruct
    * @param bwd       Adjoint wavefield view
    * @param gradient  Gradient container for acoustic parameters
    */
-  DifferentiatorDataAcoustic(const WavefieldViewForwardAcoustic& fwd,
-                             const WavefieldViewBackwardAcoustic& bwd,
+  DifferentiatorDataAcoustic(const WavefieldViewForwardAcoustic& fwd, const WavefieldViewBackwardAcoustic& bwd,
                              const GradientAcoustic& gradient)
-      : m_fwd(fwd), m_bwd(bwd), m_gradient(gradient)
-  {
-  }
+      : m_fwd(fwd), m_bwd(bwd), m_gradient(gradient) {}
 
   PROXY_HOST_DEVICE
   VECTOR_REAL_VIEW getForwardField(int i) const { return m_fwd.getField(i); }
@@ -50,13 +45,9 @@ struct DifferentiatorDataAcoustic : public Differentiator::DataStruct
   VECTOR_REAL_VIEW getBackwardField(int i) const { return m_bwd.getField(i); }
 
   PROXY_HOST_DEVICE
-  VECTOR_REAL_VIEW getGradient(int i) const
-  {
-    return m_gradient.getGradient(i);
-  }
+  VECTOR_REAL_VIEW getGradient(int i) const { return m_gradient.getGradient(i); }
 
-  void print() const override
-  {
+  void print() const override {
     std::cout << "DifferentiatorDataAcoustic\n";
     m_fwd.print();
     m_bwd.print();

--- a/src/gradient/impl/acoustic/include/gradient_acoustic.h
+++ b/src/gradient/impl/acoustic/include/gradient_acoustic.h
@@ -6,28 +6,22 @@
 
 #include "gradient.h"
 
-namespace gradient
-{
+namespace gradient {
 /**
  * @brief Acoustic gradient data structure.
  * Arrays are kept flat for easy cpp-python-fortran interop.
  */
-class GradientAcoustic : public Gradient
-{
+class GradientAcoustic : public Gradient {
  public:
   static constexpr int kNumGrads = 2;
 
   GradientAcoustic(VECTOR_REAL_VIEW gradKappa, VECTOR_REAL_VIEW gradBuoyancy)
-      : gradKappa_(gradKappa), gradBuoyancy_(gradBuoyancy)
-  {
-  }
+      : gradKappa_(gradKappa), gradBuoyancy_(gradBuoyancy) {}
 
   int getNumGradients() const override final { return kNumGrads; }
 
-  std::string getGradientName(int i) const override final
-  {
-    switch (i)
-    {
+  std::string getGradientName(int i) const override final {
+    switch (i) {
       case 0:
         return "gradKappa";
       case 1:
@@ -39,10 +33,8 @@ class GradientAcoustic : public Gradient
 
   // TODO use template + constexpr if when C++20 is available
   PROXY_HOST_DEVICE
-  VECTOR_REAL_VIEW getGradient(int i) const override
-  {
-    switch (i)
-    {
+  VECTOR_REAL_VIEW getGradient(int i) const override {
+    switch (i) {
       case 0:
         return gradKappa_;
       case 1:
@@ -52,8 +44,7 @@ class GradientAcoustic : public Gradient
     }
   }
 
-  void print() const override
-  {
+  void print() const override {
     std::cout << "Grad Kappa size: " << gradKappa_.extent(0) << std::endl;
     std::cout << "Grad Buoyancy size: " << gradBuoyancy_.extent(0) << std::endl;
   }

--- a/src/gradient/impl/acoustic/include/physics_traits_acoustic.h
+++ b/src/gradient/impl/acoustic/include/physics_traits_acoustic.h
@@ -6,12 +6,10 @@
 #include "wavefield_view_backward_acoustic.h"
 #include "wavefield_view_forward_acoustic.h"
 
-namespace gradient
-{
+namespace gradient {
 
 template <>
-struct PhysicsTraits<utils::enums::physicType::kAcoustic>
-{
+struct PhysicsTraits<utils::enums::physicType::kAcoustic> {
   static constexpr const char* kName = "Acoustic";
   using WavefieldViewForwardType = WavefieldViewForwardAcoustic;
   using WavefieldViewBackwardType = WavefieldViewBackwardAcoustic;

--- a/src/gradient/impl/acoustic/include/wavefield_view_backward_acoustic.h
+++ b/src/gradient/impl/acoustic/include/wavefield_view_backward_acoustic.h
@@ -6,8 +6,7 @@
 
 #include "wavefield_view.h"
 
-namespace gradient
-{
+namespace gradient {
 
 /**
  * @brief Read-only view of an acoustic adjoint wavefield for gradient
@@ -30,23 +29,17 @@ namespace gradient
  *   getField(1) = qnPrev      (adjoint pressure at time n-1)
  *   getField(2) = qnPrevPrev  (adjoint pressure at time n-2)
  */
-class WavefieldViewBackwardAcoustic : public WavefieldView
-{
+class WavefieldViewBackwardAcoustic : public WavefieldView {
  public:
   static constexpr int kNumFields = 3;
 
-  WavefieldViewBackwardAcoustic(VECTOR_REAL_VIEW qn, VECTOR_REAL_VIEW qnPrev,
-                                VECTOR_REAL_VIEW qnPrevPrev)
-      : qn_(qn), qnPrev_(qnPrev), qnPrevPrev_(qnPrevPrev)
-  {
-  }
+  WavefieldViewBackwardAcoustic(VECTOR_REAL_VIEW qn, VECTOR_REAL_VIEW qnPrev, VECTOR_REAL_VIEW qnPrevPrev)
+      : qn_(qn), qnPrev_(qnPrev), qnPrevPrev_(qnPrevPrev) {}
 
   int getNumFields() const override { return kNumFields; }
 
-  std::string getFieldName(int i) const override
-  {
-    switch (i)
-    {
+  std::string getFieldName(int i) const override {
+    switch (i) {
       case 0:
         return "qn";
       case 1:
@@ -60,10 +53,8 @@ class WavefieldViewBackwardAcoustic : public WavefieldView
 
   // TODO use template + constexpr if when C++20 is available
   PROXY_HOST_DEVICE
-  VECTOR_REAL_VIEW getField(int i) const override
-  {
-    switch (i)
-    {
+  VECTOR_REAL_VIEW getField(int i) const override {
+    switch (i) {
       case 0:
         return qn_;
       case 1:
@@ -75,11 +66,9 @@ class WavefieldViewBackwardAcoustic : public WavefieldView
     }
   }
 
-  void print() const override
-  {
-    std::cout << "WavefieldViewBackwardAcoustic:" << " qn size="
-              << qn_.extent(0) << " qnPrev size=" << qnPrev_.extent(0)
-              << " qnPrevPrev size=" << qnPrevPrev_.extent(0) << "\n";
+  void print() const override {
+    std::cout << "WavefieldViewBackwardAcoustic:" << " qn size=" << qn_.extent(0)
+              << " qnPrev size=" << qnPrev_.extent(0) << " qnPrevPrev size=" << qnPrevPrev_.extent(0) << "\n";
   }
 
  private:

--- a/src/gradient/impl/acoustic/include/wavefield_view_forward_acoustic.h
+++ b/src/gradient/impl/acoustic/include/wavefield_view_forward_acoustic.h
@@ -6,8 +6,7 @@
 
 #include "wavefield_view.h"
 
-namespace gradient
-{
+namespace gradient {
 
 /**
  * @brief Read-only view of an acoustic forward wavefield for gradient
@@ -19,8 +18,7 @@ namespace gradient
  * Fields:
  *   getField(0) = pn  (current pressure)
  */
-class WavefieldViewForwardAcoustic : public WavefieldView
-{
+class WavefieldViewForwardAcoustic : public WavefieldView {
  public:
   static constexpr int kNumFields = 1;
 
@@ -34,11 +32,7 @@ class WavefieldViewForwardAcoustic : public WavefieldView
   PROXY_HOST_DEVICE
   VECTOR_REAL_VIEW getField(int i) const override { return pn_; }
 
-  void print() const override
-  {
-    std::cout << "WavefieldViewForwardAcoustic: pn size=" << pn_.extent(0)
-              << "\n";
-  }
+  void print() const override { std::cout << "WavefieldViewForwardAcoustic: pn size=" << pn_.extent(0) << "\n"; }
 
  private:
   VECTOR_REAL_VIEW pn_;  ///< Current pressure snapshot

--- a/src/gradient/impl/common/include/differentiator_factory.h
+++ b/src/gradient/impl/common/include/differentiator_factory.h
@@ -4,8 +4,7 @@
 #include "differentiator.h"
 #include "sem_enums.h"
 
-namespace gradient
-{
+namespace gradient {
 
 /**
  * @brief Factory function to create a Differentiator instance with specified
@@ -30,10 +29,10 @@ namespace gradient
  * @throws Potentially throws exceptions if invalid parameter combinations are
  * provided or if memory allocation fails.
  */
-std::unique_ptr<Differentiator> createDifferentiator(
-    utils::enums::implemType implemType, utils::enums::meshType meshType,
-    utils::enums::modelLocationType modelLocation,
-    utils::enums::physicType physicType, int order);
+std::unique_ptr<Differentiator> createDifferentiator(utils::enums::implemType implemType,
+                                                     utils::enums::meshType meshType,
+                                                     utils::enums::modelLocationType modelLocation,
+                                                     utils::enums::physicType physicType, int order);
 
 }  // namespace gradient
 #endif  // FUNTIDES_GRADIENT_IMPL_COMMON_INCLUDE_DIFFERENTIATOR_FACTORY_H_

--- a/src/gradient/impl/common/src/differentiator_factory.cc
+++ b/src/gradient/impl/common/src/differentiator_factory.cc
@@ -6,8 +6,7 @@
 #include <model_struct.h>
 #include <model_unstruct.h>
 
-namespace gradient
-{
+namespace gradient {
 
 using physicType = utils::enums::physicType;
 using meshType = utils::enums::meshType;
@@ -20,21 +19,15 @@ using implemType = utils::enums::implemType;
  * jusqu'à 1.
  */
 template <int CurrentOrder, typename FUNC>
-std::unique_ptr<Differentiator> orderDispatch(int const order, FUNC&& func)
-{
-  if (order == CurrentOrder)
-  {
+std::unique_ptr<Differentiator> orderDispatch(int const order, FUNC&& func) {
+  if (order == CurrentOrder) {
     return func(std::integral_constant<int, CurrentOrder>{});
   }
 
-  if constexpr (CurrentOrder > 1)
-  {
+  if constexpr (CurrentOrder > 1) {
     return orderDispatch<CurrentOrder - 1>(order, std::forward<FUNC>(func));
-  }
-  else
-  {
-    throw std::runtime_error("Unsupported polynomial order: " +
-                             std::to_string(order));
+  } else {
+    throw std::runtime_error("Unsupported polynomial order: " + std::to_string(order));
   }
 }
 
@@ -42,36 +35,22 @@ std::unique_ptr<Differentiator> orderDispatch(int const order, FUNC&& func)
  * @brief Creates differentiator for structured mesh.
  */
 template <auto ImplTag, int ORDER>
-std::unique_ptr<Differentiator> makeDifferentiatorStruct(bool isModelOnNodes,
-                                                         physicType physic)
-{
+std::unique_ptr<Differentiator> makeDifferentiatorStruct(bool isModelOnNodes, physicType physic) {
   using MeshT = model::ModelStruct<float, int, ORDER>;
   using SelectedIntegral = typename IntegralTypeSelector<ORDER, ImplTag>::type;
 
-  if (physic == physicType::kAcoustic)
+  if (physic == physicType::kAcoustic) {
+    if (isModelOnNodes) {
+      return std::make_unique<DifferentiatorAcoustic<ORDER, SelectedIntegral, MeshT, true>>();
+    } else {
+      return std::make_unique<DifferentiatorAcoustic<ORDER, SelectedIntegral, MeshT, false>>();
+    }
+  } else  // kElastic
   {
-    if (isModelOnNodes)
-    {
-      return std::make_unique<
-          DifferentiatorAcoustic<ORDER, SelectedIntegral, MeshT, true>>();
-    }
-    else
-    {
-      return std::make_unique<
-          DifferentiatorAcoustic<ORDER, SelectedIntegral, MeshT, false>>();
-    }
-  }
-  else  // kElastic
-  {
-    if (isModelOnNodes)
-    {
-      return std::make_unique<
-          DifferentiatorElastic<ORDER, SelectedIntegral, MeshT, true>>();
-    }
-    else
-    {
-      return std::make_unique<
-          DifferentiatorElastic<ORDER, SelectedIntegral, MeshT, false>>();
+    if (isModelOnNodes) {
+      return std::make_unique<DifferentiatorElastic<ORDER, SelectedIntegral, MeshT, true>>();
+    } else {
+      return std::make_unique<DifferentiatorElastic<ORDER, SelectedIntegral, MeshT, false>>();
     }
   }
 }
@@ -80,36 +59,22 @@ std::unique_ptr<Differentiator> makeDifferentiatorStruct(bool isModelOnNodes,
  * @brief Creates differentiator for unstructured mesh.
  */
 template <auto ImplTag, int ORDER>
-std::unique_ptr<Differentiator> makeDifferentiatorUnstruct(bool isModelOnNodes,
-                                                           physicType physic)
-{
+std::unique_ptr<Differentiator> makeDifferentiatorUnstruct(bool isModelOnNodes, physicType physic) {
   using MeshT = model::ModelUnstruct<float, int>;
   using SelectedIntegral = typename IntegralTypeSelector<ORDER, ImplTag>::type;
 
-  if (physic == physicType::kAcoustic)
+  if (physic == physicType::kAcoustic) {
+    if (isModelOnNodes) {
+      return std::make_unique<DifferentiatorAcoustic<ORDER, SelectedIntegral, MeshT, true>>();
+    } else {
+      return std::make_unique<DifferentiatorAcoustic<ORDER, SelectedIntegral, MeshT, false>>();
+    }
+  } else  // kElastic
   {
-    if (isModelOnNodes)
-    {
-      return std::make_unique<
-          DifferentiatorAcoustic<ORDER, SelectedIntegral, MeshT, true>>();
-    }
-    else
-    {
-      return std::make_unique<
-          DifferentiatorAcoustic<ORDER, SelectedIntegral, MeshT, false>>();
-    }
-  }
-  else  // kElastic
-  {
-    if (isModelOnNodes)
-    {
-      return std::make_unique<
-          DifferentiatorElastic<ORDER, SelectedIntegral, MeshT, true>>();
-    }
-    else
-    {
-      return std::make_unique<
-          DifferentiatorElastic<ORDER, SelectedIntegral, MeshT, false>>();
+    if (isModelOnNodes) {
+      return std::make_unique<DifferentiatorElastic<ORDER, SelectedIntegral, MeshT, true>>();
+    } else {
+      return std::make_unique<DifferentiatorElastic<ORDER, SelectedIntegral, MeshT, false>>();
     }
   }
 }
@@ -118,10 +83,8 @@ std::unique_ptr<Differentiator> makeDifferentiatorUnstruct(bool isModelOnNodes,
  * @brief Creates a SEM solver with the specified integral implementation.
  */
 template <auto ImplTag>
-std::unique_ptr<Differentiator> makeDifferentiatorSem(
-    int order, meshType mesh, modelLocationType modelLocation,
-    physicType physic)
-{
+std::unique_ptr<Differentiator> makeDifferentiatorSem(int order, meshType mesh, modelLocationType modelLocation,
+                                                      physicType physic) {
   bool const isModelOnNodes = (modelLocation == modelLocationType::kOnNodes);
 
 // Définir une macro de fallback au cas où CMake ne passe pas les variables
@@ -134,47 +97,31 @@ std::unique_ptr<Differentiator> makeDifferentiatorSem(
 
   // On dispatch selon la physique D'ABORD, pour injecter la bonne limite
   // d'ordre max.
-  if (physic == physicType::kAcoustic)
-  {
-    return orderDispatch<MAX_DIFFERENTIATOR_ACOUSTIC_ORDER>(
-        order, [&](auto orderIC) {
-          constexpr int ORDER = decltype(orderIC)::value;
-          return (mesh == meshType::kStruct)
-                     ? makeDifferentiatorStruct<ImplTag, ORDER>(isModelOnNodes,
-                                                                physic)
-                     : makeDifferentiatorUnstruct<ImplTag, ORDER>(
-                           isModelOnNodes, physic);
-        });
-  }
-  else if (physic == physicType::kElastic)
-  {
-    return orderDispatch<MAX_DIFFERENTIATOR_ELASTIC_ORDER>(
-        order, [&](auto orderIC) {
-          constexpr int ORDER = decltype(orderIC)::value;
-          return (mesh == meshType::kStruct)
-                     ? makeDifferentiatorStruct<ImplTag, ORDER>(isModelOnNodes,
-                                                                physic)
-                     : makeDifferentiatorUnstruct<ImplTag, ORDER>(
-                           isModelOnNodes, physic);
-        });
+  if (physic == physicType::kAcoustic) {
+    return orderDispatch<MAX_DIFFERENTIATOR_ACOUSTIC_ORDER>(order, [&](auto orderIC) {
+      constexpr int ORDER = decltype(orderIC)::value;
+      return (mesh == meshType::kStruct) ? makeDifferentiatorStruct<ImplTag, ORDER>(isModelOnNodes, physic)
+                                         : makeDifferentiatorUnstruct<ImplTag, ORDER>(isModelOnNodes, physic);
+    });
+  } else if (physic == physicType::kElastic) {
+    return orderDispatch<MAX_DIFFERENTIATOR_ELASTIC_ORDER>(order, [&](auto orderIC) {
+      constexpr int ORDER = decltype(orderIC)::value;
+      return (mesh == meshType::kStruct) ? makeDifferentiatorStruct<ImplTag, ORDER>(isModelOnNodes, physic)
+                                         : makeDifferentiatorUnstruct<ImplTag, ORDER>(isModelOnNodes, physic);
+    });
   }
 
   throw std::runtime_error("Unknown physics type");
 }
 
-std::unique_ptr<Differentiator> createDifferentiator(
-    implemType const implemType, meshType const mesh,
-    modelLocationType const modelLocation, physicType const physicType,
-    int const order)
-{
-  switch (implemType)
-  {
+std::unique_ptr<Differentiator> createDifferentiator(implemType const implemType, meshType const mesh,
+                                                     modelLocationType const modelLocation, physicType const physicType,
+                                                     int const order) {
+  switch (implemType) {
     case implemType::kMakutu:
-      return makeDifferentiatorSem<IntegralType::MAKUTU>(
-          order, mesh, modelLocation, physicType);
+      return makeDifferentiatorSem<IntegralType::MAKUTU>(order, mesh, modelLocation, physicType);
     default:
-      throw std::runtime_error("Unknown implementation type: " +
-                               std::to_string(static_cast<int>(implemType)));
+      throw std::runtime_error("Unknown implementation type: " + std::to_string(static_cast<int>(implemType)));
   }
 }
 

--- a/src/gradient/impl/elastic/include/differentiator_data_elastic.h
+++ b/src/gradient/impl/elastic/include/differentiator_data_elastic.h
@@ -5,8 +5,7 @@
 #include "differentiator.h"
 #include "physics_traits_elastic.h"
 
-namespace gradient
-{
+namespace gradient {
 
 /**
  * @brief Elastic data container for differentiator computation.
@@ -21,8 +20,7 @@ namespace gradient
  *   differentiator->compute(mesh, data, dt);
  *   auto rho = data.getGradient(0);
  */
-struct DifferentiatorDataElastic : public Differentiator::DataStruct
-{
+struct DifferentiatorDataElastic : public Differentiator::DataStruct {
   using Traits = PhysicsTraits<utils::enums::physicType::kElastic>;
 
   using WavefieldViewForwardType = typename Traits::WavefieldViewForwardType;
@@ -36,12 +34,9 @@ struct DifferentiatorDataElastic : public Differentiator::DataStruct
    * @param bwd       Adjoint wavefield view
    * @param gradient  Gradient container for elastic parameters
    */
-  DifferentiatorDataElastic(const WavefieldViewForwardElastic& fwd,
-                            const WavefieldViewBackwardElastic& bwd,
+  DifferentiatorDataElastic(const WavefieldViewForwardElastic& fwd, const WavefieldViewBackwardElastic& bwd,
                             const GradientElastic& gradient)
-      : m_fwd(fwd), m_bwd(bwd), m_gradient(gradient)
-  {
-  }
+      : m_fwd(fwd), m_bwd(bwd), m_gradient(gradient) {}
 
   PROXY_HOST_DEVICE
   VECTOR_REAL_VIEW getForwardField(int i) const { return m_fwd.getField(i); }
@@ -50,13 +45,9 @@ struct DifferentiatorDataElastic : public Differentiator::DataStruct
   VECTOR_REAL_VIEW getBackwardField(int i) const { return m_bwd.getField(i); }
 
   PROXY_HOST_DEVICE
-  VECTOR_REAL_VIEW getGradient(int i) const
-  {
-    return m_gradient.getGradient(i);
-  }
+  VECTOR_REAL_VIEW getGradient(int i) const { return m_gradient.getGradient(i); }
 
-  void print() const override
-  {
+  void print() const override {
     std::cout << "DifferentiatorDataElastic\n";
     m_fwd.print();
     m_bwd.print();

--- a/src/gradient/impl/elastic/include/differentiator_elastic.h
+++ b/src/gradient/impl/elastic/include/differentiator_elastic.h
@@ -8,8 +8,7 @@
 #include "differentiator_data_elastic.h"
 #include "model.h"
 
-namespace gradient
-{
+namespace gradient {
 
 /**
  * @brief Elastic gradient computation for independent use.
@@ -44,23 +43,19 @@ namespace gradient
  *   MESH_TYPE             - Mesh topology (e.g., Cartesian)
  *   IS_MODEL_ON_NODES     - Model discretization (true=nodes, false=elements)
  */
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-class DifferentiatorElastic : public Differentiator
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+class DifferentiatorElastic : public Differentiator {
  public:
   static constexpr int kOrder = ORDER;
   static constexpr bool kIsModelOnNodes = IS_MODEL_ON_NODES;
-  static constexpr int kPointsPerElement =
-      (ORDER + 1) * (ORDER + 1) * (ORDER + 1);
+  static constexpr int kPointsPerElement = (ORDER + 1) * (ORDER + 1) * (ORDER + 1);
 
   ~DifferentiatorElastic() override = default;
 
   /**
    * @brief Compute elastic gradients (Rho, Lambda, Mu).
    */
-  void compute(model::ModelApi<float, int>& mesh, DataStruct& data,
-               float dt) const override;
+  void compute(model::ModelApi<float, int>& mesh, DataStruct& data, float dt) const override;
 
   int getOrder() const override;
   bool isModelOnNodes() const override;
@@ -78,35 +73,28 @@ class DifferentiatorElastic : public Differentiator
    * @param grad       Output: gradient tensor grad[3] (spatial derivatives)
    */
   KOKKOS_INLINE_FUNCTION
-  static void computeDisplacementGradient(
-      int qa, int qb, int qc, float const (&J)[3][3], float const* localUx,
-      float const* localUy, float const* localUz, float (&grad)[3][3]);
+  static void computeDisplacementGradient(int qa, int qb, int qc, float const (&J)[3][3], float const* localUx,
+                                          float const* localUy, float const* localUz, float (&grad)[3][3]);
 
   /**
    * @brief Element-based model: each element writes to a unique index — no
    * atomic add required.
    */
-  void computeOnElements(
-      MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const ux_fwd,
-      VECTOR_REAL_VIEW const uy_fwd, VECTOR_REAL_VIEW const uz_fwd,
-      VECTOR_REAL_VIEW const ux_adj, VECTOR_REAL_VIEW const uy_adj,
-      VECTOR_REAL_VIEW const uz_adj, VECTOR_REAL_VIEW const ux_dt2,
-      VECTOR_REAL_VIEW const uy_dt2, VECTOR_REAL_VIEW const uz_dt2,
-      VECTOR_REAL_VIEW const gradRho, VECTOR_REAL_VIEW const gradLambda,
-      VECTOR_REAL_VIEW const gradMu) const;
+  void computeOnElements(MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const ux_fwd, VECTOR_REAL_VIEW const uy_fwd,
+                         VECTOR_REAL_VIEW const uz_fwd, VECTOR_REAL_VIEW const ux_adj, VECTOR_REAL_VIEW const uy_adj,
+                         VECTOR_REAL_VIEW const uz_adj, VECTOR_REAL_VIEW const ux_dt2, VECTOR_REAL_VIEW const uy_dt2,
+                         VECTOR_REAL_VIEW const uz_dt2, VECTOR_REAL_VIEW const gradRho,
+                         VECTOR_REAL_VIEW const gradLambda, VECTOR_REAL_VIEW const gradMu) const;
 
   /**
    * @brief Node-based model: multiple elements share boundary nodes — ATOMICADD
    * required.
    */
-  void computeOnNodes(
-      MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const ux_fwd,
-      VECTOR_REAL_VIEW const uy_fwd, VECTOR_REAL_VIEW const uz_fwd,
-      VECTOR_REAL_VIEW const ux_adj, VECTOR_REAL_VIEW const uy_adj,
-      VECTOR_REAL_VIEW const uz_adj, VECTOR_REAL_VIEW const ux_dt2,
-      VECTOR_REAL_VIEW const uy_dt2, VECTOR_REAL_VIEW const uz_dt2,
-      VECTOR_REAL_VIEW const gradRho, VECTOR_REAL_VIEW const gradLambda,
-      VECTOR_REAL_VIEW const gradMu) const;
+  void computeOnNodes(MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const ux_fwd, VECTOR_REAL_VIEW const uy_fwd,
+                      VECTOR_REAL_VIEW const uz_fwd, VECTOR_REAL_VIEW const ux_adj, VECTOR_REAL_VIEW const uy_adj,
+                      VECTOR_REAL_VIEW const uz_adj, VECTOR_REAL_VIEW const ux_dt2, VECTOR_REAL_VIEW const uy_dt2,
+                      VECTOR_REAL_VIEW const uz_dt2, VECTOR_REAL_VIEW const gradRho, VECTOR_REAL_VIEW const gradLambda,
+                      VECTOR_REAL_VIEW const gradMu) const;
 };
 
 }  // namespace gradient
@@ -118,13 +106,11 @@ class DifferentiatorElastic : public Differentiator
 #include "model_struct.h"
 #include "model_unstruct.h"
 
-#define DECLARE_EXTERN_DIFF_ELASTIC(ORDER, MESH_TYPE)                          \
-  extern template class gradient::DifferentiatorElastic<                       \
-      ORDER, typename IntegralTypeSelector<ORDER, IntegralType::MAKUTU>::type, \
-      MESH_TYPE, true>;                                                        \
-  extern template class gradient::DifferentiatorElastic<                       \
-      ORDER, typename IntegralTypeSelector<ORDER, IntegralType::MAKUTU>::type, \
-      MESH_TYPE, false>;
+#define DECLARE_EXTERN_DIFF_ELASTIC(ORDER, MESH_TYPE)                                            \
+  extern template class gradient::DifferentiatorElastic<                                         \
+      ORDER, typename IntegralTypeSelector<ORDER, IntegralType::MAKUTU>::type, MESH_TYPE, true>; \
+  extern template class gradient::DifferentiatorElastic<                                         \
+      ORDER, typename IntegralTypeSelector<ORDER, IntegralType::MAKUTU>::type, MESH_TYPE, false>;
 
 #define DECLARE_EXTERN_DIFF_ELASTIC_ALL_ORDERS(MESH_TYPE_MACRO) \
   DECLARE_EXTERN_DIFF_ELASTIC(1, MESH_TYPE_MACRO(1))            \

--- a/src/gradient/impl/elastic/include/differentiator_elastic_impl.h
+++ b/src/gradient/impl/elastic/include/differentiator_elastic_impl.h
@@ -6,14 +6,11 @@
 
 #include "differentiator_elastic.h"
 
-namespace gradient
-{
+namespace gradient {
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::
-    compute(model::ModelApi<float, int>& mesh, DataStruct& data, float dt) const
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::compute(
+    model::ModelApi<float, int>& mesh, DataStruct& data, float dt) const {
   auto& myData = dynamic_cast<DifferentiatorDataElastic&>(data);
   auto& myMesh = dynamic_cast<MESH_TYPE&>(mesh);
 
@@ -34,61 +31,44 @@ void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::
   VECTOR_REAL_VIEW const gradMu = myData.getGradient(2);
 
   if constexpr (!IS_MODEL_ON_NODES)
-    computeOnElements(myMesh, dt, ux_fwd, uy_fwd, uz_fwd, ux_adj, uy_adj,
-                      uz_adj, ux_dt2, uy_dt2, uz_dt2, gradRho, gradLambda,
-                      gradMu);
+    computeOnElements(myMesh, dt, ux_fwd, uy_fwd, uz_fwd, ux_adj, uy_adj, uz_adj, ux_dt2, uy_dt2, uz_dt2, gradRho,
+                      gradLambda, gradMu);
   else
-    computeOnNodes(myMesh, dt, ux_fwd, uy_fwd, uz_fwd, ux_adj, uy_adj, uz_adj,
-                   ux_dt2, uy_dt2, uz_dt2, gradRho, gradLambda, gradMu);
+    computeOnNodes(myMesh, dt, ux_fwd, uy_fwd, uz_fwd, ux_adj, uy_adj, uz_adj, ux_dt2, uy_dt2, uz_dt2, gradRho,
+                   gradLambda, gradMu);
   Kokkos::fence();
 }
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-int DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
-                          IS_MODEL_ON_NODES>::getOrder() const
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+int DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::getOrder() const {
   return kOrder;
 }
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-bool DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
-                           IS_MODEL_ON_NODES>::isModelOnNodes() const
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+bool DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::isModelOnNodes() const {
   return kIsModelOnNodes;
 }
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
-                           IS_MODEL_ON_NODES>::print() const
-{
-  std::cout << "DifferentiatorElastic<ORDER=" << kOrder
-            << ", INTEGRAL_TYPE=" << typeid(INTEGRAL_TYPE).name()
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::print() const {
+  std::cout << "DifferentiatorElastic<ORDER=" << kOrder << ", INTEGRAL_TYPE=" << typeid(INTEGRAL_TYPE).name()
             << ", MESH_TYPE=" << typeid(MESH_TYPE).name()
-            << ", IS_MODEL_ON_NODES=" << (kIsModelOnNodes ? "true" : "false")
-            << ">\n";
+            << ", IS_MODEL_ON_NODES=" << (kIsModelOnNodes ? "true" : "false") << ">\n";
 }
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
 KOKKOS_INLINE_FUNCTION void
-DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::
-    computeDisplacementGradient(int qa, int qb, int qc, float const (&J)[3][3],
-                                float const* localUx, float const* localUy,
-                                float const* localUz, float (&grad)[3][3])
-{
+DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::computeDisplacementGradient(
+    int qa, int qb, int qc, float const (&J)[3][3], float const* localUx, float const* localUy, float const* localUz,
+    float (&grad)[3][3]) {
   int const dim = kOrder + 1;
   for (int c = 0; c < 3; ++c)
     for (int d = 0; d < 3; ++d) grad[c][d] = 0.0f;
 
-  for (int n = 0; n < dim; ++n)
-  {
+  for (int n = 0; n < dim; ++n) {
     int const nIdx_a = n + qb * dim + qc * dim * dim;
     float const dNdxi0 = INTEGRAL_TYPE::basisGradientAt(n, qa);
-    for (int d = 0; d < 3; ++d)
-    {
+    for (int d = 0; d < 3; ++d) {
       float const JdN = dNdxi0 * J[0][d];
       grad[0][d] += JdN * localUx[nIdx_a];
       grad[1][d] += JdN * localUy[nIdx_a];
@@ -97,8 +77,7 @@ DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::
 
     int const nIdx_b = qa + n * dim + qc * dim * dim;
     float const dNdxi1 = INTEGRAL_TYPE::basisGradientAt(n, qb);
-    for (int d = 0; d < 3; ++d)
-    {
+    for (int d = 0; d < 3; ++d) {
       float const JdN = dNdxi1 * J[1][d];
       grad[0][d] += JdN * localUx[nIdx_b];
       grad[1][d] += JdN * localUy[nIdx_b];
@@ -107,8 +86,7 @@ DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::
 
     int const nIdx_c = qa + qb * dim + n * dim * dim;
     float const dNdxi2 = INTEGRAL_TYPE::basisGradientAt(n, qc);
-    for (int d = 0; d < 3; ++d)
-    {
+    for (int d = 0; d < 3; ++d) {
       float const JdN = dNdxi2 * J[2][d];
       grad[0][d] += JdN * localUx[nIdx_c];
       grad[1][d] += JdN * localUy[nIdx_c];
@@ -117,22 +95,16 @@ DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::
   }
 }
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::
-    computeOnElements(
-        MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const ux_fwd,
-        VECTOR_REAL_VIEW const uy_fwd, VECTOR_REAL_VIEW const uz_fwd,
-        VECTOR_REAL_VIEW const ux_adj, VECTOR_REAL_VIEW const uy_adj,
-        VECTOR_REAL_VIEW const uz_adj, VECTOR_REAL_VIEW const ux_dt2,
-        VECTOR_REAL_VIEW const uy_dt2, VECTOR_REAL_VIEW const uz_dt2,
-        VECTOR_REAL_VIEW const gradRho, VECTOR_REAL_VIEW const gradLambda,
-        VECTOR_REAL_VIEW const gradMu) const
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::computeOnElements(
+    MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const ux_fwd, VECTOR_REAL_VIEW const uy_fwd,
+    VECTOR_REAL_VIEW const uz_fwd, VECTOR_REAL_VIEW const ux_adj, VECTOR_REAL_VIEW const uy_adj,
+    VECTOR_REAL_VIEW const uz_adj, VECTOR_REAL_VIEW const ux_dt2, VECTOR_REAL_VIEW const uy_dt2,
+    VECTOR_REAL_VIEW const uz_dt2, VECTOR_REAL_VIEW const gradRho, VECTOR_REAL_VIEW const gradLambda,
+    VECTOR_REAL_VIEW const gradMu) const {
   Kokkos::parallel_for(
       "Compute Elastic Gradient on Elements",
-      Kokkos::RangePolicy<
-          Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(
+      Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(
           0, mesh.getNumberOfElements()),
       KOKKOS_LAMBDA(const int elementNumber) {
         if (elementNumber >= mesh.getNumberOfElements()) return;
@@ -151,8 +123,7 @@ void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::
 
         for (int i = 0; i < dim; ++i)
           for (int j = 0; j < dim; ++j)
-            for (int k = 0; k < dim; ++k)
-            {
+            for (int k = 0; k < dim; ++k) {
               int const gIdx = mesh.globalNodeIndex(elementNumber, i, j, k);
               int const lIdx = i + j * dim + k * dim * dim;
               localUxFwd[lIdx] = ux_fwd(gIdx);
@@ -172,10 +143,8 @@ void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::
           int I = 0;
           for (int kv = 0; kv < 2; ++kv)
             for (int jv = 0; jv < 2; ++jv)
-              for (int iv = 0; iv < 2; ++iv)
-              {
-                auto const vertexIndex =
-                    mesh.globalVertexIndex(elementIndex, iv, jv, kv);
+              for (int iv = 0; iv < 2; ++iv) {
+                auto const vertexIndex = mesh.globalVertexIndex(elementIndex, iv, jv, kv);
                 mesh.vertexCoords(vertexIndex, transformData.data[I]);
                 ++I;
               }
@@ -189,17 +158,13 @@ void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::
             [&](int qa, int qb, int qc, float const(&J)[3][3]) {
               float grad_fwd[3][3] = {{0}};
               float grad_adj[3][3] = {{0}};
-              computeDisplacementGradient(qa, qb, qc, J, localUxFwd, localUyFwd,
-                                          localUzFwd, grad_fwd);
-              computeDisplacementGradient(qa, qb, qc, J, localUxAdj, localUyAdj,
-                                          localUzAdj, grad_adj);
+              computeDisplacementGradient(qa, qb, qc, J, localUxFwd, localUyFwd, localUzFwd, grad_fwd);
+              computeDisplacementGradient(qa, qb, qc, J, localUxAdj, localUyAdj, localUzAdj, grad_adj);
 
               int const qIdx = qa + qb * dim + qc * dim * dim;
 
-              float const div_fwd =
-                  grad_fwd[0][0] + grad_fwd[1][1] + grad_fwd[2][2];
-              float const div_adj =
-                  grad_adj[0][0] + grad_adj[1][1] + grad_adj[2][2];
+              float const div_fwd = grad_fwd[0][0] + grad_fwd[1][1] + grad_fwd[2][2];
+              float const div_adj = grad_adj[0][0] + grad_adj[1][1] + grad_adj[2][2];
               strainDiv[qIdx] = div_adj * div_fwd;
 
               float const exx_f = grad_fwd[0][0];
@@ -216,9 +181,8 @@ void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::
               float const exz_a = 0.5f * (grad_adj[0][2] + grad_adj[2][0]);
               float const eyz_a = 0.5f * (grad_adj[1][2] + grad_adj[2][1]);
 
-              strainEps[qIdx] =
-                  2.0f * (exx_a * exx_f + eyy_a * eyy_f + ezz_a * ezz_f) +
-                  4.0f * (exy_a * exy_f + exz_a * exz_f + eyz_a * eyz_f);
+              strainEps[qIdx] = 2.0f * (exx_a * exx_f + eyy_a * eyy_f + ezz_a * ezz_f) +
+                                4.0f * (exy_a * exy_f + exz_a * exz_f + eyz_a * eyz_f);
             },
             [&](int, int, float, const int, const int) {});
 
@@ -226,15 +190,12 @@ void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::
         float localGradLambda = 0.0f;
         float localGradMu = 0.0f;
 
-        INTEGRAL_TYPE::computeMassTerm(
-            transformData, [&](const int q, const real_t wdetJ) {
-              localGradRho += (localUxDt2[q] * localUxFwd[q] +
-                               localUyDt2[q] * localUyFwd[q] +
-                               localUzDt2[q] * localUzFwd[q]) *
-                              wdetJ;
-              localGradLambda += strainDiv[q] * wdetJ;
-              localGradMu += strainEps[q] * wdetJ;
-            });
+        INTEGRAL_TYPE::computeMassTerm(transformData, [&](const int q, const real_t wdetJ) {
+          localGradRho +=
+              (localUxDt2[q] * localUxFwd[q] + localUyDt2[q] * localUyFwd[q] + localUzDt2[q] * localUzFwd[q]) * wdetJ;
+          localGradLambda += strainDiv[q] * wdetJ;
+          localGradMu += strainEps[q] * wdetJ;
+        });
 
         gradRho(elementNumber) += localGradRho;
         gradLambda(elementNumber) += localGradLambda;
@@ -242,22 +203,16 @@ void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::
       });
 }
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::
-    computeOnNodes(MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const ux_fwd,
-                   VECTOR_REAL_VIEW const uy_fwd, VECTOR_REAL_VIEW const uz_fwd,
-                   VECTOR_REAL_VIEW const ux_adj, VECTOR_REAL_VIEW const uy_adj,
-                   VECTOR_REAL_VIEW const uz_adj, VECTOR_REAL_VIEW const ux_dt2,
-                   VECTOR_REAL_VIEW const uy_dt2, VECTOR_REAL_VIEW const uz_dt2,
-                   VECTOR_REAL_VIEW const gradRho,
-                   VECTOR_REAL_VIEW const gradLambda,
-                   VECTOR_REAL_VIEW const gradMu) const
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::computeOnNodes(
+    MESH_TYPE mesh, float dt, VECTOR_REAL_VIEW const ux_fwd, VECTOR_REAL_VIEW const uy_fwd,
+    VECTOR_REAL_VIEW const uz_fwd, VECTOR_REAL_VIEW const ux_adj, VECTOR_REAL_VIEW const uy_adj,
+    VECTOR_REAL_VIEW const uz_adj, VECTOR_REAL_VIEW const ux_dt2, VECTOR_REAL_VIEW const uy_dt2,
+    VECTOR_REAL_VIEW const uz_dt2, VECTOR_REAL_VIEW const gradRho, VECTOR_REAL_VIEW const gradLambda,
+    VECTOR_REAL_VIEW const gradMu) const {
   Kokkos::parallel_for(
       "Compute Elastic Gradient on Nodes",
-      Kokkos::RangePolicy<
-          Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(
+      Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(
           0, mesh.getNumberOfElements()),
       KOKKOS_LAMBDA(const int elementNumber) {
         if (elementNumber >= mesh.getNumberOfElements()) return;
@@ -277,8 +232,7 @@ void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::
 
         for (int i = 0; i < dim; ++i)
           for (int j = 0; j < dim; ++j)
-            for (int k = 0; k < dim; ++k)
-            {
+            for (int k = 0; k < dim; ++k) {
               int const gIdx = mesh.globalNodeIndex(elementNumber, i, j, k);
               int const lIdx = i + j * dim + k * dim * dim;
               localGIdx[lIdx] = gIdx;
@@ -299,10 +253,8 @@ void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::
           int I = 0;
           for (int kv = 0; kv < 2; ++kv)
             for (int jv = 0; jv < 2; ++jv)
-              for (int iv = 0; iv < 2; ++iv)
-              {
-                auto const vertexIndex =
-                    mesh.globalVertexIndex(elementIndex, iv, jv, kv);
+              for (int iv = 0; iv < 2; ++iv) {
+                auto const vertexIndex = mesh.globalVertexIndex(elementIndex, iv, jv, kv);
                 mesh.vertexCoords(vertexIndex, transformData.data[I]);
                 ++I;
               }
@@ -316,17 +268,13 @@ void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::
             [&](int qa, int qb, int qc, float const(&J)[3][3]) {
               float grad_fwd[3][3] = {{0}};
               float grad_adj[3][3] = {{0}};
-              computeDisplacementGradient(qa, qb, qc, J, localUxFwd, localUyFwd,
-                                          localUzFwd, grad_fwd);
-              computeDisplacementGradient(qa, qb, qc, J, localUxAdj, localUyAdj,
-                                          localUzAdj, grad_adj);
+              computeDisplacementGradient(qa, qb, qc, J, localUxFwd, localUyFwd, localUzFwd, grad_fwd);
+              computeDisplacementGradient(qa, qb, qc, J, localUxAdj, localUyAdj, localUzAdj, grad_adj);
 
               int const qIdx = qa + qb * dim + qc * dim * dim;
 
-              float const div_fwd =
-                  grad_fwd[0][0] + grad_fwd[1][1] + grad_fwd[2][2];
-              float const div_adj =
-                  grad_adj[0][0] + grad_adj[1][1] + grad_adj[2][2];
+              float const div_fwd = grad_fwd[0][0] + grad_fwd[1][1] + grad_fwd[2][2];
+              float const div_adj = grad_adj[0][0] + grad_adj[1][1] + grad_adj[2][2];
               strainDiv[qIdx] = div_adj * div_fwd;
 
               float const exx_f = grad_fwd[0][0];
@@ -343,21 +291,18 @@ void DifferentiatorElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::
               float const exz_a = 0.5f * (grad_adj[0][2] + grad_adj[2][0]);
               float const eyz_a = 0.5f * (grad_adj[1][2] + grad_adj[2][1]);
 
-              strainEps[qIdx] =
-                  2.0f * (exx_a * exx_f + eyy_a * eyy_f + ezz_a * ezz_f) +
-                  4.0f * (exy_a * exy_f + exz_a * exz_f + eyz_a * eyz_f);
+              strainEps[qIdx] = 2.0f * (exx_a * exx_f + eyy_a * eyy_f + ezz_a * ezz_f) +
+                                4.0f * (exy_a * exy_f + exz_a * exz_f + eyz_a * eyz_f);
             },
             [&](int, int, float, const int, const int) {});
 
-        INTEGRAL_TYPE::computeMassTerm(
-            transformData, [&](const int q, const real_t wdetJ) {
-              float const dot = localUxDt2[q] * localUxFwd[q] +
-                                localUyDt2[q] * localUyFwd[q] +
-                                localUzDt2[q] * localUzFwd[q];
-              ATOMICADD(gradRho(localGIdx[q]), dot * wdetJ);
-              ATOMICADD(gradLambda(localGIdx[q]), strainDiv[q] * wdetJ);
-              ATOMICADD(gradMu(localGIdx[q]), strainEps[q] * wdetJ);
-            });
+        INTEGRAL_TYPE::computeMassTerm(transformData, [&](const int q, const real_t wdetJ) {
+          float const dot =
+              localUxDt2[q] * localUxFwd[q] + localUyDt2[q] * localUyFwd[q] + localUzDt2[q] * localUzFwd[q];
+          ATOMICADD(gradRho(localGIdx[q]), dot * wdetJ);
+          ATOMICADD(gradLambda(localGIdx[q]), strainDiv[q] * wdetJ);
+          ATOMICADD(gradMu(localGIdx[q]), strainEps[q] * wdetJ);
+        });
       });
 }
 

--- a/src/gradient/impl/elastic/include/gradient_elastic.h
+++ b/src/gradient/impl/elastic/include/gradient_elastic.h
@@ -6,29 +6,22 @@
 
 #include "gradient.h"
 
-namespace gradient
-{
+namespace gradient {
 /**
  * @brief Elastic gradient data structure.
  * Arrays are kept flat for easy cpp-python-fortran interop.
  */
-class GradientElastic : public Gradient
-{
+class GradientElastic : public Gradient {
  public:
   static constexpr int kNumGrads = 3;
 
-  GradientElastic(VECTOR_REAL_VIEW gradRho, VECTOR_REAL_VIEW gradLambda,
-                  VECTOR_REAL_VIEW gradMu)
-      : gradRho_(gradRho), gradLambda_(gradLambda), gradMu_(gradMu)
-  {
-  }
+  GradientElastic(VECTOR_REAL_VIEW gradRho, VECTOR_REAL_VIEW gradLambda, VECTOR_REAL_VIEW gradMu)
+      : gradRho_(gradRho), gradLambda_(gradLambda), gradMu_(gradMu) {}
 
   int getNumGradients() const override final { return kNumGrads; }
 
-  std::string getGradientName(int i) const override final
-  {
-    switch (i)
-    {
+  std::string getGradientName(int i) const override final {
+    switch (i) {
       case 0:
         return "gradRho";
       case 1:
@@ -42,10 +35,8 @@ class GradientElastic : public Gradient
 
   // TODO use template + constexpr if when C++20 is available
   PROXY_HOST_DEVICE
-  VECTOR_REAL_VIEW getGradient(int i) const override
-  {
-    switch (i)
-    {
+  VECTOR_REAL_VIEW getGradient(int i) const override {
+    switch (i) {
       case 0:
         return gradRho_;
       case 1:
@@ -57,8 +48,7 @@ class GradientElastic : public Gradient
     }
   }
 
-  void print() const override
-  {
+  void print() const override {
     std::cout << "Grad Rho size: " << gradRho_.extent(0) << std::endl;
     std::cout << "Grad Lambda size: " << gradLambda_.extent(0) << std::endl;
     std::cout << "Grad Mu size: " << gradMu_.extent(0) << std::endl;

--- a/src/gradient/impl/elastic/include/physics_traits_elastic.h
+++ b/src/gradient/impl/elastic/include/physics_traits_elastic.h
@@ -6,12 +6,10 @@
 #include "wavefield_view_backward_elastic.h"
 #include "wavefield_view_forward_elastic.h"
 
-namespace gradient
-{
+namespace gradient {
 
 template <>
-struct PhysicsTraits<utils::enums::physicType::kElastic>
-{
+struct PhysicsTraits<utils::enums::physicType::kElastic> {
   static constexpr const char* kName = "Elastic";
   using WavefieldViewForwardType = WavefieldViewForwardElastic;
   using WavefieldViewBackwardType = WavefieldViewBackwardElastic;

--- a/src/gradient/impl/elastic/include/wavefield_view_backward_elastic.h
+++ b/src/gradient/impl/elastic/include/wavefield_view_backward_elastic.h
@@ -7,8 +7,7 @@
 
 #include "wavefield_view.h"
 
-namespace gradient
-{
+namespace gradient {
 
 /**
  * @brief Read-only view of an elastic adjoint wavefield for gradient
@@ -29,29 +28,18 @@ namespace gradient
  *   getField(4) = uy_dt2  (second-order time derivative, y-component)
  *   getField(5) = uz_dt2  (second-order time derivative, z-component)
  */
-class WavefieldViewBackwardElastic : public WavefieldView
-{
+class WavefieldViewBackwardElastic : public WavefieldView {
  public:
   static constexpr int kNumFields = 6;
 
-  WavefieldViewBackwardElastic(VECTOR_REAL_VIEW ux_n, VECTOR_REAL_VIEW uy_n,
-                               VECTOR_REAL_VIEW uz_n, VECTOR_REAL_VIEW ux_dt2,
-                               VECTOR_REAL_VIEW uy_dt2, VECTOR_REAL_VIEW uz_dt2)
-      : ux_n_(ux_n),
-        uy_n_(uy_n),
-        uz_n_(uz_n),
-        ux_dt2_(ux_dt2),
-        uy_dt2_(uy_dt2),
-        uz_dt2_(uz_dt2)
-  {
-  }
+  WavefieldViewBackwardElastic(VECTOR_REAL_VIEW ux_n, VECTOR_REAL_VIEW uy_n, VECTOR_REAL_VIEW uz_n,
+                               VECTOR_REAL_VIEW ux_dt2, VECTOR_REAL_VIEW uy_dt2, VECTOR_REAL_VIEW uz_dt2)
+      : ux_n_(ux_n), uy_n_(uy_n), uz_n_(uz_n), ux_dt2_(ux_dt2), uy_dt2_(uy_dt2), uz_dt2_(uz_dt2) {}
 
   int getNumFields() const override { return kNumFields; }
 
-  std::string getFieldName(int i) const override
-  {
-    switch (i)
-    {
+  std::string getFieldName(int i) const override {
+    switch (i) {
       case 0:
         return "ux_n";
       case 1:
@@ -71,10 +59,8 @@ class WavefieldViewBackwardElastic : public WavefieldView
 
   // TODO use template + constexpr if when C++20 is available
   PROXY_HOST_DEVICE
-  VECTOR_REAL_VIEW getField(int i) const override
-  {
-    switch (i)
-    {
+  VECTOR_REAL_VIEW getField(int i) const override {
+    switch (i) {
       case 0:
         return ux_n_;
       case 1:
@@ -92,14 +78,10 @@ class WavefieldViewBackwardElastic : public WavefieldView
     }
   }
 
-  void print() const override
-  {
-    std::cout << "WavefieldViewBackwardElastic:" << " ux_n size="
-              << ux_n_.extent(0) << " uy_n size=" << uy_n_.extent(0)
-              << " uz_n size=" << uz_n_.extent(0)
-              << " ux_dt2 size=" << ux_dt2_.extent(0)
-              << " uy_dt2 size=" << uy_dt2_.extent(0)
-              << " uz_dt2 size=" << uz_dt2_.extent(0) << "\n";
+  void print() const override {
+    std::cout << "WavefieldViewBackwardElastic:" << " ux_n size=" << ux_n_.extent(0) << " uy_n size=" << uy_n_.extent(0)
+              << " uz_n size=" << uz_n_.extent(0) << " ux_dt2 size=" << ux_dt2_.extent(0)
+              << " uy_dt2 size=" << uy_dt2_.extent(0) << " uz_dt2 size=" << uz_dt2_.extent(0) << "\n";
   }
 
  private:

--- a/src/gradient/impl/elastic/include/wavefield_view_forward_elastic.h
+++ b/src/gradient/impl/elastic/include/wavefield_view_forward_elastic.h
@@ -6,8 +6,7 @@
 
 #include "wavefield_view.h"
 
-namespace gradient
-{
+namespace gradient {
 
 /**
  * @brief Read-only view of an elastic forward wavefield for gradient
@@ -22,23 +21,17 @@ namespace gradient
  *   getField(1) = uy_n  (current y-displacement)
  *   getField(2) = uz_n  (current z-displacement)
  */
-class WavefieldViewForwardElastic : public WavefieldView
-{
+class WavefieldViewForwardElastic : public WavefieldView {
  public:
   static constexpr int kNumFields = 3;
 
-  WavefieldViewForwardElastic(VECTOR_REAL_VIEW ux_n, VECTOR_REAL_VIEW uy_n,
-                              VECTOR_REAL_VIEW uz_n)
-      : ux_n_(ux_n), uy_n_(uy_n), uz_n_(uz_n)
-  {
-  }
+  WavefieldViewForwardElastic(VECTOR_REAL_VIEW ux_n, VECTOR_REAL_VIEW uy_n, VECTOR_REAL_VIEW uz_n)
+      : ux_n_(ux_n), uy_n_(uy_n), uz_n_(uz_n) {}
 
   int getNumFields() const override { return kNumFields; }
 
-  std::string getFieldName(int i) const override
-  {
-    switch (i)
-    {
+  std::string getFieldName(int i) const override {
+    switch (i) {
       case 0:
         return "ux_n";
       case 1:
@@ -52,10 +45,8 @@ class WavefieldViewForwardElastic : public WavefieldView
 
   // TODO use template + constexpr if when C++20 is available
   PROXY_HOST_DEVICE
-  VECTOR_REAL_VIEW getField(int i) const override
-  {
-    switch (i)
-    {
+  VECTOR_REAL_VIEW getField(int i) const override {
+    switch (i) {
       case 0:
         return ux_n_;
       case 1:
@@ -67,10 +58,8 @@ class WavefieldViewForwardElastic : public WavefieldView
     }
   }
 
-  void print() const override
-  {
-    std::cout << "WavefieldViewForwardElastic:" << " ux_n size="
-              << ux_n_.extent(0) << " uy_n size=" << uy_n_.extent(0)
+  void print() const override {
+    std::cout << "WavefieldViewForwardElastic:" << " ux_n size=" << ux_n_.extent(0) << " uy_n size=" << uy_n_.extent(0)
               << " uz_n size=" << uz_n_.extent(0) << "\n";
   }
 

--- a/src/gradient/pywrap/include/bindings_differentiator.h
+++ b/src/gradient/pywrap/include/bindings_differentiator.h
@@ -22,60 +22,46 @@
 
 namespace py = pybind11;
 
-namespace gradient
-{
+namespace gradient {
 
-void bind_data_struct(py::module_& m)
-{
-  py::class_<Differentiator::DataStruct,
-             std::shared_ptr<Differentiator::DataStruct>>(m, "DataStruct")
+void bind_data_struct(py::module_& m) {
+  py::class_<Differentiator::DataStruct, std::shared_ptr<Differentiator::DataStruct>>(m, "DataStruct")
       .def("print", &Differentiator::DataStruct::print);
 }
 
-void bind_gradient_data_acoustic(py::module_& m)
-{
-  py::class_<GradientDataAcoustic, Differentiator::DataStruct,
-             std::shared_ptr<GradientDataAcoustic>>(m, "GradientDataAcoustic")
-      .def(py::init<const WavefieldViewForwardAcoustic&,
-                    const WavefieldViewBackwardAcoustic&,
+void bind_gradient_data_acoustic(py::module_& m) {
+  py::class_<GradientDataAcoustic, Differentiator::DataStruct, std::shared_ptr<GradientDataAcoustic>>(
+      m, "GradientDataAcoustic")
+      .def(py::init<const WavefieldViewForwardAcoustic&, const WavefieldViewBackwardAcoustic&,
                     const GradientAcoustic&>(),
            py::arg("fwd"), py::arg("bwd"), py::arg("gradient"))
       .def("print", &GradientDataAcoustic::print);
 }
 
-void bind_gradient_data_elastic(py::module_& m)
-{
-  py::class_<GradientDataElastic, Differentiator::DataStruct,
-             std::shared_ptr<GradientDataElastic>>(m, "GradientDataElastic")
-      .def(py::init<const WavefieldViewForwardElastic&,
-                    const WavefieldViewBackwardElastic&,
-                    const GradientElastic&>(),
+void bind_gradient_data_elastic(py::module_& m) {
+  py::class_<GradientDataElastic, Differentiator::DataStruct, std::shared_ptr<GradientDataElastic>>(
+      m, "GradientDataElastic")
+      .def(py::init<const WavefieldViewForwardElastic&, const WavefieldViewBackwardElastic&, const GradientElastic&>(),
            py::arg("fwd"), py::arg("bwd"), py::arg("gradient"))
       .def("print", &GradientDataElastic::print);
 }
 
-void bind_differentiator_base(py::module_& m)
-{
-  py::class_<Differentiator, std::shared_ptr<Differentiator>>(m,
-                                                              "Differentiator")
-      .def("compute", &Differentiator::compute, py::arg("mesh"),
-           py::arg("data"), py::arg("dt"))
+void bind_differentiator_base(py::module_& m) {
+  py::class_<Differentiator, std::shared_ptr<Differentiator>>(m, "Differentiator")
+      .def("compute", &Differentiator::compute, py::arg("mesh"), py::arg("data"), py::arg("dt"))
       .def("print", &Differentiator::print);
 }
 
-void bind_differentiator_factory(py::module_& m)
-{
+void bind_differentiator_factory(py::module_& m) {
   m.def(
       "create_differentiator",
-      [](utils::enums::implemType implem, utils::enums::meshType mesh,
-         utils::enums::modelLocationType modelLocation,
+      [](utils::enums::implemType implem, utils::enums::meshType mesh, utils::enums::modelLocationType modelLocation,
          utils::enums::physicType physic, int order) {
-        auto diff =
-            createDifferentiator(implem, mesh, modelLocation, physic, order);
+        auto diff = createDifferentiator(implem, mesh, modelLocation, physic, order);
         return std::shared_ptr<Differentiator>(std::move(diff));
       },
-      py::arg("implem_type"), py::arg("mesh_type"), py::arg("model_location"),
-      py::arg("physic_type"), py::arg("order"));
+      py::arg("implem_type"), py::arg("mesh_type"), py::arg("model_location"), py::arg("physic_type"),
+      py::arg("order"));
 }
 
 }  // namespace gradient

--- a/src/gradient/pywrap/include/bindings_gradient.h
+++ b/src/gradient/pywrap/include/bindings_gradient.h
@@ -14,37 +14,28 @@
 
 namespace py = pybind11;
 
-namespace gradient
-{
+namespace gradient {
 
-void bind_gradient_base(py::module_& m)
-{
+void bind_gradient_base(py::module_& m) {
   // Bind Gradient (base class)
-  py::class_<Gradient, std::shared_ptr<Gradient>>(m, "Gradient")
-      .def("print", &Gradient::print);
+  py::class_<Gradient, std::shared_ptr<Gradient>>(m, "Gradient").def("print", &Gradient::print);
 }
 
-void bind_gradient_acoustic(py::module_& m)
-{
+void bind_gradient_acoustic(py::module_& m) {
   // Bind GradientAcoustic (inherits from Gradient)
-  py::class_<GradientAcoustic, Gradient, std::shared_ptr<GradientAcoustic>>(
-      m, "GradientAcoustic")
-      .def(py::init<
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>>(),
+  py::class_<GradientAcoustic, Gradient, std::shared_ptr<GradientAcoustic>>(m, "GradientAcoustic")
+      .def(py::init<Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>>(),
            py::arg("grad_kappa"), py::arg("grad_buoyancy"))
       .def("print", &GradientAcoustic::print);
 }
 
-void bind_gradient_elastic(py::module_& m)
-{
+void bind_gradient_elastic(py::module_& m) {
   // Bind GradientElastic (inherits from Gradient)
-  py::class_<GradientElastic, Gradient, std::shared_ptr<GradientElastic>>(
-      m, "GradientElastic")
-      .def(py::init<
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>>(),
+  py::class_<GradientElastic, Gradient, std::shared_ptr<GradientElastic>>(m, "GradientElastic")
+      .def(py::init<Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>>(),
            py::arg("grad_rho"), py::arg("grad_lambda"), py::arg("grad_mu"))
       .def("print", &GradientElastic::print);
 }

--- a/src/gradient/pywrap/include/bindings_wavefield_view.h
+++ b/src/gradient/pywrap/include/bindings_wavefield_view.h
@@ -16,71 +16,54 @@
 
 namespace py = pybind11;
 
-namespace gradient
-{
+namespace gradient {
 
-void bind_wavefield_view_base(py::module_& m)
-{
+void bind_wavefield_view_base(py::module_& m) {
   // Bind WavefieldView (base class)
-  py::class_<WavefieldView, std::shared_ptr<WavefieldView>>(m, "WavefieldView")
-      .def("print", &WavefieldView::print);
+  py::class_<WavefieldView, std::shared_ptr<WavefieldView>>(m, "WavefieldView").def("print", &WavefieldView::print);
 }
 
-void bind_wavefield_view_forward_acoustic(py::module_& m)
-{
+void bind_wavefield_view_forward_acoustic(py::module_& m) {
   // Bind WavefieldViewForwardAcoustic (inherits from WavefieldView)
-  py::class_<WavefieldViewForwardAcoustic, WavefieldView,
-             std::shared_ptr<WavefieldViewForwardAcoustic>>(
+  py::class_<WavefieldViewForwardAcoustic, WavefieldView, std::shared_ptr<WavefieldViewForwardAcoustic>>(
       m, "WavefieldViewForwardAcoustic")
-      .def(py::init<
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>>(),
-           py::arg("pn"))
+      .def(py::init<Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>>(), py::arg("pn"))
       .def("print", &WavefieldViewForwardAcoustic::print);
 }
 
-void bind_wavefield_view_backward_acoustic(py::module_& m)
-{
+void bind_wavefield_view_backward_acoustic(py::module_& m) {
   // Bind WavefieldViewBackwardAcoustic (inherits from WavefieldView)
-  py::class_<WavefieldViewBackwardAcoustic, WavefieldView,
-             std::shared_ptr<WavefieldViewBackwardAcoustic>>(
+  py::class_<WavefieldViewBackwardAcoustic, WavefieldView, std::shared_ptr<WavefieldViewBackwardAcoustic>>(
       m, "WavefieldViewBackwardAcoustic")
-      .def(py::init<
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>>(),
+      .def(py::init<Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>>(),
            py::arg("qn"), py::arg("qn_prev"), py::arg("qn_prev_prev"))
       .def("print", &WavefieldViewBackwardAcoustic::print);
 }
 
-void bind_wavefield_view_forward_elastic(py::module_& m)
-{
+void bind_wavefield_view_forward_elastic(py::module_& m) {
   // Bind WavefieldViewForwardElastic (inherits from WavefieldView)
-  py::class_<WavefieldViewForwardElastic, WavefieldView,
-             std::shared_ptr<WavefieldViewForwardElastic>>(
+  py::class_<WavefieldViewForwardElastic, WavefieldView, std::shared_ptr<WavefieldViewForwardElastic>>(
       m, "WavefieldViewForwardElastic")
-      .def(py::init<
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>>(),
+      .def(py::init<Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>>(),
            py::arg("ux_n"), py::arg("uy_n"), py::arg("uz_n"))
       .def("print", &WavefieldViewForwardElastic::print);
 }
 
-void bind_wavefield_view_backward_elastic(py::module_& m)
-{
+void bind_wavefield_view_backward_elastic(py::module_& m) {
   // Bind WavefieldViewBackwardElastic (inherits from WavefieldView)
-  py::class_<WavefieldViewBackwardElastic, WavefieldView,
-             std::shared_ptr<WavefieldViewBackwardElastic>>(
+  py::class_<WavefieldViewBackwardElastic, WavefieldView, std::shared_ptr<WavefieldViewBackwardElastic>>(
       m, "WavefieldViewBackwardElastic")
-      .def(py::init<
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>>(),
-           py::arg("ux_n"), py::arg("uy_n"), py::arg("uz_n"), py::arg("ux_dt2"),
-           py::arg("uy_dt2"), py::arg("uz_dt2"))
+      .def(py::init<Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>>(),
+           py::arg("ux_n"), py::arg("uy_n"), py::arg("uz_n"), py::arg("ux_dt2"), py::arg("uy_dt2"), py::arg("uz_dt2"))
       .def("print", &WavefieldViewBackwardElastic::print);
 }
 

--- a/src/gradient/pywrap/src/bindings.cpp
+++ b/src/gradient/pywrap/src/bindings.cpp
@@ -8,8 +8,7 @@
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(gradient, m)
-{
+PYBIND11_MODULE(gradient, m) {
   m.attr("__name__") = "pyfuntides.gradient";
 
   // Bind WavefieldView types

--- a/src/main/fd/include/fd_io.h
+++ b/src/main/fd/include/fd_io.h
@@ -10,19 +10,13 @@
 #include "fd_stencils.h"
 
 using namespace std;
-namespace fdtd
-{
-namespace io
-{
-struct FdtdIo
-{
+namespace fdtd {
+namespace io {
+struct FdtdIo {
   // writes  pn values at the source location and save snapshot
-  void outputPnValues(int itSample, int i1, model::fdgrid::FdtdGrids &m_grids,
-                      fdtd::kernel::FdtdKernels &m_kernels,
-                      fdtd::stencils::FdtdStencils &m_stencils,
-                      fdtd::options::FdtdOptions &m_opt,
-                      FdtdSourceReceivers &m_src)
-  {
+  void outputPnValues(int itSample, int i1, model::fdgrid::FdtdGrids &m_grids, fdtd::kernel::FdtdKernels &m_kernels,
+                      fdtd::stencils::FdtdStencils &m_stencils, fdtd::options::FdtdOptions &m_opt,
+                      FdtdSourceReceivers &m_src) {
     int nx = m_grids.nx();
     int ny = m_grids.ny();
     int nz = m_grids.nz();
@@ -34,28 +28,20 @@ struct FdtdIo
     int zs = m_src.zsrc;
 
     bool saveSnapShots = m_opt.output.save_snapshots;
-    if (itSample % 50 == 0)
-    {
+    if (itSample % 50 == 0) {
       FDFENCE
-      printf("TimeStep=%d\t; Pressure value at source [%d %d %d] =%f %f %f\n",
-             itSample, xs, ys, zs,
-             m_kernels.pnGlobal(IDX3_l(xs - 1, ys, zs), i1),
-             m_kernels.pnGlobal(IDX3_l(xs, ys, zs), i1),
+      printf("TimeStep=%d\t; Pressure value at source [%d %d %d] =%f %f %f\n", itSample, xs, ys, zs,
+             m_kernels.pnGlobal(IDX3_l(xs - 1, ys, zs), i1), m_kernels.pnGlobal(IDX3_l(xs, ys, zs), i1),
              m_kernels.pnGlobal(IDX3_l(xs + 1, ys, zs), i1));
       if (saveSnapShots)
-        WriteSnapshot(0, nx, ny / 2, ny / 2, 0, nz, itSample, i1, m_grids,
-                      m_kernels, m_stencils, m_opt);
+        WriteSnapshot(0, nx, ny / 2, ny / 2, 0, nz, itSample, i1, m_grids, m_kernels, m_stencils, m_opt);
     }
   }
 
   // write snapshot to file
-  void WriteSnapshot(const int &x0, const int &x1, const int &y0, const int &y1,
-                     const int &z0, const int &z1, const int istep, int i1,
-                     model::fdgrid::FdtdGrids &m_grids,
-                     fdtd::kernel::FdtdKernels &m_kernels,
-                     fdtd::stencils::FdtdStencils &m_stencils,
-                     fdtd::options::FdtdOptions &m_opt)
-  {
+  void WriteSnapshot(const int &x0, const int &x1, const int &y0, const int &y1, const int &z0, const int &z1,
+                     const int istep, int i1, model::fdgrid::FdtdGrids &m_grids, fdtd::kernel::FdtdKernels &m_kernels,
+                     fdtd::stencils::FdtdStencils &m_stencils, fdtd::options::FdtdOptions &m_opt) {
     int ny = m_grids.ny();
     int nz = m_grids.nz();
     int lx = m_stencils.lx;
@@ -65,10 +51,8 @@ struct FdtdIo
     snprintf(filename_buf, sizeof(filename_buf), "snapshot_it_%d.H@", istep);
 
     FILE *snapshot_file = fopen(filename_buf, "wb");
-    if (!snapshot_file)
-    {
-      fprintf(stderr, "Error: Could not open file %s for writing\n",
-              filename_buf);
+    if (!snapshot_file) {
+      fprintf(stderr, "Error: Could not open file %s for writing\n", filename_buf);
       return;
     }
 
@@ -77,23 +61,18 @@ struct FdtdIo
     buffer.reserve((x1 - x0) * (y1 - y0 + 1) * (z1 - z0));
 
     // Collect data into buffer
-    for (int k = z0; k < z1; ++k)
-    {
-      for (int j = y0; j < y1 + 1; ++j)
-      {
-        for (int i = x0; i < x1; ++i)
-        {
+    for (int k = z0; k < z1; ++k) {
+      for (int j = y0; j < y1 + 1; ++j) {
+        for (int i = x0; i < x1; ++i) {
           buffer.push_back(m_kernels.pnGlobal(IDX3_l(i, j, k), i1));
         }
       }
     }
 
     // Write entire buffer at once
-    size_t elements_written =
-        fwrite(buffer.data(), sizeof(float), buffer.size(), snapshot_file);
+    size_t elements_written = fwrite(buffer.data(), sizeof(float), buffer.size(), snapshot_file);
 
-    if (elements_written != buffer.size())
-    {
+    if (elements_written != buffer.size()) {
       fprintf(stderr,
               "Error: Failed to write complete snapshot, wrote %zu of %zu "
               "elements\n",

--- a/src/main/fd/include/fd_options.h
+++ b/src/main/fd/include/fd_options.h
@@ -18,11 +18,9 @@
 #include <stdexcept>
 #include <string>
 
-namespace fdtd
-{
+namespace fdtd {
 
-namespace options
-{
+namespace options {
 /**
  * @class FdtdOptions
  * @brief Configuration container for FDTD simulation parameters.
@@ -40,15 +38,13 @@ namespace options
  *   options.Validate();
  * @endcode
  */
-class FdtdOptions
-{
+class FdtdOptions {
  public:
   /**
    * @struct GridParams
    * @brief Parameters defining the computational grid geometry.
    */
-  struct GridParams
-  {
+  struct GridParams {
     int nx{200};                    ///< Number of grid points in X direction
     int ny{200};                    ///< Number of grid points in Y direction
     int nz{200};                    ///< Number of grid points in Z direction
@@ -62,8 +58,7 @@ class FdtdOptions
    * @struct StencilParams
    * @brief Parameters for finite difference stencil configuration.
    */
-  struct StencilParams
-  {
+  struct StencilParams {
     int lx{4};                    ///< Half-width of stencil in X direction
     int ly{4};                    ///< Half-width of stencil in Y direction
     int lz{4};                    ///< Half-width of stencil in Z direction
@@ -74,8 +69,7 @@ class FdtdOptions
    * @struct SourceParams
    * @brief Parameters defining the seismic source configuration.
    */
-  struct SourceParams
-  {
+  struct SourceParams {
     int xs{-1};           ///< Source X position (-1 = grid center)
     int ys{-1};           ///< Source Y position (-1 = grid center)
     int zs{-1};           ///< Source Z position (-1 = grid center)
@@ -87,8 +81,7 @@ class FdtdOptions
    * @struct VelocityParams
    * @brief Parameters for velocity model configuration.
    */
-  struct VelocityParams
-  {
+  struct VelocityParams {
     float vmin{1500.f};          ///< Minimum velocity in model (m/s)
     float vmax{4500.f};          ///< Maximum velocity in model (m/s)
     std::string file_model{""};  ///< Path to velocity model file
@@ -99,8 +92,7 @@ class FdtdOptions
    * @struct TimeParams
    * @brief Parameters for time integration configuration.
    */
-  struct TimeParams
-  {
+  struct TimeParams {
     float time_step{0.f};        ///< Time step size (0 = auto-compute from CFL)
     float time_max{1.f};         ///< Maximum simulation time (seconds)
     std::string method{"FDTD"};  ///< Time stepping method
@@ -110,8 +102,7 @@ class FdtdOptions
    * @struct BoundaryParams
    * @brief Parameters for absorbing boundary conditions.
    */
-  struct BoundaryParams
-  {
+  struct BoundaryParams {
     bool use_pml{true};          ///< Enable PML boundary conditions
     bool use_sponge{false};      ///< Enable PML boundary conditions
     int pml_size{4};             ///< Thickness of PML layers (grid points)
@@ -123,8 +114,7 @@ class FdtdOptions
    * @struct OutputParams
    * @brief Parameters controlling simulation output.
    */
-  struct OutputParams
-  {
+  struct OutputParams {
     bool save_snapshots{false};  ///< Enable wavefield snapshot saving
     int snapshot_interval{10};   ///< Time steps between snapshots
   } output;
@@ -137,8 +127,7 @@ class FdtdOptions
    *
    * @throws std::runtime_error if any parameter is invalid
    */
-  void Validate() const
-  {
+  void Validate() const {
     ValidateGrid();
     ValidateStencil();
     ValidateSource();
@@ -157,174 +146,121 @@ class FdtdOptions
    * @param opts The cxxopts::Options object to configure
    * @param options The FdtdOptions instance to populate with parsed values
    */
-  static void BindCli(cxxopts::Options& opts, FdtdOptions& options)
-  {
+  static void BindCli(cxxopts::Options& opts, FdtdOptions& options) {
     // Grid options
-    opts.add_options("Grid")("nx", "Number of grid points in X direction",
-                             cxxopts::value<int>(options.grid.nx))(
-        "ny", "Number of grid points in Y direction",
-        cxxopts::value<int>(options.grid.ny))(
-        "nz", "Number of grid points in Z direction",
-        cxxopts::value<int>(options.grid.nz))(
-        "dx", "Grid spacing in X direction (meters)",
-        cxxopts::value<float>(options.grid.dx))(
-        "dy", "Grid spacing in Y direction (meters)",
-        cxxopts::value<float>(options.grid.dy))(
-        "dz", "Grid spacing in Z direction (meters)",
-        cxxopts::value<float>(options.grid.dz))(
-        "mesh", "Mesh type (cartesian)",
-        cxxopts::value<std::string>(options.grid.mesh));
+    opts.add_options("Grid")("nx", "Number of grid points in X direction", cxxopts::value<int>(options.grid.nx))(
+        "ny", "Number of grid points in Y direction", cxxopts::value<int>(options.grid.ny))(
+        "nz", "Number of grid points in Z direction", cxxopts::value<int>(options.grid.nz))(
+        "dx", "Grid spacing in X direction (meters)", cxxopts::value<float>(options.grid.dx))(
+        "dy", "Grid spacing in Y direction (meters)", cxxopts::value<float>(options.grid.dy))(
+        "dz", "Grid spacing in Z direction (meters)", cxxopts::value<float>(options.grid.dz))(
+        "mesh", "Mesh type (cartesian)", cxxopts::value<std::string>(options.grid.mesh));
 
     // Stencil options
-    opts.add_options("Stencil")("lx", "Half-width of stencil in X direction",
-                                cxxopts::value<int>(options.stencil.lx))(
-        "ly", "Half-width of stencil in Y direction",
-        cxxopts::value<int>(options.stencil.ly))(
-        "lz", "Half-width of stencil in Z direction",
-        cxxopts::value<int>(options.stencil.lz))(
-        "implem", "Stencil implementation method (remez|taylor)",
-        cxxopts::value<std::string>(options.stencil.implem));
+    opts.add_options("Stencil")("lx", "Half-width of stencil in X direction", cxxopts::value<int>(options.stencil.lx))(
+        "ly", "Half-width of stencil in Y direction", cxxopts::value<int>(options.stencil.ly))(
+        "lz", "Half-width of stencil in Z direction", cxxopts::value<int>(options.stencil.lz))(
+        "implem", "Stencil implementation method (remez|taylor)", cxxopts::value<std::string>(options.stencil.implem));
 
     // Source options
-    opts.add_options("Source")("xs", "Source X position (-1 for grid center)",
-                               cxxopts::value<int>(options.source.xs))(
-        "ys", "Source Y position (-1 for grid center)",
-        cxxopts::value<int>(options.source.ys))(
-        "zs", "Source Z position (-1 for grid center)",
-        cxxopts::value<int>(options.source.zs))(
-        "f0", "Source peak frequency (Hz)",
-        cxxopts::value<float>(options.source.f0))(
-        "sourceOrder", "Source time derivative order",
-        cxxopts::value<int>(options.source.source_order));
+    opts.add_options("Source")("xs", "Source X position (-1 for grid center)", cxxopts::value<int>(options.source.xs))(
+        "ys", "Source Y position (-1 for grid center)", cxxopts::value<int>(options.source.ys))(
+        "zs", "Source Z position (-1 for grid center)", cxxopts::value<int>(options.source.zs))(
+        "f0", "Source peak frequency (Hz)", cxxopts::value<float>(options.source.f0))(
+        "sourceOrder", "Source time derivative order", cxxopts::value<int>(options.source.source_order));
 
     // Velocity options
     opts.add_options("Velocity")("vmin", "Minimum velocity in model (m/s)",
                                  cxxopts::value<float>(options.velocity.vmin))(
-        "vmax", "Maximum velocity in model (m/s)",
-        cxxopts::value<float>(options.velocity.vmax))(
-        "fileModel", "Path to velocity model file",
-        cxxopts::value<std::string>(options.velocity.file_model));
+        "vmax", "Maximum velocity in model (m/s)", cxxopts::value<float>(options.velocity.vmax))(
+        "fileModel", "Path to velocity model file", cxxopts::value<std::string>(options.velocity.file_model));
 
     // Time stepping options
-    opts.add_options("Time")("timeStep",
-                             "Time step size (0 for auto-compute from CFL)",
+    opts.add_options("Time")("timeStep", "Time step size (0 for auto-compute from CFL)",
                              cxxopts::value<float>(options.time.time_step))(
-        "timeMax", "Maximum simulation time (seconds)",
-        cxxopts::value<float>(options.time.time_max))(
-        "method", "Time stepping method (FDTD)",
-        cxxopts::value<std::string>(options.time.method));
+        "timeMax", "Maximum simulation time (seconds)", cxxopts::value<float>(options.time.time_max))(
+        "method", "Time stepping method (FDTD)", cxxopts::value<std::string>(options.time.method));
 
     // Boundary options
-    opts.add_options("Boundary")(
-        "usePML", "Enable PML absorbing boundaries",
-        cxxopts::value<bool>(options.boundary.use_pml))(
-        "pmlSize", "PML layer thickness (grid points)",
-        cxxopts::value<int>(options.boundary.pml_size))(
-        "useSponge", "Enable sponge absorbing boundaries",
-        cxxopts::value<bool>(options.boundary.use_sponge))(
-        "spongeSize", "Sponge layer thickness (grid points)",
-        cxxopts::value<int>(options.boundary.sponge_size))(
-        "spongeAlpha", "Sponge damping coefficient",
-        cxxopts::value<float>(options.boundary.sponge_alpha));
+    opts.add_options("Boundary")("usePML", "Enable PML absorbing boundaries",
+                                 cxxopts::value<bool>(options.boundary.use_pml))(
+        "pmlSize", "PML layer thickness (grid points)", cxxopts::value<int>(options.boundary.pml_size))(
+        "useSponge", "Enable sponge absorbing boundaries", cxxopts::value<bool>(options.boundary.use_sponge))(
+        "spongeSize", "Sponge layer thickness (grid points)", cxxopts::value<int>(options.boundary.sponge_size))(
+        "spongeAlpha", "Sponge damping coefficient", cxxopts::value<float>(options.boundary.sponge_alpha));
 
     // Output options
-    opts.add_options("Output")(
-        "saveSnapShots", "Enable wavefield snapshot saving",
-        cxxopts::value<bool>(options.output.save_snapshots))(
-        "snapShotInterval", "Time steps between snapshots",
-        cxxopts::value<int>(options.output.snapshot_interval));
+    opts.add_options("Output")("saveSnapShots", "Enable wavefield snapshot saving",
+                               cxxopts::value<bool>(options.output.save_snapshots))(
+        "snapShotInterval", "Time steps between snapshots", cxxopts::value<int>(options.output.snapshot_interval));
 
     // Help option
     opts.add_options()("h,help", "Print usage information");
   }
 
  private:
-  void ValidateGrid() const
-  {
-    if (grid.nx <= 0 || grid.ny <= 0 || grid.nz <= 0)
-    {
+  void ValidateGrid() const {
+    if (grid.nx <= 0 || grid.ny <= 0 || grid.nz <= 0) {
       throw std::runtime_error("Grid dimensions must be positive");
     }
-    if (grid.dx <= 0.f || grid.dy <= 0.f || grid.dz <= 0.f)
-    {
+    if (grid.dx <= 0.f || grid.dy <= 0.f || grid.dz <= 0.f) {
       throw std::runtime_error("Grid spacing must be positive");
     }
   }
 
-  void ValidateStencil() const
-  {
-    if (stencil.lx <= 0 || stencil.ly <= 0 || stencil.lz <= 0)
-    {
+  void ValidateStencil() const {
+    if (stencil.lx <= 0 || stencil.ly <= 0 || stencil.lz <= 0) {
       throw std::runtime_error("Stencil half-widths must be positive");
     }
-    if (stencil.implem != "remez" && stencil.implem != "taylor")
-    {
-      throw std::runtime_error(
-          "Stencil implementation must be 'remez' or 'taylor'");
+    if (stencil.implem != "remez" && stencil.implem != "taylor") {
+      throw std::runtime_error("Stencil implementation must be 'remez' or 'taylor'");
     }
   }
 
-  void ValidateSource() const
-  {
-    if (source.f0 <= 0.f)
-    {
+  void ValidateSource() const {
+    if (source.f0 <= 0.f) {
       throw std::runtime_error("Source frequency must be positive");
     }
-    if (source.source_order < 1)
-    {
+    if (source.source_order < 1) {
       throw std::runtime_error("Source order must be >= 1");
     }
   }
 
-  void ValidateVelocity() const
-  {
-    if (velocity.vmin <= 0.f || velocity.vmax <= 0.f)
-    {
+  void ValidateVelocity() const {
+    if (velocity.vmin <= 0.f || velocity.vmax <= 0.f) {
       throw std::runtime_error("Velocities must be positive");
     }
-    if (velocity.vmin >= velocity.vmax)
-    {
+    if (velocity.vmin >= velocity.vmax) {
       throw std::runtime_error("Minimum velocity must be less than maximum");
     }
   }
 
-  void ValidateTime() const
-  {
-    if (time.time_max <= 0.f)
-    {
+  void ValidateTime() const {
+    if (time.time_max <= 0.f) {
       throw std::runtime_error("Maximum simulation time must be positive");
     }
-    if (time.time_step < 0.f)
-    {
+    if (time.time_step < 0.f) {
       throw std::runtime_error("Time step cannot be negative");
     }
   }
 
-  void ValidateBoundary() const
-  {
-    if (boundary.pml_size < 0)
-    {
+  void ValidateBoundary() const {
+    if (boundary.pml_size < 0) {
       throw std::runtime_error("PML size cannot be negative");
     }
-    if (boundary.sponge_size < 0)
-    {
+    if (boundary.sponge_size < 0) {
       throw std::runtime_error("Sponge size cannot be negative");
     }
-    if (boundary.sponge_alpha < 0.f)
-    {
+    if (boundary.sponge_alpha < 0.f) {
       throw std::runtime_error("Sponge damping coefficient cannot be negative");
     }
-    if (!boundary.use_pml && !boundary.use_sponge)
-    {
-      throw std::runtime_error(
-          "At least one absorbing boundary condition must be enabled");
+    if (!boundary.use_pml && !boundary.use_sponge) {
+      throw std::runtime_error("At least one absorbing boundary condition must be enabled");
     }
   }
 
-  void ValidateOutput() const
-  {
-    if (output.snapshot_interval <= 0)
-    {
+  void ValidateOutput() const {
+    if (output.snapshot_interval <= 0) {
       throw std::runtime_error("Snapshot interval must be positive");
     }
   }

--- a/src/main/fd/include/fd_proxy.h
+++ b/src/main/fd/include/fd_proxy.h
@@ -28,8 +28,7 @@
 #include "fd_stencils.h"
 #include "utils.h"
 
-namespace fdtd
-{
+namespace fdtd {
 /**
  * @class FdtdProxy
  * @brief Main orchestration class for FDTD acoustic wave propagation
@@ -49,8 +48,7 @@ namespace fdtd
  *   proxy.Run();
  * @endcode
  */
-class FdtdProxy
-{
+class FdtdProxy {
  public:
   /**
    * @brief Constructs an FDTD proxy with the given simulation options.
@@ -142,9 +140,8 @@ class FdtdProxy
    * @param total_compute_time Accumulated computation time
    * @param total_output_time Accumulated I/O time
    */
-  void PrintPerformanceMetrics(
-      const std::chrono::nanoseconds& total_compute_time,
-      const std::chrono::nanoseconds& total_output_time) const;
+  void PrintPerformanceMetrics(const std::chrono::nanoseconds& total_compute_time,
+                               const std::chrono::nanoseconds& total_output_time) const;
 
   // Simulation configuration
   fdtd::options::FdtdOptions opt_;

--- a/src/main/fd/src/fd_proxy.cc
+++ b/src/main/fd/src/fd_proxy.cc
@@ -31,16 +31,12 @@ using std::chrono::nanoseconds;
 using std::chrono::system_clock;
 using std::chrono::time_point;
 
-namespace
-{
+namespace {
 
 /**
  * @brief Prints a section separator line.
  */
-void PrintSeparator()
-{
-  std::cout << "--------------------------------------" << std::endl;
-}
+void PrintSeparator() { std::cout << "--------------------------------------" << std::endl; }
 
 /**
  * @brief Converts microseconds to seconds.
@@ -51,8 +47,7 @@ inline double MicrosecondsToSeconds(double time_us) { return time_us / 1E6; }
 
 }  // namespace
 
-namespace fdtd
-{
+namespace fdtd {
 
 FdtdProxy::FdtdProxy(const fdtd::options::FdtdOptions& opt)
     : opt_(opt),
@@ -62,15 +57,11 @@ FdtdProxy::FdtdProxy(const fdtd::options::FdtdOptions& opt)
       io_(),
       utils_(),
       abckernels_(),
-      solver_(grids_, kernels_, abckernels_, stencils_, source_receivers_)
-{
-}
+      solver_(grids_, kernels_, abckernels_, stencils_, source_receivers_) {}
 
-void FdtdProxy::InitFdtd()
-{
+void FdtdProxy::InitFdtd() {
   std::cout << "+======================================" << std::endl;
-  std::cout << "saveSnapshots=" << opt_.output.save_snapshots
-            << " snapShotInterval=" << opt_.output.snapshot_interval
+  std::cout << "saveSnapshots=" << opt_.output.save_snapshots << " snapShotInterval=" << opt_.output.snapshot_interval
             << std::endl;
   PrintSeparator();
   std::cout << std::endl;
@@ -87,53 +78,42 @@ void FdtdProxy::InitFdtd()
   PrintSeparator();
 }
 
-void FdtdProxy::InitializeGrid()
-{
+void FdtdProxy::InitializeGrid() {
   std::cout << "geometry init" << std::endl;
   grids_.InitGrid(opt_);
   PrintSeparator();
-  std::cout << "dx=" << grids_.dx() << " dy=" << grids_.dy()
-            << " dz=" << grids_.dz() << std::endl;
-  std::cout << "nx=" << grids_.nx() << " ny=" << grids_.ny()
-            << " nz=" << grids_.nz() << std::endl;
+  std::cout << "dx=" << grids_.dx() << " dy=" << grids_.dy() << " dz=" << grids_.dz() << std::endl;
+  std::cout << "nx=" << grids_.nx() << " ny=" << grids_.ny() << " nz=" << grids_.nz() << std::endl;
 }
 
-void FdtdProxy::InitializeStencils()
-{
+void FdtdProxy::InitializeStencils() {
   std::cout << "stencil init" << std::endl;
   PrintSeparator();
-  stencils_.initStencilsCoefficients(opt_, grids_.dx(), grids_.dy(),
-                                     grids_.dz());
+  stencils_.initStencilsCoefficients(opt_, grids_.dx(), grids_.dy(), grids_.dz());
   std::cout << "stencil coefficients" << std::endl;
-  std::cout << "lx=" << stencils_.lx << " ly=" << stencils_.ly
-            << " lz=" << stencils_.lz << std::endl;
+  std::cout << "lx=" << stencils_.lx << " ly=" << stencils_.ly << " lz=" << stencils_.lz << std::endl;
   std::cout << "coef0=" << stencils_.coef0 << std::endl;
 
-  for (int i = 0; i < stencils_.ncoefsX; i++)
-  {
+  for (int i = 0; i < stencils_.ncoefsX; i++) {
     std::cout << "coefx[" << i << "]=" << stencils_.coefx[i] << " ";
   }
   std::cout << std::endl;
 
-  for (int i = 0; i < stencils_.ncoefsY; i++)
-  {
+  for (int i = 0; i < stencils_.ncoefsY; i++) {
     std::cout << "coefy[" << i << "]=" << stencils_.coefy[i] << " ";
   }
   std::cout << std::endl;
 
-  for (int i = 0; i < stencils_.ncoefsZ; i++)
-  {
+  for (int i = 0; i < stencils_.ncoefsZ; i++) {
     std::cout << "coefz[" << i << "]=" << stencils_.coefz[i] << " ";
   }
   std::cout << std::endl;
 }
 
-void FdtdProxy::InitializeVelocityModel()
-{
+void FdtdProxy::InitializeVelocityModel() {
   std::cout << std::endl;
   std::cout << "velocity model init" << std::endl;
-  std::cout << "vmin=" << opt_.velocity.vmin << " vmax=" << opt_.velocity.vmax
-            << std::endl;
+  std::cout << "vmin=" << opt_.velocity.vmin << " vmax=" << opt_.velocity.vmax << std::endl;
   PrintSeparator();
 
   velocity_min_ = opt_.velocity.vmin;
@@ -142,20 +122,15 @@ void FdtdProxy::InitializeVelocityModel()
   time_step_ = opt_.time.time_step;
   time_max_ = opt_.time.time_max;
 
-  std::cout << "user defined time step=" << std::scientific << time_step_
-            << std::endl;
-  std::cout << "user defined max time=" << std::fixed << opt_.time.time_max
-            << std::endl;
+  std::cout << "user defined time step=" << std::scientific << time_step_ << std::endl;
+  std::cout << "user defined max time=" << std::fixed << opt_.time.time_max << std::endl;
   PrintSeparator();
 
   // Compute time step from CFL condition if not user-defined
-  if (time_step_ == 0.0f)
-  {
+  if (time_step_ == 0.0f) {
     time_step_ = stencils_.compute_dt_sch(velocity_max_);
     std::cout << "compute time step from CFL condition" << std::endl;
-  }
-  else
-  {
+  } else {
     std::cout << "user defined time step" << std::endl;
   }
 
@@ -165,24 +140,20 @@ void FdtdProxy::InitializeVelocityModel()
   PrintSeparator();
 }
 
-void FdtdProxy::InitializeModelArrays()
-{
+void FdtdProxy::InitializeModelArrays() {
   std::cout << "model init" << std::endl;
   grids_.InitModelArrays(opt_);
   std::cout << "model init done" << std::endl;
   PrintSeparator();
 }
 
-void FdtdProxy::InitializeWavefieldArrays()
-{
-  kernels_.initFieldsArrays(grids_.nx(), grids_.ny(), grids_.nz(), stencils_.lx,
-                            stencils_.ly, stencils_.lz);
+void FdtdProxy::InitializeWavefieldArrays() {
+  kernels_.initFieldsArrays(grids_.nx(), grids_.ny(), grids_.nz(), stencils_.lx, stencils_.ly, stencils_.lz);
   std::cout << "arrays init done" << std::endl;
   PrintSeparator();
 }
 
-void FdtdProxy::InitializeSource()
-{
+void FdtdProxy::InitializeSource() {
   source_frequency_ = opt_.source.f0;
   source_order_ = opt_.source.source_order;
   std::cout << "central freq and source order" << std::endl;
@@ -191,16 +162,12 @@ void FdtdProxy::InitializeSource()
   PrintSeparator();
 
   // Set source position (use grid center if not specified)
-  source_receivers_.xsrc =
-      (opt_.source.xs < 0) ? grids_.nx() / 2 : opt_.source.xs;
-  source_receivers_.ysrc =
-      (opt_.source.ys < 0) ? grids_.ny() / 2 : opt_.source.ys;
-  source_receivers_.zsrc =
-      (opt_.source.zs < 0) ? grids_.nz() / 2 : opt_.source.zs;
+  source_receivers_.xsrc = (opt_.source.xs < 0) ? grids_.nx() / 2 : opt_.source.xs;
+  source_receivers_.ysrc = (opt_.source.ys < 0) ? grids_.ny() / 2 : opt_.source.ys;
+  source_receivers_.zsrc = (opt_.source.zs < 0) ? grids_.nz() / 2 : opt_.source.zs;
 
   std::cout << "source position" << std::endl;
-  std::cout << "xsrc=" << source_receivers_.xsrc
-            << " ysrc=" << source_receivers_.ysrc
+  std::cout << "xsrc=" << source_receivers_.xsrc << " ysrc=" << source_receivers_.ysrc
             << " zsrc=" << source_receivers_.zsrc << std::endl;
   PrintSeparator();
 
@@ -209,22 +176,18 @@ void FdtdProxy::InitializeSource()
   PrintSeparator();
 }
 
-void FdtdProxy::InitializeBoundaries()
-{
+void FdtdProxy::InitializeBoundaries() {
   std::cout << "boundary init" << std::endl;
   // abckernels_.Initialize(opt_);
-  if (opt_.boundary.use_sponge)
-  {
+  if (opt_.boundary.use_sponge) {
     int nx = grids_.nx();
     int ny = grids_.ny();
     int nz = grids_.nz();
-    abckernels_.spongeArray =
-        allocateVector<vectorReal>(nx * ny * nz, "spongeArray");
+    abckernels_.spongeArray = allocateVector<vectorReal>(nx * ny * nz, "spongeArray");
     abckernels_.defineSpongeBoundary(nx, ny, nz);
     std::cout << "sponge boundary init done" << std::endl;
   }
-  if (opt_.boundary.use_pml)
-  {
+  if (opt_.boundary.use_pml) {
     int nx = grids_.nx();
     int ny = grids_.ny();
     int nz = grids_.nz();
@@ -255,93 +218,69 @@ void FdtdProxy::InitializeBoundaries()
     float dt_sch = 0.001f;
     float vmax = opt_.velocity.vmax;
 
-    printf("PML params: nx=%d ny=%d nz=%d ndampx=%d ndampy=%d ndampz=%d\n", nx,
-           ny, nz, ndampx, ndampy, ndampz);
+    printf("PML params: nx=%d ny=%d nz=%d ndampx=%d ndampy=%d ndampz=%d\n", nx, ny, nz, ndampx, ndampy, ndampz);
     // allocate eta array
-    abckernels_.eta =
-        allocateVector<vectorReal>((nx + 2) * (ny + 2) * (nz + 2), "eta");
+    abckernels_.eta = allocateVector<vectorReal>((nx + 2) * (ny + 2) * (nz + 2), "eta");
     vectorReal& eta = abckernels_.eta;
-    abckernels_.init_eta(nx, ny, nz, ndampx, ndampy, ndampz, x1, x2, x3, x4, x5,
-                         x6, y1, y2, y3, y4, y5, y6, z1, z2, z3, z4, z5, z6, dx,
-                         dy, dz, dt_sch, vmax, eta);
+    abckernels_.init_eta(nx, ny, nz, ndampx, ndampy, ndampz, x1, x2, x3, x4, x5, x6, y1, y2, y3, y4, y5, y6, z1, z2, z3,
+                         z4, z5, z6, dx, dy, dz, dt_sch, vmax, eta);
     std::cout << "PML boundary init done" << std::endl;
   }
   PrintSeparator();
 }
 
-void FdtdProxy::InitSource()
-{
+void FdtdProxy::InitSource() {
   // Compute source term (e.g., Ricker wavelet)
   kernels_.RHSTerm = allocateVector<vectorReal>(num_time_samples_, "RHSTerm");
 
   float const tpeak = 1.0f / source_frequency_;
-  std::vector<float> source_term = utils_.computeSourceTerm(
-      num_time_samples_, time_step_, source_frequency_, source_order_, tpeak);
+  std::vector<float> source_term =
+      utils_.computeSourceTerm(num_time_samples_, time_step_, source_frequency_, source_order_, tpeak);
 
-  for (int i = 0; i < num_time_samples_; i++)
-  {
+  for (int i = 0; i < num_time_samples_; i++) {
     kernels_.RHSTerm[i] = source_term[i];
   }
 }
 
-void FdtdProxy::Run()
-{
+void FdtdProxy::Run() {
   nanoseconds total_compute_time{0};
   nanoseconds total_output_time{0};
 
-  for (int index_time_sample = 0; index_time_sample < num_time_samples_;
-       index_time_sample++)
-  {
+  for (int index_time_sample = 0; index_time_sample < num_time_samples_; index_time_sample++) {
     // Compute one time step
     auto start_compute_time = system_clock::now();
-    if (opt_.boundary.use_sponge)
-    {
-      solver_.compute_one_stepSB(index_time_sample, time_index_current_,
-                                 time_index_next_);
+    if (opt_.boundary.use_sponge) {
+      solver_.compute_one_stepSB(index_time_sample, time_index_current_, time_index_next_);
     }
-    if (opt_.boundary.use_pml)
-    {
-      solver_.compute_one_stepPML(index_time_sample, time_index_current_,
-                                  time_index_next_);
+    if (opt_.boundary.use_pml) {
+      solver_.compute_one_stepPML(index_time_sample, time_index_current_, time_index_next_);
     }
-    total_compute_time +=
-        duration_cast<nanoseconds>(system_clock::now() - start_compute_time);
+    total_compute_time += duration_cast<nanoseconds>(system_clock::now() - start_compute_time);
 
     // Output snapshots at specified intervals
     auto start_output_time = system_clock::now();
-    if (index_time_sample % opt_.output.snapshot_interval == 0)
-    {
-      io_.outputPnValues(index_time_sample, time_index_current_, grids_,
-                         kernels_, stencils_, opt_, source_receivers_);
+    if (index_time_sample % opt_.output.snapshot_interval == 0) {
+      io_.outputPnValues(index_time_sample, time_index_current_, grids_, kernels_, stencils_, opt_, source_receivers_);
     }
 
     // Swap time indices for next iteration
     std::swap(time_index_current_, time_index_next_);
 
-    total_output_time +=
-        duration_cast<nanoseconds>(system_clock::now() - start_output_time);
+    total_output_time += duration_cast<nanoseconds>(system_clock::now() - start_output_time);
     std::cout.flush();
   }
 
   PrintPerformanceMetrics(total_compute_time, total_output_time);
 }
 
-void FdtdProxy::PrintPerformanceMetrics(
-    const nanoseconds& total_compute_time,
-    const nanoseconds& total_output_time) const
-{
-  const double kernel_time_us = static_cast<double>(
-      duration_cast<microseconds>(total_compute_time).count());
-  const double output_time_us = static_cast<double>(
-      duration_cast<microseconds>(total_output_time).count());
+void FdtdProxy::PrintPerformanceMetrics(const nanoseconds& total_compute_time,
+                                        const nanoseconds& total_output_time) const {
+  const double kernel_time_us = static_cast<double>(duration_cast<microseconds>(total_compute_time).count());
+  const double output_time_us = static_cast<double>(duration_cast<microseconds>(total_output_time).count());
 
   std::cout << "------------------------------------------------ " << std::endl;
-  std::cout << "\n---- Elapsed Kernel Time : "
-            << MicrosecondsToSeconds(kernel_time_us) << " seconds."
-            << std::endl;
-  std::cout << "---- Elapsed Output Time : "
-            << MicrosecondsToSeconds(output_time_us) << " seconds."
-            << std::endl;
+  std::cout << "\n---- Elapsed Kernel Time : " << MicrosecondsToSeconds(kernel_time_us) << " seconds." << std::endl;
+  std::cout << "---- Elapsed Output Time : " << MicrosecondsToSeconds(output_time_us) << " seconds." << std::endl;
   std::cout << "------------------------------------------------ " << std::endl;
 }
 

--- a/src/main/fd/src/main.cc
+++ b/src/main/fd/src/main.cc
@@ -23,8 +23,7 @@
 #include "fd_options.h"
 #include "fd_proxy.h"
 
-namespace
-{
+namespace {
 
 using std::chrono::duration_cast;
 using std::chrono::nanoseconds;
@@ -37,13 +36,9 @@ time_point<system_clock> g_start_init_time;
 /**
  * @brief RAII wrapper for Kokkos initialization/finalization.
  */
-class KokkosScope
-{
+class KokkosScope {
  public:
-  explicit KokkosScope(int argc, char* argv[])
-  {
-    Kokkos::initialize(argc, argv);
-  }
+  explicit KokkosScope(int argc, char* argv[]) { Kokkos::initialize(argc, argv); }
   ~KokkosScope() { Kokkos::finalize(); }
 
   // Prevent copying and moving
@@ -58,20 +53,15 @@ class KokkosScope
  * @param duration Duration in nanoseconds
  * @return Duration in seconds
  */
-inline double NanosecondsToSeconds(const nanoseconds& duration)
-{
-  return duration.count() / 1E9;
-}
+inline double NanosecondsToSeconds(const nanoseconds& duration) { return duration.count() / 1E9; }
 
 /**
  * @brief Prints a formatted timing report.
  * @param label Description of the timing measurement
  * @param duration Duration to report
  */
-void PrintTiming(const std::string& label, const nanoseconds& duration)
-{
-  std::cout << label << ": " << NanosecondsToSeconds(duration) << " seconds."
-            << std::endl;
+void PrintTiming(const std::string& label, const nanoseconds& duration) {
+  std::cout << label << ": " << NanosecondsToSeconds(duration) << " seconds." << std::endl;
 }
 
 /**
@@ -82,8 +72,7 @@ void PrintTiming(const std::string& label, const nanoseconds& duration)
  *
  * @param fd_sim Reference to the FdtdProxy simulation object
  */
-void Compute(fdtd::FdtdProxy& fd_sim)
-{
+void Compute(fdtd::FdtdProxy& fd_sim) {
   // Initialize FDTD simulation
   std::cout << "Initializing FDTD simulation..." << std::endl;
   fd_sim.InitFdtd();
@@ -98,10 +87,8 @@ void Compute(fdtd::FdtdProxy& fd_sim)
   std::cout << "FDTD computation complete.\n" << std::endl;
 
   // Report timing information
-  const auto init_duration =
-      duration_cast<nanoseconds>(start_run_time - g_start_init_time);
-  const auto compute_duration =
-      duration_cast<nanoseconds>(system_clock::now() - start_run_time);
+  const auto init_duration = duration_cast<nanoseconds>(start_run_time - g_start_init_time);
+  const auto compute_duration = duration_cast<nanoseconds>(system_clock::now() - start_run_time);
 
   std::cout << "=== Timing Summary ===" << std::endl;
   PrintTiming("Initialization time", init_duration);
@@ -113,8 +100,7 @@ void Compute(fdtd::FdtdProxy& fd_sim)
  * @brief Configures environment variables for optimal Kokkos/OpenMP
  * performance.
  */
-void ConfigureParallelEnvironment()
-{
+void ConfigureParallelEnvironment() {
   // Configure OpenMP thread binding for optimal performance
   setenv("OMP_PROC_BIND", "spread", 0);  // Don't override if already set
   setenv("OMP_PLACES", "threads", 0);
@@ -133,8 +119,7 @@ void ConfigureParallelEnvironment()
  * @param argv Array of command-line argument strings
  * @return 0 on success, 1 on error
  */
-int main(int argc, char* argv[])
-{
+int main(int argc, char* argv[]) {
   g_start_init_time = system_clock::now();
 
   // Configure parallel execution environment
@@ -144,8 +129,7 @@ int main(int argc, char* argv[])
   // scope
   KokkosScope kokkos_scope(argc, argv);
 
-  try
-  {
+  try {
     // Set up command-line option parser
     cxxopts::Options options("FDTD Proxy", "FDTD acoustic wave simulation");
     options.allow_unrecognised_options();  // Allow Kokkos flags to pass through
@@ -158,8 +142,7 @@ int main(int argc, char* argv[])
     auto result = options.parse(argc, argv);
 
     // Display help if requested
-    if (result.count("help"))
-    {
+    if (result.count("help")) {
       std::cout << options.help() << std::endl;
       return 0;
     }
@@ -172,20 +155,15 @@ int main(int argc, char* argv[])
     Compute(fd_sim);
 
     // Report total execution time
-    const auto total_duration =
-        duration_cast<nanoseconds>(system_clock::now() - g_start_init_time);
+    const auto total_duration = duration_cast<nanoseconds>(system_clock::now() - g_start_init_time);
     std::cout << "\n";
     PrintTiming("Total execution time", total_duration);
 
     return 0;
-  }
-  catch (const std::exception& e)
-  {
+  } catch (const std::exception& e) {
     std::cerr << "\nError: " << e.what() << std::endl;
     return 1;
-  }
-  catch (...)
-  {
+  } catch (...) {
     std::cerr << "\nFatal error: Unknown exception" << std::endl;
     return 1;
   }

--- a/src/main/fe/include/sem_io_controller.h
+++ b/src/main/fe/include/sem_io_controller.h
@@ -16,8 +16,7 @@
 #define RECEIVERS_FILE "receivers"
 #define SNAPS_FILE "snapshots"
 
-class SemIOController
-{
+class SemIOController {
  private:
   adios2::ADIOS adios_;
   adios2::IO io_;
@@ -35,8 +34,7 @@ class SemIOController
   std::string rcv_file_{"rcv_not_set.bp"};
   std::string snap_file_{"snap_not_set.bp"};
 
-  void initAdios()
-  {
+  void initAdios() {
 #ifdef USE_MPI
     adios_ = adios2::ADIOS(MPI_COMM_WORLD);
 #else
@@ -44,14 +42,12 @@ class SemIOController
 #endif
   }
 
-  void configureFilesName()
-  {
+  void configureFilesName() {
     rcv_file_ = RECEIVERS_FILE;
     snap_file_ = SNAPS_FILE;
   }
 
-  void configureIO()
-  {
+  void configureIO() {
     io_ = adios_.DeclareIO("AccousticSEMOutput");
     io_.SetEngine("BP5");
     io_.SetParameter("Threads", "4");
@@ -68,35 +64,26 @@ class SemIOController
     // compressor_op_ = adios_.DefineOperator("bloscSnap", "blosc");
   }
 
-  void launchWriters()
-  {
+  void launchWriters() {
     receiver_writer_ = io_.Open(rcv_file_, adios2::Mode::Write);
     snaps_writer_ = async_io_.Open(snap_file_, adios2::Mode::Write);
   }
 
-  void defineVariable(const std::vector<size_t>& global_dims,
-                      const std::vector<size_t>& start_offsets,
-                      const std::vector<size_t>& local_dims,
-                      const size_t nb_iter, const size_t nb_receiver)
-  {
-    receivers_ =
-        io_.DefineVariable<float>("AccousticReceiver", {nb_receiver, nb_iter},
-                                  {0, 0}, {nb_receiver, nb_iter});
+  void defineVariable(const std::vector<size_t>& global_dims, const std::vector<size_t>& start_offsets,
+                      const std::vector<size_t>& local_dims, const size_t nb_iter, const size_t nb_receiver) {
+    receivers_ = io_.DefineVariable<float>("AccousticReceiver", {nb_receiver, nb_iter}, {0, 0}, {nb_receiver, nb_iter});
 
-    receivers_coords_ = io_.DefineVariable<float>(
-        "AccousticReceiverCoords", {nb_receiver, 3}, {0, 0}, {nb_receiver, 3});
+    receivers_coords_ =
+        io_.DefineVariable<float>("AccousticReceiverCoords", {nb_receiver, 3}, {0, 0}, {nb_receiver, 3});
 
-    iter_times_ =
-        io_.DefineVariable<float>("IterationTimes", {nb_iter}, {0}, {nb_iter});
+    iter_times_ = io_.DefineVariable<float>("IterationTimes", {nb_iter}, {0}, {nb_iter});
 
-    pn_ = async_io_.DefineVariable<float>("PressureField", global_dims,
-                                          start_offsets, local_dims);
+    pn_ = async_io_.DefineVariable<float>("PressureField", global_dims, start_offsets, local_dims);
 
     timestep_ = async_io_.DefineVariable<int>("TimeStep", {1}, {0}, {1});
   }
 
-  void attachOperator()
-  {
+  void attachOperator() {
     // NOTE: This is about I/O compression. This is currently diseable.
     // Alexis (01/10/2025): This could compress the I/O by a factor 2. However
     // this slow down the execution time by two when saving every 10 time step
@@ -113,38 +100,31 @@ class SemIOController
   }
 
  public:
-  SemIOController(const std::vector<size_t>& global_dims,
-                  const std::vector<size_t>& start_offsets,
-                  const std::vector<size_t>& local_dims, const size_t nb_iter,
-                  const size_t nb_receiver)
-  {
+  SemIOController(const std::vector<size_t>& global_dims, const std::vector<size_t>& start_offsets,
+                  const std::vector<size_t>& local_dims, const size_t nb_iter, const size_t nb_receiver) {
     initAdios();
     configureIO();
     configureFilesName();
-    defineVariable(global_dims, start_offsets, local_dims, nb_iter,
-                   nb_receiver);
+    defineVariable(global_dims, start_offsets, local_dims, nb_iter, nb_receiver);
     launchWriters();
     attachOperator();
   }
 
   SemIOController() = delete;
 
-  ~SemIOController()
-  {
+  ~SemIOController() {
     snaps_writer_.Close();
     receiver_writer_.Close();
   }
 
-  void saveReceiver(vectorReal& receiver, const std::array<float, 3>& coords)
-  {
+  void saveReceiver(vectorReal& receiver, const std::array<float, 3>& coords) {
     receiver_writer_.BeginStep();
     receiver_writer_.Put(receivers_, receiver.data());
     receiver_writer_.Put(receivers_coords_, coords.data());
     receiver_writer_.EndStep();
   }
 
-  void saveSnapshot(const vectorReal& pnGlobal, const int timestep)
-  {
+  void saveSnapshot(const vectorReal& pnGlobal, const int timestep) {
     snaps_writer_.BeginStep();
 
     // Wrap scalar in array

--- a/src/main/fe/include/sem_proxy.h
+++ b/src/main/fe/include/sem_proxy.h
@@ -23,8 +23,7 @@
 /**
  * @class SEMproxy
  */
-class SEMproxy
-{
+class SEMproxy {
  public:
   /**
    * @brief Constructor of the SEMproxy class
@@ -34,8 +33,7 @@ class SEMproxy
   /**
    * @brief Destructor of the SEMproxy class
    */
-  SEMproxy()
-  {
+  SEMproxy() {
     io_ctrl_.reset();  // Manually trigger SemIOController destructor (which
                        // closes engines)
   }
@@ -43,8 +41,7 @@ class SEMproxy
    * @brief Initialize the simulation.
    * @post run()
    */
-  void initFiniteElem()
-  {
+  void initFiniteElem() {
     init_arrays();
     init_source();
   };
@@ -61,8 +58,7 @@ class SEMproxy
    * Format: space-separated matrix with blank lines between rows for 3D
    * plotting
    */
-  void saveSlice(const VECTOR_REAL_VIEW& host_slice, int sizex, int sizey,
-                 const std::string& filepath) const;
+  void saveSlice(const VECTOR_REAL_VIEW& host_slice, int sizex, int sizey, const std::string& filepath) const;
 
   void saveSnapshot(int timesample, VECTOR_REAL_VIEW data) const;
 
@@ -163,17 +159,14 @@ class SEMproxy
   arrayReal uznAtReceiver;
 
   // DAS receiver data
-  SourceAndReceiverUtils::DASType dasType_ =
-      SourceAndReceiverUtils::DASType::kNone;
+  SourceAndReceiverUtils::DASType dasType_ = SourceAndReceiverUtils::DASType::kNone;
   int dasNumSamples_ = 5;
   float dasGaugeLength_ = 1.0f;
-  std::array<float, 3> dasDirection_ = {1, 0,
-                                        0};  ///< Fiber direction unit vector
-  std::array<float, 3> dasVector_ = {
-      1, 0, 0};                    ///< Direction (for dipole: divided by L)
-  std::vector<int> dasNodeIds_;    ///< Global node IDs [nSamples * npe]
-  std::vector<float> dasWeights_;  ///< Precomputed weights [nSamples * npe]
-  vectorReal dasSignal_;           ///< DAS trace [num_sample_]
+  std::array<float, 3> dasDirection_ = {1, 0, 0};  ///< Fiber direction unit vector
+  std::array<float, 3> dasVector_ = {1, 0, 0};     ///< Direction (for dipole: divided by L)
+  std::vector<int> dasNodeIds_;                    ///< Global node IDs [nSamples * npe]
+  std::vector<float> dasWeights_;                  ///< Precomputed weights [nSamples * npe]
+  vectorReal dasSignal_;                           ///< DAS trace [num_sample_]
 
   // io controller
   std::shared_ptr<SemIOController> io_ctrl_;

--- a/src/main/fe/include/sem_proxy_options.h
+++ b/src/main/fe/include/sem_proxy_options.h
@@ -8,8 +8,7 @@
 #include <string>
 #include <vector>
 
-class SemProxyOptions
-{
+class SemProxyOptions {
  public:
   // Defaults
   int order = 2;
@@ -53,96 +52,61 @@ class SemProxyOptions
   float das_gauge_length = 1.f;   ///< Gauge length in meters
   int das_samples = 5;            ///< Number of integration points along fiber
 
-  void validate() const
-  {
+  void validate() const {
     if (order < 1) throw std::runtime_error("order must be >= 1");
-    if (ex <= 0 || ey <= 0 || ez <= 0)
-      throw std::runtime_error("ex/ey/ez must be > 0");
-    if (lx <= 0 || ly <= 0 || lz <= 0)
-      throw std::runtime_error("lx/ly/lz must be > 0");
+    if (ex <= 0 || ey <= 0 || ez <= 0) throw std::runtime_error("ex/ey/ez must be > 0");
+    if (lx <= 0 || ly <= 0 || lz <= 0) throw std::runtime_error("lx/ly/lz must be > 0");
   }
 
   // Bind CLI flags to this instance (no --help here)
-  static void bind_cli(cxxopts::Options& opts, SemProxyOptions& o)
-  {
-    opts.add_options()("o,order", "Order of approximation",
-                       cxxopts::value<int>(o.order))(
-        "ex", "Number of elements on X (Cartesian mesh)",
-        cxxopts::value<int>(o.ex))("ey",
-                                   "Number of elements on Y (Cartesian mesh)",
-                                   cxxopts::value<int>(o.ey))(
-        "ez", "Number of elements on Z (Cartesian mesh)",
-        cxxopts::value<int>(o.ez))("lx", "Domain size X (Cartesian)",
-                                   cxxopts::value<float>(o.lx))(
-        "ly", "Domain size Y (Cartesian)", cxxopts::value<float>(o.ly))(
-        "lz", "Domain size Z (Cartesian)", cxxopts::value<float>(o.lz))(
-        "implem", "Implementation: makutu",
-        cxxopts::value<std::string>(o.implem))(
-        "method", "Method: sem|dg", cxxopts::value<std::string>(o.method))(
-        "mesh", "Mesh: cartesian|ucartesian",
-        cxxopts::value<std::string>(o.mesh))(
-        "dt", "Time step selection in s (default = 0.001s)",
-        cxxopts::value<float>(o.dt))(
-        "timemax", "Duration of the simulation in s (default = 1.5s)",
-        cxxopts::value<float>(o.timemax))(
-        "auto-dt", "Select automatique dt via CFL equation.",
-        cxxopts::value<bool>(o.autodt))("s,snapshots", "Enable snapshot.",
-                                        cxxopts::value<bool>(o.snapshots))(
-        "snap-interval",
-        "Interval on iteration between two snapshots. (default=10)",
-        cxxopts::value<int>(o.snap_time_interval))(
-        "boundaries-size", "Size of absorbing boundaries (meters)",
-        cxxopts::value<float>(o.boundaries_size))(
-        "sponge-surface", "Considere the surface's nodes as non sponge nodes",
-        cxxopts::value<bool>(o.surface_sponge))(
-        "taper-delta", "Taper delta for sponge boundaries value",
-        cxxopts::value<float>(o.taper_delta))(
+  static void bind_cli(cxxopts::Options& opts, SemProxyOptions& o) {
+    opts.add_options()("o,order", "Order of approximation", cxxopts::value<int>(o.order))(
+        "ex", "Number of elements on X (Cartesian mesh)", cxxopts::value<int>(o.ex))(
+        "ey", "Number of elements on Y (Cartesian mesh)", cxxopts::value<int>(o.ey))(
+        "ez", "Number of elements on Z (Cartesian mesh)", cxxopts::value<int>(o.ez))(
+        "lx", "Domain size X (Cartesian)", cxxopts::value<float>(o.lx))("ly", "Domain size Y (Cartesian)",
+                                                                        cxxopts::value<float>(o.ly))(
+        "lz", "Domain size Z (Cartesian)", cxxopts::value<float>(o.lz))("implem", "Implementation: makutu",
+                                                                        cxxopts::value<std::string>(o.implem))(
+        "method", "Method: sem|dg", cxxopts::value<std::string>(o.method))("mesh", "Mesh: cartesian|ucartesian",
+                                                                           cxxopts::value<std::string>(o.mesh))(
+        "dt", "Time step selection in s (default = 0.001s)", cxxopts::value<float>(o.dt))(
+        "timemax", "Duration of the simulation in s (default = 1.5s)", cxxopts::value<float>(o.timemax))(
+        "auto-dt", "Select automatique dt via CFL equation.", cxxopts::value<bool>(o.autodt))(
+        "s,snapshots", "Enable snapshot.", cxxopts::value<bool>(o.snapshots))(
+        "snap-interval", "Interval on iteration between two snapshots. (default=10)",
+        cxxopts::value<int>(o.snap_time_interval))("boundaries-size", "Size of absorbing boundaries (meters)",
+                                                   cxxopts::value<float>(o.boundaries_size))(
+        "sponge-surface", "Considere the surface's nodes as non sponge nodes", cxxopts::value<bool>(o.surface_sponge))(
+        "taper-delta", "Taper delta for sponge boundaries value", cxxopts::value<float>(o.taper_delta))(
         "is-model-on-nodes",
         "Boolean to tell if the model is charged on nodes (true) or on element "
         "(false)",
-        cxxopts::value<bool>(o.isModelOnNodes))(
-        "is-elastic", "Elastic simulation", cxxopts::value<bool>(o.isElastic))(
-        "is-acousto-elastic", "Acousto-elastic coupled simulation",
-        cxxopts::value<bool>(o.isAcoustoElastic))(
-        "acousto-elastic-boundary-z",
-        "Z coordinate of the fluid–solid interface (meters)",
+        cxxopts::value<bool>(o.isModelOnNodes))("is-elastic", "Elastic simulation", cxxopts::value<bool>(o.isElastic))(
+        "is-acousto-elastic", "Acousto-elastic coupled simulation", cxxopts::value<bool>(o.isAcoustoElastic))(
+        "acousto-elastic-boundary-z", "Z coordinate of the fluid–solid interface (meters)",
         cxxopts::value<float>(o.acoustoElasticBoundaryZ))(
-        "free-surface",
-        "Enable free surface on top boundary (Z+). Default: true",
-        cxxopts::value<bool>(o.free_surface))(
-        "anisotropy", "Anisotropy type for elastic: iso|vti|tti (default=iso)",
-        cxxopts::value<std::string>(o.anisotropy))(
-        "das-type", "DAS receiver type: none|dipole|strain (default=none)",
-        cxxopts::value<std::string>(o.das_type))(
-        "das-dip", "DAS fiber dip angle in degrees (default=0)",
-        cxxopts::value<float>(o.das_dip))(
-        "das-azimuth", "DAS fiber azimuth angle in degrees (default=0)",
-        cxxopts::value<float>(o.das_azimuth))(
-        "das-gauge-length", "DAS gauge length in meters (default=1)",
-        cxxopts::value<float>(o.das_gauge_length))(
-        "das-samples",
-        "Number of integration points along DAS fiber (default=5)",
-        cxxopts::value<int>(o.das_samples))(
-        "f0", "Dominant frequency of the source in Hz",
-        cxxopts::value<float>(o.f0))("tpeak",
-                                     "Peak time of the Ricker wavelet source",
-                                     cxxopts::value<float>(o.tpeak))(
-        "ricker-order", "Order of the Ricker wavelet source",
-        cxxopts::value<int>(o.ricker_order))(
-        "srcx", "Source position X (meters)", cxxopts::value<float>(o.srcx))(
-        "srcy", "Source position Y (meters)", cxxopts::value<float>(o.srcy))(
-        "srcz", "Source position Z (meters)", cxxopts::value<float>(o.srcz))(
-        "rcvx", "Receiver position X (meters)", cxxopts::value<float>(o.rcvx))(
-        "rcvy", "Receiver position Y (meters)", cxxopts::value<float>(o.rcvy))(
-        "rcvz", "Receiver position Z (meters)", cxxopts::value<float>(o.rcvz))(
-        "qp", "Quality factor for P-waves (default: no attenuation)",
-        cxxopts::value<float>(o.qp))(
-        "qs", "Quality factor for S-waves (default: no attenuation)",
-        cxxopts::value<float>(o.qs))(
-        "sls-reference-angular-frequencies",
-        "Comma-separated SLS reference angular frequencies (rad/s)",
-        cxxopts::value<std::vector<float>>(
-            o.sls_reference_angular_frequencies))(
+        "free-surface", "Enable free surface on top boundary (Z+). Default: true",
+        cxxopts::value<bool>(o.free_surface))("anisotropy", "Anisotropy type for elastic: iso|vti|tti (default=iso)",
+                                              cxxopts::value<std::string>(o.anisotropy))(
+        "das-type", "DAS receiver type: none|dipole|strain (default=none)", cxxopts::value<std::string>(o.das_type))(
+        "das-dip", "DAS fiber dip angle in degrees (default=0)", cxxopts::value<float>(o.das_dip))(
+        "das-azimuth", "DAS fiber azimuth angle in degrees (default=0)", cxxopts::value<float>(o.das_azimuth))(
+        "das-gauge-length", "DAS gauge length in meters (default=1)", cxxopts::value<float>(o.das_gauge_length))(
+        "das-samples", "Number of integration points along DAS fiber (default=5)", cxxopts::value<int>(o.das_samples))(
+        "f0", "Dominant frequency of the source in Hz", cxxopts::value<float>(o.f0))(
+        "tpeak", "Peak time of the Ricker wavelet source", cxxopts::value<float>(o.tpeak))(
+        "ricker-order", "Order of the Ricker wavelet source", cxxopts::value<int>(o.ricker_order))(
+        "srcx", "Source position X (meters)", cxxopts::value<float>(o.srcx))("srcy", "Source position Y (meters)",
+                                                                             cxxopts::value<float>(o.srcy))(
+        "srcz", "Source position Z (meters)", cxxopts::value<float>(o.srcz))("rcvx", "Receiver position X (meters)",
+                                                                             cxxopts::value<float>(o.rcvx))(
+        "rcvy", "Receiver position Y (meters)", cxxopts::value<float>(o.rcvy))("rcvz", "Receiver position Z (meters)",
+                                                                               cxxopts::value<float>(o.rcvz))(
+        "qp", "Quality factor for P-waves (default: no attenuation)", cxxopts::value<float>(o.qp))(
+        "qs", "Quality factor for S-waves (default: no attenuation)", cxxopts::value<float>(o.qs))(
+        "sls-reference-angular-frequencies", "Comma-separated SLS reference angular frequencies (rad/s)",
+        cxxopts::value<std::vector<float>>(o.sls_reference_angular_frequencies))(
         "sls-anelasticity-coefficients",
         "Comma-separated SLS anelasticity coefficients (same size as "
         "frequencies)",

--- a/src/main/fe/src/main.cc
+++ b/src/main/fe/src/main.cc
@@ -11,8 +11,7 @@
 
 time_point<system_clock> startInitTime;
 
-void compute(SEMproxy &semsim)
-{
+void compute(SEMproxy &semsim) {
   cout << "\n+================================= " << endl;
   cout << "| Running SEM Application ...      " << endl;
   cout << "+================================= \n" << endl;
@@ -26,30 +25,23 @@ void compute(SEMproxy &semsim)
   cout << "+================================= \n" << endl;
 
   // print timing information
-  cout << "Elapsed Initial Time : "
-       << (startRunTime - startInitTime).count() / 1E9 << " seconds." << endl;
-  cout << "Elapsed Compute Time : "
-       << (system_clock::now() - startRunTime).count() / 1E9 << " seconds."
-       << endl;
+  cout << "Elapsed Initial Time : " << (startRunTime - startInitTime).count() / 1E9 << " seconds." << endl;
+  cout << "Elapsed Compute Time : " << (system_clock::now() - startRunTime).count() / 1E9 << " seconds." << endl;
 };
 
 void compute_loop(SEMproxy &semsim) { compute(semsim); }
 
 // Helper to determine local rank for GPU affinity
-int get_local_rank()
-{
+int get_local_rank() {
 #ifdef USE_MPI
   // Check standard environment variables first
-  if (const char *p = std::getenv("OMPI_COMM_WORLD_LOCAL_RANK"))
-    return std::atoi(p);
-  if (const char *p = std::getenv("MV2_COMM_WORLD_LOCAL_RANK"))
-    return std::atoi(p);
+  if (const char *p = std::getenv("OMPI_COMM_WORLD_LOCAL_RANK")) return std::atoi(p);
+  if (const char *p = std::getenv("MV2_COMM_WORLD_LOCAL_RANK")) return std::atoi(p);
   if (const char *p = std::getenv("SLURM_LOCALID")) return std::atoi(p);
 
   // Fallback to MPI split type if env vars are missing
   MPI_Comm nodeComm;
-  MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL,
-                      &nodeComm);
+  MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &nodeComm);
   int local_rank;
   MPI_Comm_rank(nodeComm, &local_rank);
   MPI_Comm_free(&nodeComm);
@@ -59,8 +51,7 @@ int get_local_rank()
 #endif
 }
 
-int main(int argc, char *argv[])
-{
+int main(int argc, char *argv[]) {
   startInitTime = system_clock::now();
 
 #ifdef USE_MPI
@@ -87,18 +78,14 @@ int main(int argc, char *argv[])
 
     auto result = options.parse(argc, argv);
 
-    if (result.count("help"))
-    {
+    if (result.count("help")) {
       std::cout << options.help() << std::endl;
       exit(0);
     }
 
-    try
-    {
+    try {
       opt.validate();
-    }
-    catch (const std::exception &e)
-    {
+    } catch (const std::exception &e) {
       // your error path (no help printing here)
       std::cerr << "Invalid options: " << e.what() << "\n";
       return 1;
@@ -118,8 +105,6 @@ int main(int argc, char *argv[])
   MPI_Barrier(MPI_COMM_WORLD);
   MPI_Finalize();
 #endif
-  cout << "Elapsed TotalExe Time : "
-       << (system_clock::now() - startInitTime).count() / 1E9 << " seconds.\n"
-       << endl;
+  cout << "Elapsed TotalExe Time : " << (system_clock::now() - startInitTime).count() / 1E9 << " seconds.\n" << endl;
   return (0);
 }

--- a/src/main/fe/src/sem_proxy.cc
+++ b/src/main/fe/src/sem_proxy.cc
@@ -36,8 +36,7 @@ using namespace solver::fe;
 using namespace solver::fe::solver_factory;
 using namespace utils::enums;
 
-SEMproxy::SEMproxy(const SemProxyOptions& opt)
-{
+SEMproxy::SEMproxy(const SemProxyOptions& opt) {
   // Init MPI parameters
   int mpi_initialized = 0;
   init_mpi(&mpi_initialized);
@@ -53,29 +52,23 @@ SEMproxy::SEMproxy(const SemProxyOptions& opt)
   const methodType methodType = getMethod(opt.method);
   const implemType implemType = getImplem(opt.implem);
   const meshType meshType = getMesh(opt.mesh);
-  const modelLocationType modelLocation = opt.isModelOnNodes
-                                              ? modelLocationType::kOnNodes
-                                              : modelLocationType::kOnElements;
+  const modelLocationType modelLocation =
+      opt.isModelOnNodes ? modelLocationType::kOnNodes : modelLocationType::kOnElements;
   const physicType physicType =
-      isAcoustoElastic_
-          ? physicType::kAcoustoElastic
-          : (opt.isElastic ? physicType::kElastic : physicType::kAcoustic);
+      isAcoustoElastic_ ? physicType::kAcoustoElastic : (opt.isElastic ? physicType::kElastic : physicType::kAcoustic);
 
-  m_solver = createSolver(methodType, implemType, meshType, modelLocation,
-                          physicType, opt.order);
+  m_solver = createSolver(methodType, implemType, meshType, modelLocation, physicType, opt.order);
 
   const model::AnisotropyType anisotropyType = getAnisotropy(opt.anisotropy);
 
   // Setup Sponge Parameters (store as members for use in run())
-  sponge_size_ = {opt.boundaries_size, opt.boundaries_size,
-                  opt.boundaries_size};
+  sponge_size_ = {opt.boundaries_size, opt.boundaries_size, opt.boundaries_size};
   surface_sponge_ = opt.surface_sponge;
   taper_delta_ = opt.taper_delta;
 
   // Set quality factors for attenuation (must be set before setSLSAttenuation
   // so that auto-fill of anelasticity coefficients from Q works)
-  if (opt.qp > 0 || opt.qs > 0)
-  {
+  if (opt.qp > 0 || opt.qs > 0) {
     float qp = (opt.qp > 0) ? opt.qp : 1e9f;
     float qs = (opt.qs > 0) ? opt.qs : 1e9f;
     m_mesh->setQualityFactors(qp, qs);
@@ -89,31 +82,25 @@ SEMproxy::SEMproxy(const SemProxyOptions& opt)
     return view;
   };
 
-  if (!opt.sls_reference_angular_frequencies.empty())
-  {
+  if (!opt.sls_reference_angular_frequencies.empty()) {
     auto freqView = toView(opt.sls_reference_angular_frequencies, "slsFreqs");
     auto coeffView = toView(opt.sls_anelasticity_coefficients, "slsCoeffs");
     m_solver->setSLSAttenuation(freqView, coeffView);
-  }
-  else if (opt.qp > 0 || opt.qs > 0)
-  {
+  } else if (opt.qp > 0 || opt.qs > 0) {
     // Auto-enable SLS with default reference frequency based on source f0
     float omega0 = 2.0f * M_PI * opt.f0;
-    std::cout << "Auto-enabling SLS attenuation at omega0=" << omega0
-              << " rad/s (f0=" << opt.f0 << " Hz)" << std::endl;
+    std::cout << "Auto-enabling SLS attenuation at omega0=" << omega0 << " rad/s (f0=" << opt.f0 << " Hz)" << std::endl;
     auto freqView = allocateVector<vectorReal>(1, "slsFreqAuto");
     freqView[0] = omega0;
     m_solver->setSLSAttenuation(freqView);
   }
 
-  if (opt.isElastic)
-  {
+  if (opt.isElastic) {
     m_solver->setAnisotropyType(anisotropyType);
 
     // Initialize elasticity tensors ONLY for TTI on elements
     // (ISO and VTI are computed on-the-fly, TTI on nodes also on-the-fly)
-    if (anisotropyType == model::AnisotropyType::kTTI && !opt.isModelOnNodes)
-    {
+    if (anisotropyType == model::AnisotropyType::kTTI && !opt.isModelOnNodes) {
       m_mesh->initElasticityTensors(anisotropyType);
     }
   }
@@ -131,8 +118,7 @@ SEMproxy::SEMproxy(const SemProxyOptions& opt)
   // Local Size = Local_Elements * Order + 1
   // Offset = Origin_Index (calculated from origin_x)
   size_t global_nx =
-      m_localParams.global_lx / (m_localParams.global_lx / opt.ex) * opt.order +
-      1;  // Approximation if uniform
+      m_localParams.global_lx / (m_localParams.global_lx / opt.ex) * opt.order + 1;  // Approximation if uniform
   // More precise:
   size_t g_ex = static_cast<size_t>(opt.ex);
   size_t g_ey = static_cast<size_t>(opt.ey);
@@ -148,8 +134,7 @@ SEMproxy::SEMproxy(const SemProxyOptions& opt)
   // origin_x is physical coordinate. We need node index.
   // dx = lx / ex.
   float dx = m_localParams.global_lx / opt.ex;
-  size_t elem_offset_x =
-      static_cast<size_t>(std::round(m_localParams.origin_x / dx));
+  size_t elem_offset_x = static_cast<size_t>(std::round(m_localParams.origin_x / dx));
   size_t node_offset_x = elem_offset_x * opt.order;
 
   std::vector<size_t> start_offsets = {node_offset_x, 0, 0};
@@ -167,65 +152,49 @@ SEMproxy::SEMproxy(const SemProxyOptions& opt)
   // Refine Global Dims vector
   global_dims = {g_nx, g_ny, g_nz};
 
-  io_ctrl_ = std::make_shared<SemIOController>(
-      global_dims, start_offsets, local_dims, static_cast<size_t>(num_sample_),
-      static_cast<size_t>(1));
+  io_ctrl_ = std::make_shared<SemIOController>(global_dims, start_offsets, local_dims, static_cast<size_t>(num_sample_),
+                                               static_cast<size_t>(1));
 
   // snapshots settings
   is_snapshots_ = opt.snapshots;
-  if (is_snapshots_)
-  {
+  if (is_snapshots_) {
     snap_time_interval_ = opt.snap_time_interval;
   }
 
   // DAS receiver setup
-  if (opt.das_type == "dipole")
-  {
+  if (opt.das_type == "dipole") {
     dasType_ = SourceAndReceiverUtils::DASType::kDipole;
     dasNumSamples_ = 2;  // dipole uses exactly 2 endpoints
-  }
-  else if (opt.das_type == "strain")
-  {
+  } else if (opt.das_type == "strain") {
     dasType_ = SourceAndReceiverUtils::DASType::kStrainIntegration;
     dasNumSamples_ = opt.das_samples;
-  }
-  else
-  {
+  } else {
     dasType_ = SourceAndReceiverUtils::DASType::kNone;
   }
 
-  if (dasType_ != SourceAndReceiverUtils::DASType::kNone)
-  {
-    if (!isElastic_)
-    {
-      throw std::runtime_error(
-          "DAS receivers require elastic simulation (--is-elastic true)");
+  if (dasType_ != SourceAndReceiverUtils::DASType::kNone) {
+    if (!isElastic_) {
+      throw std::runtime_error("DAS receivers require elastic simulation (--is-elastic true)");
     }
     dasGaugeLength_ = opt.das_gauge_length;
-    dasDirection_ =
-        SourceAndReceiverUtils::ComputeDASVector(opt.das_dip, opt.das_azimuth);
+    dasDirection_ = SourceAndReceiverUtils::ComputeDASVector(opt.das_dip, opt.das_azimuth);
     dasVector_ = dasDirection_;
 
     // For dipole mode, divide direction by gauge length (GEOS convention)
-    if (dasType_ == SourceAndReceiverUtils::DASType::kDipole)
-    {
+    if (dasType_ == SourceAndReceiverUtils::DASType::kDipole) {
       for (int i = 0; i < 3; ++i) dasVector_[i] /= dasGaugeLength_;
     }
 
-    std::cout << "DAS receiver enabled: type=" << opt.das_type
-              << ", dip=" << opt.das_dip << " deg, azimuth=" << opt.das_azimuth
-              << " deg, gauge=" << dasGaugeLength_
+    std::cout << "DAS receiver enabled: type=" << opt.das_type << ", dip=" << opt.das_dip
+              << " deg, azimuth=" << opt.das_azimuth << " deg, gauge=" << dasGaugeLength_
               << " m, samples=" << dasNumSamples_ << std::endl;
-    std::cout << "DAS direction vector: (" << dasDirection_[0] << ", "
-              << dasDirection_[1] << ", " << dasDirection_[2] << ")"
-              << std::endl;
+    std::cout << "DAS direction vector: (" << dasDirection_[0] << ", " << dasDirection_[1] << ", " << dasDirection_[2]
+              << ")" << std::endl;
   }
 }
 
-void SEMproxy::run()
-{
-  time_point<system_clock> startComputeTime, startOutputTime, totalComputeTime,
-      totalOutputTime;
+void SEMproxy::run() {
+  time_point<system_clock> startComputeTime, startOutputTime, totalComputeTime, totalOutputTime;
 
   bool isElastic = isElastic_;
   bool isAcoustoElastic = isAcoustoElastic_;
@@ -234,23 +203,16 @@ void SEMproxy::run()
   m_solver->computeFEInit(*m_mesh, sponge_size_, surface_sponge_, taper_delta_);
 
   // Synchronize Mass Matrix (Critical for DD)
-  if (par_topology_.isDistributed())
-  {
-    if (isAcoustoElastic_)
-    {
+  if (par_topology_.isDistributed()) {
+    if (isAcoustoElastic_) {
       m_syncer->synchronize(m_solver->getMassMatrixAcoustic(), par_topology_);
       m_syncer->synchronize(m_solver->getMassMatrixElastic(), par_topology_);
-    }
-    else if (isElastic_)
-    {
+    } else if (isElastic_) {
       m_syncer->synchronize(m_solver->getMassMatrixElastic(), par_topology_);
-    }
-    else
-    {
+    } else {
       m_syncer->synchronize(m_solver->getMassMatrixAcoustic(), par_topology_);
     }
-    for (int c = 0; c < m_solver->getNumComponents(); ++c)
-    {
+    for (int c = 0; c < m_solver->getNumComponents(); ++c) {
       m_syncer->synchronize(m_solver->getDampingMatrix(c), par_topology_);
     }
   }
@@ -258,18 +220,13 @@ void SEMproxy::run()
   // Get the global node index of the first node of the source element
   int debugNodeIdx = m_mesh->globalNodeIndex(myElementSource, 0, 0, 0);
 
-  if (isAcoustoElastic)
-  {
-    WavefieldAcoustoElastic wavefield(
-        pnGlobalPrev, pnGlobalCurr, uxnGlobalPrev, uxnGlobalCurr, uynGlobalPrev,
-        uynGlobalCurr, uznGlobalPrev, uznGlobalCurr);
-    RhsAcoustoElastic rhs(myRHSTerm, rhsElement, rhsWeights, myRHSTermx,
-                          myRHSTermy, myRHSTermz);
+  if (isAcoustoElastic) {
+    WavefieldAcoustoElastic wavefield(pnGlobalPrev, pnGlobalCurr, uxnGlobalPrev, uxnGlobalCurr, uynGlobalPrev,
+                                      uynGlobalCurr, uznGlobalPrev, uznGlobalCurr);
+    RhsAcoustoElastic rhs(myRHSTerm, rhsElement, rhsWeights, myRHSTermx, myRHSTermy, myRHSTermz);
     SEMsolverDataAcoustoElastic solverData(wavefield, rhs);
 
-    for (int indexTimeSample = 0; indexTimeSample < num_sample_;
-         indexTimeSample++)
-    {
+    for (int indexTimeSample = 0; indexTimeSample < num_sample_; indexTimeSample++) {
       startComputeTime = system_clock::now();
 
       // Full staggered step: elastic forces → elastic update →
@@ -279,23 +236,17 @@ void SEMproxy::run()
       totalComputeTime += system_clock::now() - startComputeTime;
       startOutputTime = system_clock::now();
 
-      if (indexTimeSample % 50 == 0)
-      {
+      if (indexTimeSample % 50 == 0) {
         // Acoustic field: print at source element (fluid domain).
-        m_solver->outputSolutionValues(indexTimeSample, rhsElement[0],
-                                       pnGlobalPrev, "pnGlobal");
+        m_solver->outputSolutionValues(indexTimeSample, rhsElement[0], pnGlobalPrev, "pnGlobal");
         // Elastic fields: print at receiver element — place receiver in the
         // solid domain (z < acoustoElasticBoundaryZ) to see non-zero values.
-        m_solver->outputSolutionValues(indexTimeSample, rhsElementRcv[0],
-                                       uxnGlobalPrev, "uxnGlobal");
-        m_solver->outputSolutionValues(indexTimeSample, rhsElementRcv[0],
-                                       uynGlobalPrev, "uynGlobal");
-        m_solver->outputSolutionValues(indexTimeSample, rhsElementRcv[0],
-                                       uznGlobalPrev, "uznGlobal");
+        m_solver->outputSolutionValues(indexTimeSample, rhsElementRcv[0], uxnGlobalPrev, "uxnGlobal");
+        m_solver->outputSolutionValues(indexTimeSample, rhsElementRcv[0], uynGlobalPrev, "uynGlobal");
+        m_solver->outputSolutionValues(indexTimeSample, rhsElementRcv[0], uznGlobalPrev, "uznGlobal");
       }
 
-      if (is_snapshots_ && indexTimeSample % snap_time_interval_ == 0)
-      {
+      if (is_snapshots_ && indexTimeSample % snap_time_interval_ == 0) {
         saveSnapshot(indexTimeSample, pnGlobalPrev);
         saveSnapshot(indexTimeSample, uznGlobalPrev);
       }
@@ -303,17 +254,12 @@ void SEMproxy::run()
       // Save acoustic pressure at receiver
       const int order = m_mesh->getOrder();
       float varnp1 = 0.0;
-      for (int i = 0; i < order + 1; i++)
-      {
-        for (int j = 0; j < order + 1; j++)
-        {
-          for (int k = 0; k < order + 1; k++)
-          {
+      for (int i = 0; i < order + 1; i++) {
+        for (int j = 0; j < order + 1; j++) {
+          for (int k = 0; k < order + 1; k++) {
             int nodeIdx = m_mesh->globalNodeIndex(rhsElementRcv[0], i, j, k);
-            int globalNodeOnElement =
-                i + j * (order + 1) + k * (order + 1) * (order + 1);
-            varnp1 +=
-                pnGlobalCurr(nodeIdx) * rhsWeightsRcv(0, globalNodeOnElement);
+            int globalNodeOnElement = i + j * (order + 1) + k * (order + 1) * (order + 1);
+            varnp1 += pnGlobalCurr(nodeIdx) * rhsWeightsRcv(0, globalNodeOnElement);
           }
         }
       }
@@ -324,8 +270,7 @@ void SEMproxy::run()
       totalOutputTime += system_clock::now() - startOutputTime;
     }
 
-    for (int i = 0; i < pnAtReceiver.extent(0); i++)
-    {
+    for (int i = 0; i < pnAtReceiver.extent(0); i++) {
 #ifdef USE_KOKKOS
       auto subview = Kokkos::subview(pnAtReceiver, i, Kokkos::ALL());
       vectorReal subset("receiver_save", num_sample_);
@@ -333,36 +278,28 @@ void SEMproxy::run()
 #else
       auto& subview = pnAtReceiver;
       vectorReal subset(subview.extent(0) * subview.extent(1));
-      for (size_t k = 0; k < subview.extent(0); ++k)
-      {
-        for (size_t j = 0; j < subview.extent(1); ++j)
-        {
+      for (size_t k = 0; k < subview.extent(0); ++k) {
+        for (size_t j = 0; j < subview.extent(1); ++j) {
           subset[k * subview.extent(1) + j] = subview(k, j);
         }
       }
 #endif
       io_ctrl_->saveReceiver(subset, src_coord_);
     }
-  }
-  else if (!isElastic)
-  {
+  } else if (!isElastic) {
     WavefieldAcoustic wavefield(pnGlobalPrev, pnGlobalCurr);
     RhsAcoustic rhs(myRHSTerm, rhsElement, rhsWeights);
     SEMsolverDataAcoustic solverData(wavefield, rhs);
 
-    for (int indexTimeSample = 0; indexTimeSample < num_sample_;
-         indexTimeSample++)
-    {
+    for (int indexTimeSample = 0; indexTimeSample < num_sample_; indexTimeSample++) {
       startComputeTime = system_clock::now();
 
       // Compute Local Forces
       m_solver->computeForces(dt_, indexTimeSample, solverData);
 
       // Synchronize Forces
-      if (par_topology_.isDistributed())
-      {
-        for (int c = 0; c < m_solver->getNumComponents(); ++c)
-        {
+      if (par_topology_.isDistributed()) {
+        for (int c = 0; c < m_solver->getNumComponents(); ++c) {
           m_syncer->synchronize(m_solver->getForceVector(c), par_topology_);
         }
       }
@@ -372,15 +309,12 @@ void SEMproxy::run()
       totalComputeTime += system_clock::now() - startComputeTime;
       startOutputTime = system_clock::now();
 
-      if (indexTimeSample % 50 == 0)
-      {
-        m_solver->outputSolutionValues(indexTimeSample, rhsElement[0],
-                                       pnGlobalPrev, "pnGlobal");
+      if (indexTimeSample % 50 == 0) {
+        m_solver->outputSolutionValues(indexTimeSample, rhsElement[0], pnGlobalPrev, "pnGlobal");
       }
 
       // Save slice in dat format
-      if (is_snapshots_ && indexTimeSample % snap_time_interval_ == 0)
-      {
+      if (is_snapshots_ && indexTimeSample % snap_time_interval_ == 0) {
 #ifdef USE_MPI
         MPI_Barrier(MPI_COMM_WORLD);
 #endif
@@ -392,13 +326,10 @@ void SEMproxy::run()
         int nz = nb_nodes_[2];
         int zSlice = nz / 2;
         std::ostringstream fname;
-        fname << "slice_" << std::setfill('0') << std::setw(5)
-              << indexTimeSample << ".dat";
+        fname << "slice_" << std::setfill('0') << std::setw(5) << indexTimeSample << ".dat";
         std::ofstream fslice(fname.str());
-        for (int iy = 0; iy < ny; ++iy)
-        {
-          for (int ix = 0; ix < nx; ++ix)
-          {
+        for (int iy = 0; iy < ny; ++iy) {
+          for (int ix = 0; ix < nx; ++ix) {
             int nodeIdx = ix + iy * nx + zSlice * nx * ny;
             fslice << pnGlobalPrev(nodeIdx);
             if (ix < nx - 1) fslice << " ";
@@ -412,17 +343,12 @@ void SEMproxy::run()
       const int order = m_mesh->getOrder();
 
       float varnp1 = 0.0;
-      for (int i = 0; i < order + 1; i++)
-      {
-        for (int j = 0; j < order + 1; j++)
-        {
-          for (int k = 0; k < order + 1; k++)
-          {
+      for (int i = 0; i < order + 1; i++) {
+        for (int j = 0; j < order + 1; j++) {
+          for (int k = 0; k < order + 1; k++) {
             int nodeIdx = m_mesh->globalNodeIndex(rhsElementRcv[0], i, j, k);
-            int globalNodeOnElement =
-                i + j * (order + 1) + k * (order + 1) * (order + 1);
-            varnp1 +=
-                pnGlobalCurr(nodeIdx) * rhsWeightsRcv(0, globalNodeOnElement);
+            int globalNodeOnElement = i + j * (order + 1) + k * (order + 1) * (order + 1);
+            varnp1 += pnGlobalCurr(nodeIdx) * rhsWeightsRcv(0, globalNodeOnElement);
           }
         }
       }
@@ -434,8 +360,7 @@ void SEMproxy::run()
       totalOutputTime += system_clock::now() - startOutputTime;
     }
 
-    for (int i = 0; i < pnAtReceiver.extent(0); i++)
-    {
+    for (int i = 0; i < pnAtReceiver.extent(0); i++) {
       auto subview = Kokkos::subview(pnAtReceiver, i, Kokkos::ALL());
       vectorReal subset("receiver_save", num_sample_);
       Kokkos::deep_copy(subset, subview);
@@ -446,25 +371,19 @@ void SEMproxy::run()
     {
       std::ofstream fout("receiver_trace.txt");
       fout << "# time pressure_at_receiver\n";
-      for (int t = 0; t < num_sample_; ++t)
-      {
+      for (int t = 0; t < num_sample_; ++t) {
         fout << t * dt_ << " " << pnAtReceiver(0, t) << "\n";
       }
       fout.close();
-      std::cout << "Receiver trace saved to receiver_trace.txt (" << num_sample_
-                << " samples)" << std::endl;
+      std::cout << "Receiver trace saved to receiver_trace.txt (" << num_sample_ << " samples)" << std::endl;
     }
-  }
-  else
-  {
-    WavefieldElastic wavefield(uxnGlobalPrev, uxnGlobalCurr, uynGlobalPrev,
-                               uynGlobalCurr, uznGlobalPrev, uznGlobalCurr);
+  } else {
+    WavefieldElastic wavefield(uxnGlobalPrev, uxnGlobalCurr, uynGlobalPrev, uynGlobalCurr, uznGlobalPrev,
+                               uznGlobalCurr);
     RhsElastic rhs(myRHSTermx, myRHSTermy, myRHSTermz, rhsElement, rhsWeights);
     SEMsolverDataElastic solverData(wavefield, rhs);
 
-    for (int indexTimeSample = 0; indexTimeSample < num_sample_;
-         indexTimeSample++)
-    {
+    for (int indexTimeSample = 0; indexTimeSample < num_sample_; indexTimeSample++) {
       startComputeTime = system_clock::now();
 
       // Compute Local Forces
@@ -472,10 +391,8 @@ void SEMproxy::run()
 
       // Synchronize Forces
       // TODO: Getting it work within semproxy
-      if (par_topology_.isDistributed())
-      {
-        for (int c = 0; c < m_solver->getNumComponents(); ++c)
-        {
+      if (par_topology_.isDistributed()) {
+        for (int c = 0; c < m_solver->getNumComponents(); ++c) {
           m_syncer->synchronize(m_solver->getForceVector(c), par_topology_);
         }
       }
@@ -486,18 +403,13 @@ void SEMproxy::run()
       totalComputeTime += system_clock::now() - startComputeTime;
       startOutputTime = system_clock::now();
 
-      if (indexTimeSample % 50 == 0)
-      {
-        m_solver->outputSolutionValues(indexTimeSample, rhsElement[0],
-                                       uxnGlobalPrev, "uxnGlobal");
-        m_solver->outputSolutionValues(indexTimeSample, rhsElement[0],
-                                       uynGlobalPrev, "uynGlobal");
-        m_solver->outputSolutionValues(indexTimeSample, rhsElement[0],
-                                       uznGlobalPrev, "uznGlobal");
+      if (indexTimeSample % 50 == 0) {
+        m_solver->outputSolutionValues(indexTimeSample, rhsElement[0], uxnGlobalPrev, "uxnGlobal");
+        m_solver->outputSolutionValues(indexTimeSample, rhsElement[0], uynGlobalPrev, "uynGlobal");
+        m_solver->outputSolutionValues(indexTimeSample, rhsElement[0], uznGlobalPrev, "uznGlobal");
       }
 
-      if (is_snapshots_ && indexTimeSample % snap_time_interval_ == 0)
-      {
+      if (is_snapshots_ && indexTimeSample % snap_time_interval_ == 0) {
         saveSnapshot(indexTimeSample, uxnGlobalPrev);
       }
 
@@ -507,21 +419,14 @@ void SEMproxy::run()
       float varuxnp1 = 0.0;
       float varyunp1 = 0.0;
       float varuznp1 = 0.0;
-      for (int i = 0; i < order + 1; i++)
-      {
-        for (int j = 0; j < order + 1; j++)
-        {
-          for (int k = 0; k < order + 1; k++)
-          {
+      for (int i = 0; i < order + 1; i++) {
+        for (int j = 0; j < order + 1; j++) {
+          for (int k = 0; k < order + 1; k++) {
             int nodeIdx = m_mesh->globalNodeIndex(rhsElementRcv[0], i, j, k);
-            int globalNodeOnElement =
-                i + j * (order + 1) + k * (order + 1) * (order + 1);
-            varuxnp1 +=
-                uxnGlobalCurr(nodeIdx) * rhsWeightsRcv(0, globalNodeOnElement);
-            varyunp1 +=
-                uynGlobalCurr(nodeIdx) * rhsWeightsRcv(0, globalNodeOnElement);
-            varuznp1 +=
-                uznGlobalCurr(nodeIdx) * rhsWeightsRcv(0, globalNodeOnElement);
+            int globalNodeOnElement = i + j * (order + 1) + k * (order + 1) * (order + 1);
+            varuxnp1 += uxnGlobalCurr(nodeIdx) * rhsWeightsRcv(0, globalNodeOnElement);
+            varyunp1 += uynGlobalCurr(nodeIdx) * rhsWeightsRcv(0, globalNodeOnElement);
+            varuznp1 += uznGlobalCurr(nodeIdx) * rhsWeightsRcv(0, globalNodeOnElement);
           }
         }
       }
@@ -531,18 +436,14 @@ void SEMproxy::run()
       uznAtReceiver(0, indexTimeSample) = varuznp1;
 
       // Compute DAS signal at this timestep
-      if (dasType_ != SourceAndReceiverUtils::DASType::kNone)
-      {
+      if (dasType_ != SourceAndReceiverUtils::DASType::kNone) {
         float dasVal = 0.0f;
         const int totalDASNodes = static_cast<int>(dasNodeIds_.size());
-        for (int iNode = 0; iNode < totalDASNodes; ++iNode)
-        {
+        for (int iNode = 0; iNode < totalDASNodes; ++iNode) {
           int nId = dasNodeIds_[iNode];
-          if (nId >= 0)
-          {
+          if (nId >= 0) {
             float w = dasWeights_[iNode];
-            dasVal += (uxnGlobalCurr(nId) * dasVector_[0] +
-                       uynGlobalCurr(nId) * dasVector_[1] +
+            dasVal += (uxnGlobalCurr(nId) * dasVector_[0] + uynGlobalCurr(nId) * dasVector_[1] +
                        uznGlobalCurr(nId) * dasVector_[2]) *
                       w;
           }
@@ -555,8 +456,7 @@ void SEMproxy::run()
       totalOutputTime += system_clock::now() - startOutputTime;
     }
 
-    for (int i = 0; i < uxnAtReceiver.extent(0); i++)
-    {
+    for (int i = 0; i < uxnAtReceiver.extent(0); i++) {
       auto subview = Kokkos::subview(uxnAtReceiver, i, Kokkos::ALL());
       vectorReal subset("receiver_save", num_sample_);
       Kokkos::deep_copy(subset, subview);
@@ -564,58 +464,43 @@ void SEMproxy::run()
     }
 
     // Save DAS trace to text file
-    if (dasType_ != SourceAndReceiverUtils::DASType::kNone)
-    {
+    if (dasType_ != SourceAndReceiverUtils::DASType::kNone) {
       std::ofstream fDAS("das_trace.txt");
       fDAS << "# time das_signal\n";
-      for (int t = 0; t < num_sample_; ++t)
-      {
+      for (int t = 0; t < num_sample_; ++t) {
         fDAS << t * dt_ << " " << dasSignal_(t) << "\n";
       }
       fDAS.close();
-      std::cout << "Saved DAS trace to das_trace.txt (" << num_sample_
-                << " samples)" << std::endl;
+      std::cout << "Saved DAS trace to das_trace.txt (" << num_sample_ << " samples)" << std::endl;
     }
   }
 
-  float kerneltime_ms = time_point_cast<microseconds>(totalComputeTime)
-                            .time_since_epoch()
-                            .count();
-  float outputtime_ms =
-      time_point_cast<microseconds>(totalOutputTime).time_since_epoch().count();
+  float kerneltime_ms = time_point_cast<microseconds>(totalComputeTime).time_since_epoch().count();
+  float outputtime_ms = time_point_cast<microseconds>(totalOutputTime).time_since_epoch().count();
 
   cout << "------------------------------------------------ " << endl;
-  cout << "\n---- Elapsed Kernel Time : " << kerneltime_ms / 1E6 << " seconds."
-       << endl;
-  cout << "---- Elapsed Output Time : " << outputtime_ms / 1E6 << " seconds."
-       << endl;
+  cout << "\n---- Elapsed Kernel Time : " << kerneltime_ms / 1E6 << " seconds." << endl;
+  cout << "---- Elapsed Output Time : " << outputtime_ms / 1E6 << " seconds." << endl;
   cout << "------------------------------------------------ " << endl;
 }
 
 // Initialize arrays
-void SEMproxy::init_arrays()
-{
+void SEMproxy::init_arrays() {
   cout << "Allocate host memory for source and pressure values ..." << endl;
   const auto n_nodes = m_mesh->getNumberOfNodes();
   const auto n_elements = m_mesh->getNumberOfElements();
   const auto n_points_per_element = m_mesh->getNumberOfPointsPerElement();
 
   rhsElement = allocateVector<vectorInt>(myNumberOfRHS, "rhsElement");
-  rhsWeights = allocateArray2D<arrayReal>(myNumberOfRHS, n_points_per_element,
-                                          "RHSWeight");
+  rhsWeights = allocateArray2D<arrayReal>(myNumberOfRHS, n_points_per_element, "RHSWeight");
 
-  if (isAcoustoElastic_)
-  {
+  if (isAcoustoElastic_) {
     // Acousto-elastic: acoustic + elastic source terms (one may be all zeros),
     // plus both wavefields (acoustic pressure and elastic displacement).
-    myRHSTerm =
-        allocateArray2D<arrayReal>(myNumberOfRHS, num_sample_, "RHSTerm");
-    myRHSTermx =
-        allocateArray2D<arrayReal>(myNumberOfRHS, num_sample_, "RHSTermx");
-    myRHSTermy =
-        allocateArray2D<arrayReal>(myNumberOfRHS, num_sample_, "RHSTermy");
-    myRHSTermz =
-        allocateArray2D<arrayReal>(myNumberOfRHS, num_sample_, "RHSTermz");
+    myRHSTerm = allocateArray2D<arrayReal>(myNumberOfRHS, num_sample_, "RHSTerm");
+    myRHSTermx = allocateArray2D<arrayReal>(myNumberOfRHS, num_sample_, "RHSTermx");
+    myRHSTermy = allocateArray2D<arrayReal>(myNumberOfRHS, num_sample_, "RHSTermy");
+    myRHSTermz = allocateArray2D<arrayReal>(myNumberOfRHS, num_sample_, "RHSTermz");
     pnGlobalCurr = allocateVector<vectorReal>(n_nodes, "pnGlobalCurr");
     pnGlobalPrev = allocateVector<vectorReal>(n_nodes, "pnGlobalPrev");
     pnAtReceiver = allocateArray2D<arrayReal>(1, num_sample_, "pnAtReceiver");
@@ -625,23 +510,15 @@ void SEMproxy::init_arrays()
     uxnGlobalPrev = allocateVector<vectorReal>(n_nodes, "uxnGlobalPrev");
     uynGlobalPrev = allocateVector<vectorReal>(n_nodes, "uynGlobalPrev");
     uznGlobalPrev = allocateVector<vectorReal>(n_nodes, "uznGlobalPrev");
-  }
-  else if (!isElastic_)
-  {
-    myRHSTerm =
-        allocateArray2D<arrayReal>(myNumberOfRHS, num_sample_, "RHSTerm");
+  } else if (!isElastic_) {
+    myRHSTerm = allocateArray2D<arrayReal>(myNumberOfRHS, num_sample_, "RHSTerm");
     pnGlobalCurr = allocateVector<vectorReal>(n_nodes, "pnGlobalCurr");
     pnGlobalPrev = allocateVector<vectorReal>(n_nodes, "pnGlobalPrev");
     pnAtReceiver = allocateArray2D<arrayReal>(1, num_sample_, "pnAtReceiver");
-  }
-  else
-  {
-    myRHSTermx =
-        allocateArray2D<arrayReal>(myNumberOfRHS, num_sample_, "RHSTermx");
-    myRHSTermy =
-        allocateArray2D<arrayReal>(myNumberOfRHS, num_sample_, "RHSTermy");
-    myRHSTermz =
-        allocateArray2D<arrayReal>(myNumberOfRHS, num_sample_, "RHSTermz");
+  } else {
+    myRHSTermx = allocateArray2D<arrayReal>(myNumberOfRHS, num_sample_, "RHSTermx");
+    myRHSTermy = allocateArray2D<arrayReal>(myNumberOfRHS, num_sample_, "RHSTermy");
+    myRHSTermz = allocateArray2D<arrayReal>(myNumberOfRHS, num_sample_, "RHSTermz");
     uxnGlobalCurr = allocateVector<vectorReal>(n_nodes, "uxnGlobalCurr");
     uynGlobalCurr = allocateVector<vectorReal>(n_nodes, "uynGlobalCurr");
     uznGlobalCurr = allocateVector<vectorReal>(n_nodes, "uznGlobalCurr");
@@ -649,30 +526,25 @@ void SEMproxy::init_arrays()
     uynGlobalPrev = allocateVector<vectorReal>(n_nodes, "uynGlobalPrev");
     uznGlobalPrev = allocateVector<vectorReal>(n_nodes, "uznGlobalPrev");
     uxnAtReceiver = allocateArray2D<arrayReal>(1, num_sample_, "uxnAtReceiver");
-    uynAtReceiver =
-        allocateArray2D<arrayReal>(1, num_sample_, "uynAtReceiver ");
+    uynAtReceiver = allocateArray2D<arrayReal>(1, num_sample_, "uynAtReceiver ");
     uznAtReceiver = allocateArray2D<arrayReal>(1, num_sample_, "uznAtReceiver");
   }
   // Receiver
   rhsElementRcv = allocateVector<vectorInt>(1, "rhsElementRcv");
-  rhsWeightsRcv = allocateArray2D<arrayReal>(
-      1, m_mesh->getNumberOfPointsPerElement(), "RHSWeightRcv");
+  rhsWeightsRcv = allocateArray2D<arrayReal>(1, m_mesh->getNumberOfPointsPerElement(), "RHSWeightRcv");
 
   // DAS signal array
-  if (dasType_ != SourceAndReceiverUtils::DASType::kNone)
-  {
+  if (dasType_ != SourceAndReceiverUtils::DASType::kNone) {
     dasSignal_ = allocateVector<vectorReal>(num_sample_, "dasSignal");
   }
 }
 
 // Initialize sources
-void SEMproxy::init_source()
-{
+void SEMproxy::init_source() {
   arrayReal myRHSLocation = allocateArray2D<arrayReal>(1, 3, "RHSLocation");
   // std::cout << "All source are currently are coded on element 50." <<
   // std::endl;
-  std::cout << "All source are currently are coded on middle element."
-            << std::endl;
+  std::cout << "All source are currently are coded on middle element." << std::endl;
   int ex = nb_elements_[0];
   int ey = nb_elements_[1];
   int ez = nb_elements_[2];
@@ -697,14 +569,10 @@ void SEMproxy::init_source()
   // Note: Y and Z not partitioned in 1D case, so check logic is simpler.
 
   int source_index = 0;
-  if (sourceOnThisRank)
-  {
-    source_index = floor((relative_src_x * ex) / lx) +
-                   floor((relative_src_y * ey) / ly) * ex +
+  if (sourceOnThisRank) {
+    source_index = floor((relative_src_x * ex) / lx) + floor((relative_src_y * ey) / ly) * ex +
                    floor((relative_src_z * ez) / lz) * ey * ex;
-  }
-  else
-  {
+  } else {
     // Point to a safe dummy element (e.g. 0) but we will zero out weights?
     // Or we can rely on weight computation finding it outside.
     // For proxy simplicity, if not local, we just calculate 'an' index.
@@ -712,8 +580,7 @@ void SEMproxy::init_source()
     source_index = 0;  // Placeholder
   }
 
-  for (int i = 0; i < 1; i++)
-  {
+  for (int i = 0; i < 1; i++) {
     rhsElement[i] = source_index;
   }
 
@@ -721,12 +588,9 @@ void SEMproxy::init_source()
   float cornerCoords[8][3];
   int I = 0;
   int nodes_corner[2] = {0, m_mesh->getOrder()};
-  for (int k : nodes_corner)
-  {
-    for (int j : nodes_corner)
-    {
-      for (int i : nodes_corner)
-      {
+  for (int k : nodes_corner) {
+    for (int j : nodes_corner) {
+      for (int i : nodes_corner) {
         int nodeIdx = m_mesh->globalNodeIndex(rhsElement[0], i, j, k);
         cornerCoords[I][0] = m_mesh->nodeCoord(nodeIdx, 0);
         cornerCoords[I][2] = m_mesh->nodeCoord(nodeIdx, 2);
@@ -737,132 +601,96 @@ void SEMproxy::init_source()
   }
 
   // initialize source term
-  vector<float> sourceTerm =
-      myUtils.computeSourceTerm(num_sample_, dt_, f0_, ricker_order_, tpeak_);
-  if (isAcoustoElastic_)
-  {
+  vector<float> sourceTerm = myUtils.computeSourceTerm(num_sample_, dt_, f0_, ricker_order_, tpeak_);
+  if (isAcoustoElastic_) {
     // Auto-detect source domain based on depth vs interface boundary.
     // z >= acoustoElasticBoundaryZ → fluid (acoustic); otherwise → solid
     // (elastic).
-    bool const sourceInFluid =
-        (src_coord_[2] >= m_localParams.acoustoElasticBoundaryZ);
-    if (sourceInFluid)
-    {
+    bool const sourceInFluid = (src_coord_[2] >= m_localParams.acoustoElasticBoundaryZ);
+    if (sourceInFluid) {
       cout << "Acousto-elastic source: fluid domain (acoustic)." << endl;
-      for (int j = 0; j < num_sample_; j++)
-      {
+      for (int j = 0; j < num_sample_; j++) {
         myRHSTerm(0, j) = sourceTerm[j];
-        if (j % 100 == 0)
-          cout << "Sample " << j << "\t: sourceTerm = " << sourceTerm[j]
-               << endl;
+        if (j % 100 == 0) cout << "Sample " << j << "\t: sourceTerm = " << sourceTerm[j] << endl;
       }
-    }
-    else
-    {
+    } else {
       cout << "Acousto-elastic source: solid domain (elastic)." << endl;
-      for (int j = 0; j < num_sample_; j++)
-      {
+      for (int j = 0; j < num_sample_; j++) {
         myRHSTermx(0, j) = sourceTerm[j];
         myRHSTermy(0, j) = sourceTerm[j];
         myRHSTermz(0, j) = sourceTerm[j];
-        if (j % 100 == 0)
-          cout << "Sample " << j << "\t: sourceTerm = " << sourceTerm[j]
-               << endl;
+        if (j % 100 == 0) cout << "Sample " << j << "\t: sourceTerm = " << sourceTerm[j] << endl;
       }
     }
-  }
-  else if (!isElastic_)
-  {
+  } else if (!isElastic_) {
     // Pure acoustic source.
-    for (int j = 0; j < num_sample_; j++)
-    {
+    for (int j = 0; j < num_sample_; j++) {
       myRHSTerm(0, j) = sourceTerm[j];
-      if (j % 100 == 0)
-        cout << "Sample " << j << "\t: sourceTerm = " << sourceTerm[j] << endl;
+      if (j % 100 == 0) cout << "Sample " << j << "\t: sourceTerm = " << sourceTerm[j] << endl;
     }
-  }
-  else
-  {
+  } else {
     // Pure elastic source.
-    for (int j = 0; j < num_sample_; j++)
-    {
+    for (int j = 0; j < num_sample_; j++) {
       myRHSTermx(0, j) = sourceTerm[j];
       myRHSTermy(0, j) = sourceTerm[j];
       myRHSTermz(0, j) = sourceTerm[j];
-      if (j % 100 == 0)
-        cout << "Sample " << j << "\t: sourceTerm = " << sourceTerm[j] << endl;
+      if (j % 100 == 0) cout << "Sample " << j << "\t: sourceTerm = " << sourceTerm[j] << endl;
     }
   }
 
   // get element number of source term
   myElementSource = rhsElement[0];
-  cout << "Element number for the source location: " << myElementSource << endl
-       << endl;
+  cout << "Element number for the source location: " << myElementSource << endl << endl;
 
   int order = m_mesh->getOrder();
 
   // Compute Weights: If source is not local, weights will be ~0 or we should
   // explicit zero them
-  if (sourceOnThisRank)
-  {
-    switch (order)
-    {
+  if (sourceOnThisRank) {
+    switch (order) {
       case 1:
-        SourceAndReceiverUtils::ComputeRHSWeights<1>(cornerCoords, src_coord_,
-                                                     rhsWeights);
+        SourceAndReceiverUtils::ComputeRHSWeights<1>(cornerCoords, src_coord_, rhsWeights);
         break;
       case 2:
-        SourceAndReceiverUtils::ComputeRHSWeights<2>(cornerCoords, src_coord_,
-                                                     rhsWeights);
+        SourceAndReceiverUtils::ComputeRHSWeights<2>(cornerCoords, src_coord_, rhsWeights);
         break;
       case 3:
-        SourceAndReceiverUtils::ComputeRHSWeights<3>(cornerCoords, src_coord_,
-                                                     rhsWeights);
+        SourceAndReceiverUtils::ComputeRHSWeights<3>(cornerCoords, src_coord_, rhsWeights);
         break;
       case 4:
-        SourceAndReceiverUtils::ComputeRHSWeights<4>(cornerCoords, src_coord_,
-                                                     rhsWeights);
+        SourceAndReceiverUtils::ComputeRHSWeights<4>(cornerCoords, src_coord_, rhsWeights);
         break;
       case 5:
-        SourceAndReceiverUtils::ComputeRHSWeights<5>(cornerCoords, src_coord_,
-                                                     rhsWeights);
+        SourceAndReceiverUtils::ComputeRHSWeights<5>(cornerCoords, src_coord_, rhsWeights);
         break;
       default:
         throw std::runtime_error("Unsupported order: " + std::to_string(order));
     }
-  }
-  else
-  {
+  } else {
     // Zero weights if source is not on this rank
-    for (int k = 0; k < m_mesh->getNumberOfPointsPerElement(); ++k)
-      rhsWeights(0, k) = 0.0f;
+    for (int k = 0; k < m_mesh->getNumberOfPointsPerElement(); ++k) rhsWeights(0, k) = 0.0f;
   }
 
   // Receiver computation
   // Similar logic for receiver
   float relative_rcv_x = rcv_coord_[0] - m_localParams.origin_x;
-  int receiver_index = floor((relative_rcv_x * ex) / lx) +
-                       floor((rcv_coord_[1] * ey) / ly) * ex +
+  int receiver_index = floor((relative_rcv_x * ex) / lx) + floor((rcv_coord_[1] * ey) / ly) * ex +
                        floor((rcv_coord_[2] * ez) / lz) * ey * ex;
 
   // Clamp index to avoid segfaults during testing if receiver is out of bounds
   if (receiver_index < 0) receiver_index = 0;
   if (receiver_index >= m_mesh->getNumberOfElements()) receiver_index = 0;
 
-  for (int i = 0; i < 1; i++)
-  {
+  for (int i = 0; i < 1; i++) {
     rhsElementRcv[i] = receiver_index;
   }
 
   // Get coordinates of the corners of the receiver element
   float cornerCoordsRcv[8][3];
   I = 0;
-  for (int k : nodes_corner)
-  {
-    for (int j : nodes_corner)
-    {
-      for (int i : nodes_corner)
-      {
+  for (int k : nodes_corner) {
+    for (int j : nodes_corner) {
+      for (int i : nodes_corner) {
         int nodeIdx = m_mesh->globalNodeIndex(rhsElementRcv[0], i, j, k);
         cornerCoordsRcv[I][0] = m_mesh->nodeCoord(nodeIdx, 0);
         cornerCoordsRcv[I][2] = m_mesh->nodeCoord(nodeIdx, 2);
@@ -872,27 +700,21 @@ void SEMproxy::init_source()
     }
   }
 
-  switch (order)
-  {
+  switch (order) {
     case 1:
-      SourceAndReceiverUtils::ComputeRHSWeights<1>(cornerCoordsRcv, rcv_coord_,
-                                                   rhsWeightsRcv);
+      SourceAndReceiverUtils::ComputeRHSWeights<1>(cornerCoordsRcv, rcv_coord_, rhsWeightsRcv);
       break;
     case 2:
-      SourceAndReceiverUtils::ComputeRHSWeights<2>(cornerCoordsRcv, rcv_coord_,
-                                                   rhsWeightsRcv);
+      SourceAndReceiverUtils::ComputeRHSWeights<2>(cornerCoordsRcv, rcv_coord_, rhsWeightsRcv);
       break;
     case 3:
-      SourceAndReceiverUtils::ComputeRHSWeights<3>(cornerCoordsRcv, rcv_coord_,
-                                                   rhsWeightsRcv);
+      SourceAndReceiverUtils::ComputeRHSWeights<3>(cornerCoordsRcv, rcv_coord_, rhsWeightsRcv);
       break;
     case 4:
-      SourceAndReceiverUtils::ComputeRHSWeights<4>(cornerCoordsRcv, rcv_coord_,
-                                                   rhsWeightsRcv);
+      SourceAndReceiverUtils::ComputeRHSWeights<4>(cornerCoordsRcv, rcv_coord_, rhsWeightsRcv);
       break;
     case 5:
-      SourceAndReceiverUtils::ComputeRHSWeights<5>(cornerCoordsRcv, rcv_coord_,
-                                                   rhsWeightsRcv);
+      SourceAndReceiverUtils::ComputeRHSWeights<5>(cornerCoordsRcv, rcv_coord_, rhsWeightsRcv);
       break;
     default:
       throw std::runtime_error("Unsupported order: " + std::to_string(order));
@@ -900,27 +722,24 @@ void SEMproxy::init_source()
 
   std::cout << "\n--- DEBUG INFO ---" << std::endl;
   std::cout << "Source Element: " << rhsElement[0] << std::endl;
-  std::cout << "Source Coord: " << src_coord_[0] << " " << src_coord_[1] << " "
-            << src_coord_[2] << std::endl;
+  std::cout << "Source Coord: " << src_coord_[0] << " " << src_coord_[1] << " " << src_coord_[2] << std::endl;
 
   // Print Corner Coordinates of the source element
-  std::cout << "Corner Coords (Node 0): " << cornerCoords[0][0] << ", "
-            << cornerCoords[0][1] << ", " << cornerCoords[0][2] << std::endl;
-  std::cout << "Corner Coords (Node 7): " << cornerCoords[7][0] << ", "
-            << cornerCoords[7][1] << ", " << cornerCoords[7][2] << std::endl;
+  std::cout << "Corner Coords (Node 0): " << cornerCoords[0][0] << ", " << cornerCoords[0][1] << ", "
+            << cornerCoords[0][2] << std::endl;
+  std::cout << "Corner Coords (Node 7): " << cornerCoords[7][0] << ", " << cornerCoords[7][1] << ", "
+            << cornerCoords[7][2] << std::endl;
 
   // Print Calculated Weights
   std::cout << "RHS Weights: ";
-  for (int k = 0; k < m_mesh->getNumberOfPointsPerElement(); ++k)
-  {
+  for (int k = 0; k < m_mesh->getNumberOfPointsPerElement(); ++k) {
     std::cout << rhsWeights(0, k) << " ";
   }
   std::cout << std::endl;
   std::cout << "------------------\n" << std::endl;
 
   // DAS receiver precomputation
-  if (dasType_ != SourceAndReceiverUtils::DASType::kNone)
-  {
+  if (dasType_ != SourceAndReceiverUtils::DASType::kNone) {
     const int npe = m_mesh->getNumberOfPointsPerElement();
     const int totalDASNodes = dasNumSamples_ * npe;
     dasNodeIds_.resize(totalDASNodes, -1);
@@ -928,51 +747,38 @@ void SEMproxy::init_source()
 
     // Compute sample point locations along fiber [-0.5, ..., +0.5]
     std::vector<float> sampleLocations(dasNumSamples_);
-    if (dasNumSamples_ == 1)
-    {
+    if (dasNumSamples_ == 1) {
       sampleLocations[0] = 0.0f;
-    }
-    else
-    {
-      for (int i = 0; i < dasNumSamples_; ++i)
-      {
-        sampleLocations[i] =
-            -0.5f + static_cast<float>(i) / (dasNumSamples_ - 1);
+    } else {
+      for (int i = 0; i < dasNumSamples_; ++i) {
+        sampleLocations[i] = -0.5f + static_cast<float>(i) / (dasNumSamples_ - 1);
       }
     }
 
     // Compute integration constants
     std::vector<float> integrationConstants(dasNumSamples_);
-    if (dasType_ == SourceAndReceiverUtils::DASType::kDipole)
-    {
+    if (dasType_ == SourceAndReceiverUtils::DASType::kDipole) {
       integrationConstants[0] = -1.0f;
       integrationConstants[1] = 1.0f;
-    }
-    else
-    {
-      for (int i = 0; i < dasNumSamples_; ++i)
-      {
+    } else {
+      for (int i = 0; i < dasNumSamples_; ++i) {
         integrationConstants[i] = 1.0f / dasNumSamples_;
       }
     }
 
     // For each sample point along the fiber
-    for (int iSample = 0; iSample < dasNumSamples_; ++iSample)
-    {
+    for (int iSample = 0; iSample < dasNumSamples_; ++iSample) {
       // Physical coordinates of sample point
       std::array<float, 3> sampleCoord;
-      for (int d = 0; d < 3; ++d)
-      {
-        sampleCoord[d] = rcv_coord_[d] + dasDirection_[d] * dasGaugeLength_ *
-                                             sampleLocations[iSample];
+      for (int d = 0; d < 3; ++d) {
+        sampleCoord[d] = rcv_coord_[d] + dasDirection_[d] * dasGaugeLength_ * sampleLocations[iSample];
       }
 
       // Find element containing this sample point
       float rel_x = sampleCoord[0] - m_localParams.origin_x;
-      int sampleElemIdx =
-          static_cast<int>(std::floor((rel_x * ex) / lx)) +
-          static_cast<int>(std::floor((sampleCoord[1] * ey) / ly)) * ex +
-          static_cast<int>(std::floor((sampleCoord[2] * ez) / lz)) * ey * ex;
+      int sampleElemIdx = static_cast<int>(std::floor((rel_x * ex) / lx)) +
+                          static_cast<int>(std::floor((sampleCoord[1] * ey) / ly)) * ex +
+                          static_cast<int>(std::floor((sampleCoord[2] * ez) / lz)) * ey * ex;
 
       // Clamp to valid range
       if (sampleElemIdx < 0) sampleElemIdx = 0;
@@ -981,12 +787,9 @@ void SEMproxy::init_source()
       // Get corner coordinates of sample element
       float sampleCornerCoords[8][3];
       int ci = 0;
-      for (int kk : nodes_corner)
-      {
-        for (int jj : nodes_corner)
-        {
-          for (int ii : nodes_corner)
-          {
+      for (int kk : nodes_corner) {
+        for (int jj : nodes_corner) {
+          for (int ii : nodes_corner) {
             int nIdx = m_mesh->globalNodeIndex(sampleElemIdx, ii, jj, kk);
             sampleCornerCoords[ci][0] = m_mesh->nodeCoord(nIdx, 0);
             sampleCornerCoords[ci][1] = m_mesh->nodeCoord(nIdx, 1);
@@ -998,82 +801,70 @@ void SEMproxy::init_source()
 
       // Store global node IDs for this sample's element
       int baseIdx = iSample * npe;
-      for (int kk = 0; kk < order + 1; ++kk)
-      {
-        for (int jj = 0; jj < order + 1; ++jj)
-        {
-          for (int ii = 0; ii < order + 1; ++ii)
-          {
-            int localNode =
-                ii + jj * (order + 1) + kk * (order + 1) * (order + 1);
-            dasNodeIds_[baseIdx + localNode] =
-                m_mesh->globalNodeIndex(sampleElemIdx, ii, jj, kk);
+      for (int kk = 0; kk < order + 1; ++kk) {
+        for (int jj = 0; jj < order + 1; ++jj) {
+          for (int ii = 0; ii < order + 1; ++ii) {
+            int localNode = ii + jj * (order + 1) + kk * (order + 1) * (order + 1);
+            dasNodeIds_[baseIdx + localNode] = m_mesh->globalNodeIndex(sampleElemIdx, ii, jj, kk);
           }
         }
       }
 
       // Compute weights for this sample point
-      switch (order)
-      {
+      switch (order) {
         case 1:
-          SourceAndReceiverUtils::ComputeDASWeightsForSample<1>(
-              sampleCornerCoords, sampleCoord, dasDirection_,
-              integrationConstants[iSample], dasType_, &dasWeights_[baseIdx]);
+          SourceAndReceiverUtils::ComputeDASWeightsForSample<1>(sampleCornerCoords, sampleCoord, dasDirection_,
+                                                                integrationConstants[iSample], dasType_,
+                                                                &dasWeights_[baseIdx]);
           break;
         case 2:
-          SourceAndReceiverUtils::ComputeDASWeightsForSample<2>(
-              sampleCornerCoords, sampleCoord, dasDirection_,
-              integrationConstants[iSample], dasType_, &dasWeights_[baseIdx]);
+          SourceAndReceiverUtils::ComputeDASWeightsForSample<2>(sampleCornerCoords, sampleCoord, dasDirection_,
+                                                                integrationConstants[iSample], dasType_,
+                                                                &dasWeights_[baseIdx]);
           break;
         case 3:
-          SourceAndReceiverUtils::ComputeDASWeightsForSample<3>(
-              sampleCornerCoords, sampleCoord, dasDirection_,
-              integrationConstants[iSample], dasType_, &dasWeights_[baseIdx]);
+          SourceAndReceiverUtils::ComputeDASWeightsForSample<3>(sampleCornerCoords, sampleCoord, dasDirection_,
+                                                                integrationConstants[iSample], dasType_,
+                                                                &dasWeights_[baseIdx]);
           break;
         case 4:
-          SourceAndReceiverUtils::ComputeDASWeightsForSample<4>(
-              sampleCornerCoords, sampleCoord, dasDirection_,
-              integrationConstants[iSample], dasType_, &dasWeights_[baseIdx]);
+          SourceAndReceiverUtils::ComputeDASWeightsForSample<4>(sampleCornerCoords, sampleCoord, dasDirection_,
+                                                                integrationConstants[iSample], dasType_,
+                                                                &dasWeights_[baseIdx]);
           break;
         case 5:
-          SourceAndReceiverUtils::ComputeDASWeightsForSample<5>(
-              sampleCornerCoords, sampleCoord, dasDirection_,
-              integrationConstants[iSample], dasType_, &dasWeights_[baseIdx]);
+          SourceAndReceiverUtils::ComputeDASWeightsForSample<5>(sampleCornerCoords, sampleCoord, dasDirection_,
+                                                                integrationConstants[iSample], dasType_,
+                                                                &dasWeights_[baseIdx]);
           break;
         default:
-          throw std::runtime_error("Unsupported order for DAS: " +
-                                   std::to_string(order));
+          throw std::runtime_error("Unsupported order for DAS: " + std::to_string(order));
       }
     }
 
-    std::cout << "DAS precomputation complete: " << dasNumSamples_
-              << " samples, " << totalDASNodes << " node entries" << std::endl;
+    std::cout << "DAS precomputation complete: " << dasNumSamples_ << " samples, " << totalDASNodes << " node entries"
+              << std::endl;
   }
 }
 
-void SEMproxy::saveSnapshot(int timestep, VECTOR_REAL_VIEW data) const
-{
+void SEMproxy::saveSnapshot(int timestep, VECTOR_REAL_VIEW data) const {
   Kokkos::fence();
   auto nb_nodes = data.extent(0);
 
   vectorReal subset("snapshot_cpy", nb_nodes);
   // Use a parallel copy to handle the strided layout
-  Kokkos::parallel_for(
-      "copy_column", nb_nodes, KOKKOS_LAMBDA(int i) { subset(i) = data(i); });
+  Kokkos::parallel_for("copy_column", nb_nodes, KOKKOS_LAMBDA(int i) { subset(i) = data(i); });
   Kokkos::fence();
   io_ctrl_->saveSnapshot(subset, timestep);
 }
 
-implemType SEMproxy::getImplem(string implemArg)
-{
+implemType SEMproxy::getImplem(string implemArg) {
   if (implemArg == "makutu") return implemType::kMakutu;
 
-  throw std::invalid_argument(
-      "Implentation type does not follow any valid type.");
+  throw std::invalid_argument("Implentation type does not follow any valid type.");
 }
 
-meshType SEMproxy::getMesh(string meshArg)
-{
+meshType SEMproxy::getMesh(string meshArg) {
   if (meshArg == "cartesian") return meshType::kStruct;
   if (meshArg == "ucartesian") return meshType::kUnstruct;
 
@@ -1081,26 +872,22 @@ meshType SEMproxy::getMesh(string meshArg)
   throw std::invalid_argument("Mesh type does not follow any valid type.");
 }
 
-methodType SEMproxy::getMethod(string methodArg)
-{
+methodType SEMproxy::getMethod(string methodArg) {
   if (methodArg == "sem") return methodType::kSem;
   if (methodArg == "dg") return methodType::kDg;
 
   throw std::invalid_argument("Method type does not follow any valid type.");
 }
 
-model::AnisotropyType SEMproxy::getAnisotropy(string anisotropyArg)
-{
+model::AnisotropyType SEMproxy::getAnisotropy(string anisotropyArg) {
   if (anisotropyArg == "iso") return model::AnisotropyType::kIso;
   if (anisotropyArg == "vti") return model::AnisotropyType::kVTI;
   if (anisotropyArg == "tti") return model::AnisotropyType::kTTI;
 
-  throw std::invalid_argument(
-      "Anisotropy type does not follow any valid type.");
+  throw std::invalid_argument("Anisotropy type does not follow any valid type.");
 }
 
-float SEMproxy::find_cfl_dt(float cfl_factor)
-{
+float SEMproxy::find_cfl_dt(float cfl_factor) {
   float sqrtDim3 = 1.73;  // to change for 2d
   float min_spacing = m_mesh->getMinSpacing();
   float v_max = m_mesh->getMaxSpeed();
@@ -1110,43 +897,35 @@ float SEMproxy::find_cfl_dt(float cfl_factor)
   return dt;
 }
 
-void SEMproxy::init_mpi(int* mpi_init)
-{
+void SEMproxy::init_mpi(int* mpi_init) {
 #ifdef USE_MPI
   MPI_Initialized(mpi_init);
-  if (mpi_init)
-  {
+  if (mpi_init) {
     MPI_Comm_rank(MPI_COMM_WORLD, &dist_ctx_.rank);
     MPI_Comm_size(MPI_COMM_WORLD, &dist_ctx_.size);
-  }
-  else
-  {
+  } else {
     dist_ctx_.rank = 0;
     dist_ctx_.size = 1;
   }
-  std::cout << "[rank " << dist_ctx_.rank << "] size " << dist_ctx_.size
-            << std::endl;
+  std::cout << "[rank " << dist_ctx_.rank << "] size " << dist_ctx_.size << std::endl;
 #else
   dist_ctx_.rank = 0;
   dist_ctx_.size = 1;
 #endif
 }
 
-void SEMproxy::init_sim_params(const SemProxyOptions& opt)
-{
+void SEMproxy::init_sim_params(const SemProxyOptions& opt) {
   // Partition Logic
   // Create Global Params
-  model::CartesianParams<float, int> globalParams(
-      opt.order, opt.ex, opt.ey, opt.ez, opt.lx, opt.ly, opt.lz,
-      opt.isModelOnNodes, opt.isElastic);
+  model::CartesianParams<float, int> globalParams(opt.order, opt.ex, opt.ey, opt.ez, opt.lx, opt.ly, opt.lz,
+                                                  opt.isModelOnNodes, opt.isElastic);
   globalParams.isAcoustoElastic = opt.isAcoustoElastic;
   globalParams.acoustoElasticBoundaryZ = opt.acoustoElasticBoundaryZ;
   globalParams.origin_x = 0;  // Global start
 
   // Partition domain
   model::CartesianXPartitioner<float, int> partitioner;
-  m_localParams =
-      partitioner.partition(globalParams, dist_ctx_.rank, dist_ctx_.size);
+  m_localParams = partitioner.partition(globalParams, dist_ctx_.rank, dist_ctx_.size);
   // Preserve acoustoelastic fields (not handled by partitioner geometry split)
   m_localParams.isAcoustoElastic = opt.isAcoustoElastic;
   m_localParams.acoustoElasticBoundaryZ = opt.acoustoElasticBoundaryZ;
@@ -1178,8 +957,7 @@ void SEMproxy::init_sim_params(const SemProxyOptions& opt)
   isElastic_ = opt.isElastic;
 
   std::cout << "Debug Print :" << std::endl;
-  std::cout << "    Rank " << dist_ctx_.rank << "/" << dist_ctx_.size
-            << std::endl;
+  std::cout << "    Rank " << dist_ctx_.rank << "/" << dist_ctx_.size << std::endl;
   std::cout << "    Local lx " << m_localParams.lx << std::endl;
   std::cout << "    Local ly " << m_localParams.ly << std::endl;
   std::cout << "    Local lz " << m_localParams.lz << std::endl;
@@ -1188,155 +966,111 @@ void SEMproxy::init_sim_params(const SemProxyOptions& opt)
   std::cout << "    Local ez " << m_localParams.ez << std::endl;
 }
 
-void SEMproxy::init_mesh_params(const SemProxyOptions& opt)
-{
+void SEMproxy::init_mesh_params(const SemProxyOptions& opt) {
   const methodType methodType = getMethod(opt.method);
   const implemType implemType = getImplem(opt.implem);
   const meshType meshType = getMesh(opt.mesh);
 
   // Build Mesh using LOCAL parameters
-  if (meshType == meshType::kStruct)
-  {
-    switch (opt.order)
-    {
+  if (meshType == meshType::kStruct) {
+    switch (opt.order) {
       case 1: {
         model::CartesianStructBuilder<float, int, 1> builder(
-            m_localParams.ex, m_localParams.lx, m_localParams.ey,
-            m_localParams.ly, m_localParams.ez, m_localParams.lz,
-            opt.isModelOnNodes, opt.isElastic, m_localParams.origin_x,
-            m_localParams.origin_y, m_localParams.origin_z, -1.0f, -1.0f, -1.0f,
-            0.0f, 0.0f, 0.0f, opt.isAcoustoElastic,
-            opt.acoustoElasticBoundaryZ);
+            m_localParams.ex, m_localParams.lx, m_localParams.ey, m_localParams.ly, m_localParams.ez, m_localParams.lz,
+            opt.isModelOnNodes, opt.isElastic, m_localParams.origin_x, m_localParams.origin_y, m_localParams.origin_z,
+            -1.0f, -1.0f, -1.0f, 0.0f, 0.0f, 0.0f, opt.isAcoustoElastic, opt.acoustoElasticBoundaryZ);
         m_mesh = builder.getModel(opt.free_surface);
         break;
       }
       case 2: {
         model::CartesianStructBuilder<float, int, 2> builder(
-            m_localParams.ex, m_localParams.lx, m_localParams.ey,
-            m_localParams.ly, m_localParams.ez, m_localParams.lz,
-            opt.isModelOnNodes, opt.isElastic, m_localParams.origin_x,
-            m_localParams.origin_y, m_localParams.origin_z, -1.0f, -1.0f, -1.0f,
-            0.0f, 0.0f, 0.0f, opt.isAcoustoElastic,
-            opt.acoustoElasticBoundaryZ);
+            m_localParams.ex, m_localParams.lx, m_localParams.ey, m_localParams.ly, m_localParams.ez, m_localParams.lz,
+            opt.isModelOnNodes, opt.isElastic, m_localParams.origin_x, m_localParams.origin_y, m_localParams.origin_z,
+            -1.0f, -1.0f, -1.0f, 0.0f, 0.0f, 0.0f, opt.isAcoustoElastic, opt.acoustoElasticBoundaryZ);
         m_mesh = builder.getModel(opt.free_surface);
         break;
       }
       case 3: {
         model::CartesianStructBuilder<float, int, 3> builder(
-            m_localParams.ex, m_localParams.lx, m_localParams.ey,
-            m_localParams.ly, m_localParams.ez, m_localParams.lz,
-            opt.isModelOnNodes, opt.isElastic, m_localParams.origin_x,
-            m_localParams.origin_y, m_localParams.origin_z, -1.0f, -1.0f, -1.0f,
-            0.0f, 0.0f, 0.0f, opt.isAcoustoElastic,
-            opt.acoustoElasticBoundaryZ);
+            m_localParams.ex, m_localParams.lx, m_localParams.ey, m_localParams.ly, m_localParams.ez, m_localParams.lz,
+            opt.isModelOnNodes, opt.isElastic, m_localParams.origin_x, m_localParams.origin_y, m_localParams.origin_z,
+            -1.0f, -1.0f, -1.0f, 0.0f, 0.0f, 0.0f, opt.isAcoustoElastic, opt.acoustoElasticBoundaryZ);
         m_mesh = builder.getModel(opt.free_surface);
         break;
       }
       case 4: {
         model::CartesianStructBuilder<float, int, 4> builder(
-            m_localParams.ex, m_localParams.lx, m_localParams.ey,
-            m_localParams.ly, m_localParams.ez, m_localParams.lz,
-            opt.isModelOnNodes, opt.isElastic, m_localParams.origin_x,
-            m_localParams.origin_y, m_localParams.origin_z, -1.0f, -1.0f, -1.0f,
-            0.0f, 0.0f, 0.0f, opt.isAcoustoElastic,
-            opt.acoustoElasticBoundaryZ);
+            m_localParams.ex, m_localParams.lx, m_localParams.ey, m_localParams.ly, m_localParams.ez, m_localParams.lz,
+            opt.isModelOnNodes, opt.isElastic, m_localParams.origin_x, m_localParams.origin_y, m_localParams.origin_z,
+            -1.0f, -1.0f, -1.0f, 0.0f, 0.0f, 0.0f, opt.isAcoustoElastic, opt.acoustoElasticBoundaryZ);
         m_mesh = builder.getModel(opt.free_surface);
         break;
       }
       case 5: {
         model::CartesianStructBuilder<float, int, 5> builder(
-            m_localParams.ex, m_localParams.lx, m_localParams.ey,
-            m_localParams.ly, m_localParams.ez, m_localParams.lz,
-            opt.isModelOnNodes, opt.isElastic, m_localParams.origin_x,
-            m_localParams.origin_y, m_localParams.origin_z, -1.0f, -1.0f, -1.0f,
-            0.0f, 0.0f, 0.0f, opt.isAcoustoElastic,
-            opt.acoustoElasticBoundaryZ);
+            m_localParams.ex, m_localParams.lx, m_localParams.ey, m_localParams.ly, m_localParams.ez, m_localParams.lz,
+            opt.isModelOnNodes, opt.isElastic, m_localParams.origin_x, m_localParams.origin_y, m_localParams.origin_z,
+            -1.0f, -1.0f, -1.0f, 0.0f, 0.0f, 0.0f, opt.isAcoustoElastic, opt.acoustoElasticBoundaryZ);
         m_mesh = builder.getModel(opt.free_surface);
         break;
       }
       default:
-        throw std::runtime_error(
-            "Order other than 1 2 3 is not supported (semproxy)");
+        throw std::runtime_error("Order other than 1 2 3 is not supported (semproxy)");
     }
-  }
-  else if (meshType == meshType::kUnstruct)
-  {
+  } else if (meshType == meshType::kUnstruct) {
     // Pass local params to unstructured builder (handles origin internally)
     model::CartesianUnstructBuilder<float, int> builder(m_localParams);
     m_mesh = builder.getModel(opt.free_surface);
-  }
-  else
-  {
+  } else {
     throw std::runtime_error("Incorrect mesh type (SEMproxy ctor.)");
   }
 }
 
-void SEMproxy::init_topology()
-{
-  par_topology_ =
-      TopologyFactory::createFromMesh(*m_mesh, dist_ctx_.rank, dist_ctx_.size,
-                                      m_localParams.origin_x, m_localParams.lx);
+void SEMproxy::init_topology() {
+  par_topology_ = TopologyFactory::createFromMesh(*m_mesh, dist_ctx_.rank, dist_ctx_.size, m_localParams.origin_x,
+                                                  m_localParams.lx);
 }
 
-void SEMproxy::init_sync()
-{
+void SEMproxy::init_sync() {
 #if USE_MPI
-  if (dist_ctx_.size > 1)
-  {
-    m_syncer = std::make_unique<BoundarySynchronizer>(
-        std::make_unique<solver::fe::MPIBackend>());
+  if (dist_ctx_.size > 1) {
+    m_syncer = std::make_unique<BoundarySynchronizer>(std::make_unique<solver::fe::MPIBackend>());
 
-    if (dist_ctx_.rank == 0)
-    {
-      std::cout << "MPI Enabled: Using MPIBackend for " << dist_ctx_.size
-                << " ranks." << std::endl;
+    if (dist_ctx_.rank == 0) {
+      std::cout << "MPI Enabled: Using MPIBackend for " << dist_ctx_.size << " ranks." << std::endl;
     }
-  }
-  else
-  {
+  } else {
     // Fallback for serial
-    m_syncer = std::make_unique<BoundarySynchronizer>(
-        std::make_unique<SerialBackend>());
+    m_syncer = std::make_unique<BoundarySynchronizer>(std::make_unique<SerialBackend>());
   }
 #else
-  m_syncer =
-      std::make_unique<BoundarySynchronizer>(std::make_unique<SerialBackend>());
+  m_syncer = std::make_unique<BoundarySynchronizer>(std::make_unique<SerialBackend>());
 #endif
 }
 
-void SEMproxy::init_time_params(const SemProxyOptions& opt)
-{
-  if (opt.autodt)
-  {
+void SEMproxy::init_time_params(const SemProxyOptions& opt) {
+  if (opt.autodt) {
     float cfl_factor = (opt.order == 2) ? 0.5 : 0.7;
     dt_ = find_cfl_dt(cfl_factor);
-  }
-  else
-  {
+  } else {
     dt_ = opt.dt;
   }
   timemax_ = opt.timemax;
   num_sample_ = timemax_ / dt_;
 }
 
-void SEMproxy::display_init_msg(const SemProxyOptions& opt)
-{
+void SEMproxy::display_init_msg(const SemProxyOptions& opt) {
   std::cout << "Number of node is " << m_mesh->getNumberOfNodes() << std::endl;
-  std::cout << "Number of element is " << m_mesh->getNumberOfElements()
-            << std::endl;
-  std::cout << "Launching the Method " << opt.method << ", the implementation "
-            << opt.implem << " and the mesh is " << opt.mesh << std::endl;
-  std::cout << "Model is on " << (opt.isModelOnNodes ? "nodes" : "elements")
-            << std::endl;
-  std::cout << "Physics type is " << (opt.isElastic ? "elastic" : "acoustic")
-            << std::endl;
+  std::cout << "Number of element is " << m_mesh->getNumberOfElements() << std::endl;
+  std::cout << "Launching the Method " << opt.method << ", the implementation " << opt.implem << " and the mesh is "
+            << opt.mesh << std::endl;
+  std::cout << "Model is on " << (opt.isModelOnNodes ? "nodes" : "elements") << std::endl;
+  std::cout << "Physics type is " << (opt.isElastic ? "elastic" : "acoustic") << std::endl;
   std::cout << "Order of approximation will be " << opt.order << std::endl;
   std::cout << "Time step is " << dt_ << "s" << std::endl;
   std::cout << "Simulated time is " << timemax_ << "s" << std::endl;
 
-  if (is_snapshots_)
-  {
-    std::cout << "Snapshots enable every " << snap_time_interval_
-              << " iteration." << std::endl;
+  if (is_snapshots_) {
+    std::cout << "Snapshots enable every " << snap_time_interval_ << " iteration." << std::endl;
   }
 }

--- a/src/model/grid/include/fd_boundary.h
+++ b/src/model/grid/include/fd_boundary.h
@@ -4,10 +4,8 @@
  */
 #ifndef FUNTIDES_MODEL_GRID_INCLUDE_FD_BOUNDARY_H_
 #define FUNTIDES_MODEL_GRID_INCLUDE_FD_BOUNDARY_H_
-namespace model
-{
-namespace fdgrid
-{
+namespace model {
+namespace fdgrid {
 
 /**
  * @brief Absorbing boundary layer configuration
@@ -16,8 +14,7 @@ namespace fdgrid
  * Stores the geometry of absorbing regions around the computational domain
  * to prevent artificial reflections from domain edges.
  */
-class BoundaryLayers
-{
+class BoundaryLayers {
  public:
   BoundaryLayers() = default;
 
@@ -25,28 +22,23 @@ class BoundaryLayers
    * @brief Configure boundary layers from options
    * @param opt Configuration containing boundary parameters
    */
-  void Initialize(const fdtd::options::FdtdOptions& opt)
-  {
+  void Initialize(const fdtd::options::FdtdOptions& opt) {
     // TODO: Extract from opt.boundary or similar
     // For now, set to reasonable defaults
-    float lambdamax_ = opt.velocity.vmin /
-                       (2.5 * opt.source.f0);  // Maximum wavelength in model
+    float lambdamax_ = opt.velocity.vmin / (2.5 * opt.source.f0);  // Maximum wavelength in model
     ntaperx_ = ntapery_ = ntaperz_ = opt.boundary.pml_size;
-    if (opt.boundary.use_pml)
-    {
+    if (opt.boundary.use_pml) {
       ndampx_ = ntaperx_ * lambdamax_ / opt.grid.dx;
       ndampy_ = ntapery_ * lambdamax_ / opt.grid.dy;
       ndampz_ = ntaperz_ * lambdamax_ / opt.grid.dz;
     }
-    if (opt.boundary.use_sponge)
-    {
+    if (opt.boundary.use_sponge) {
       ndampx_ = 0;
       ndampy_ = 0;
       ndampz_ = 0;
     }
 
-    ComputeBoundaryRegions(opt.boundary.use_sponge, opt.boundary.use_pml,
-                           opt.grid.nx, opt.grid.ny, opt.grid.nz);
+    ComputeBoundaryRegions(opt.boundary.use_sponge, opt.boundary.use_pml, opt.grid.nx, opt.grid.ny, opt.grid.nz);
   }
 
   /**
@@ -55,8 +47,7 @@ class BoundaryLayers
    * @param ny Grid size Y
    * @param nz Grid size Z
    */
-  void ComputeBoundaryRegions(bool sponge, bool pml, int nx, int ny, int nz)
-  {
+  void ComputeBoundaryRegions(bool sponge, bool pml, int nx, int ny, int nz) {
     // Example: divide domain into 6 regions per axis
     // x1-x2: left boundary, x3-x4: interior, x5-x6: right boundary
     x1_ = 0;

--- a/src/model/grid/include/fd_grid_geometry.h
+++ b/src/model/grid/include/fd_grid_geometry.h
@@ -8,10 +8,8 @@
 
 #include <cstddef>
 
-namespace model
-{
-namespace fdgrid
-{
+namespace model {
+namespace fdgrid {
 
 /**
  * @brief 3D grid geometry and spatial discretization
@@ -27,8 +25,7 @@ namespace fdgrid
  *
  * **Thread-safe:** All operations are const after construction
  */
-class GridGeometry
-{
+class GridGeometry {
  public:
   GridGeometry() = default;
 
@@ -42,8 +39,7 @@ class GridGeometry
    * @param dz Spatial sampling in Z (meters)
    */
   GridGeometry(int nx, int ny, int nz, float dx, float dy, float dz)
-      : nx_(nx), ny_(ny), nz_(nz), dx_(dx), dy_(dy), dz_(dz)
-  {
+      : nx_(nx), ny_(ny), nz_(nz), dx_(dx), dy_(dy), dz_(dz) {
     ComputeDerivativeCoefficients();
   }
 
@@ -52,10 +48,7 @@ class GridGeometry
    * @param opt Configuration options
    */
   explicit GridGeometry(const fdtd::options::FdtdOptions& opt)
-      : GridGeometry(opt.grid.nx, opt.grid.ny, opt.grid.nz, opt.grid.dx,
-                     opt.grid.dy, opt.grid.dz)
-  {
-  }
+      : GridGeometry(opt.grid.nx, opt.grid.ny, opt.grid.nz, opt.grid.dx, opt.grid.dy, opt.grid.dz) {}
 
   /**
    * @brief Convert 3D grid coordinates to linear array index
@@ -64,8 +57,7 @@ class GridGeometry
    * @param k Z-direction index [0, nz-1]
    * @return Linear index for column-major storage
    */
-  [[nodiscard]] size_t Index3D(int i, int j, int k) const noexcept
-  {
+  [[nodiscard]] size_t Index3D(int i, int j, int k) const noexcept {
     return static_cast<size_t>(nz_) * ny_ * i + nz_ * j + k;
   }
 
@@ -73,10 +65,7 @@ class GridGeometry
    * @brief Get total number of grid points
    * @return nx * ny * nz
    */
-  [[nodiscard]] size_t TotalPoints() const noexcept
-  {
-    return static_cast<size_t>(nx_) * ny_ * nz_;
-  }
+  [[nodiscard]] size_t TotalPoints() const noexcept { return static_cast<size_t>(nx_) * ny_ * nz_; }
 
   /**
    * @brief Check if indices are within grid bounds
@@ -85,8 +74,7 @@ class GridGeometry
    * @param k Z index
    * @return true if all indices are valid
    */
-  [[nodiscard]] bool IsValidIndex(int i, int j, int k) const noexcept
-  {
+  [[nodiscard]] bool IsValidIndex(int i, int j, int k) const noexcept {
     return i >= 0 && i < nx_ && j >= 0 && j < ny_ && k >= 0 && k < nz_;
   }
 
@@ -102,8 +90,7 @@ class GridGeometry
   [[nodiscard]] float hdz_2() const noexcept { return hdz_2_; }
 
  private:
-  void ComputeDerivativeCoefficients()
-  {
+  void ComputeDerivativeCoefficients() {
     hdx_2_ = 1.0f / (4.0f * dx_ * dx_);
     hdy_2_ = 1.0f / (4.0f * dy_ * dy_);
     hdz_2_ = 1.0f / (4.0f * dz_ * dz_);

--- a/src/model/grid/include/fd_grids.h
+++ b/src/model/grid/include/fd_grids.h
@@ -11,10 +11,8 @@
 #include "fd_model_io.h"
 #include "fd_velocity_model.h"
 
-namespace model
-{
-namespace fdgrid
-{
+namespace model {
+namespace fdgrid {
 
 /**
  * @brief FDTD grid facade maintaining backward compatibility
@@ -30,8 +28,7 @@ namespace fdgrid
  * Existing code continues to work unchanged. New code should use
  * the individual components directly for better encapsulation.
  */
-class FdtdGrids
-{
+class FdtdGrids {
  public:
   FdtdGrids() = default;
 
@@ -39,15 +36,11 @@ class FdtdGrids
    * @brief Initialize grid geometry (backward compatible)
    * @param opt FDTD configuration options
    */
-  void InitGrid(const fdtd::options::FdtdOptions& opt)
-  {
+  void InitGrid(const fdtd::options::FdtdOptions& opt) {
     // Load geometry from file if specified
-    if (!opt.velocity.file_model.empty())
-    {
+    if (!opt.velocity.file_model.empty()) {
       geom_ = ModelIO::ReadGeometry(opt.velocity.file_model);
-    }
-    else
-    {
+    } else {
       geom_ = GridGeometry(opt);
     }
 
@@ -59,8 +52,7 @@ class FdtdGrids
    * @brief Initialize model arrays (backward compatible)
    * @param opt FDTD configuration options
    */
-  void InitModelArrays(const fdtd::options::FdtdOptions& opt)
-  {
+  void InitModelArrays(const fdtd::options::FdtdOptions& opt) {
     constexpr float kTimeStep = 0.001f;  // TODO: Make configurable
     model_ = std::make_unique<VelocityModel>(geom_);
     model_->Initialize(opt, kTimeStep);
@@ -70,9 +62,7 @@ class FdtdGrids
    * @brief Legacy method - no longer used
    * @deprecated Use ModelIO::ReadGeometry() instead
    */
-  void LoadModelInfo(int& nx, int& ny, int& nz, float& dx, float& dy, float& dz,
-                     const std::string& file_model)
-  {
+  void LoadModelInfo(int& nx, int& ny, int& nz, float& dx, float& dy, float& dz, const std::string& file_model) {
     if (file_model.empty()) return;
     auto geom = ModelIO::ReadGeometry(file_model);
     nx = geom.nx();
@@ -87,10 +77,8 @@ class FdtdGrids
    * @brief Legacy method - use VelocityModel::Initialize() instead
    * @deprecated
    */
-  void InitModel(float init_vp_value, bool from_file = false)
-  {
-    if (from_file)
-    {
+  void InitModel(float init_vp_value, bool from_file = false) {
+    if (from_file) {
       throw std::logic_error("File loading not supported in legacy method");
     }
     model_->InitializeSyntheticModel(init_vp_value);
@@ -146,10 +134,7 @@ class FdtdGrids
 
   // Direct access to components for new code
   [[nodiscard]] const GridGeometry& geometry() const noexcept { return geom_; }
-  [[nodiscard]] const BoundaryLayers& boundary() const noexcept
-  {
-    return boundary_;
-  }
+  [[nodiscard]] const BoundaryLayers& boundary() const noexcept { return boundary_; }
   [[nodiscard]] const VelocityModel& model() const noexcept { return *model_; }
   [[nodiscard]] VelocityModel& model() noexcept { return *model_; }
 

--- a/src/model/grid/include/fd_model_io.h
+++ b/src/model/grid/include/fd_model_io.h
@@ -12,40 +12,27 @@
 
 #include "fd_grid_geometry.h"
 
-namespace model
-{
-namespace fdgrid
-{
+namespace model {
+namespace fdgrid {
 
 /**
  * @brief Type traits for detecting container capabilities
  */
-namespace detail
-{
+namespace detail {
 
 // Check if type has resize() method (std::vector)
 template <typename T, typename = void>
-struct has_resize : std::false_type
-{
-};
+struct has_resize : std::false_type {};
 
 template <typename T>
-struct has_resize<T, std::void_t<decltype(std::declval<T>().resize(size_t{}))>>
-    : std::true_type
-{
-};
+struct has_resize<T, std::void_t<decltype(std::declval<T>().resize(size_t{}))>> : std::true_type {};
 
 // Check if type has data() method
 template <typename T, typename = void>
-struct has_data : std::false_type
-{
-};
+struct has_data : std::false_type {};
 
 template <typename T>
-struct has_data<T, std::void_t<decltype(std::declval<T>().data())>>
-    : std::true_type
-{
-};
+struct has_data<T, std::void_t<decltype(std::declval<T>().data())>> : std::true_type {};
 
 }  // namespace detail
 
@@ -59,8 +46,7 @@ struct has_data<T, std::void_t<decltype(std::declval<T>().data())>>
  * - Header: 6 values (3 ints: nx,ny,nz; 3 floats: dx,dy,dz)
  * - Data: nx*ny*nz floats (velocity values)
  */
-class ModelIO
-{
+class ModelIO {
  public:
   /**
    * @brief Read grid geometry from model file
@@ -68,11 +54,9 @@ class ModelIO
    * @return GridGeometry object with dimensions and spacing
    * @throws std::runtime_error if file cannot be read
    */
-  static GridGeometry ReadGeometry(const std::string& file_path)
-  {
+  static GridGeometry ReadGeometry(const std::string& file_path) {
     std::ifstream infile(file_path, std::ios::in | std::ios::binary);
-    if (!infile)
-    {
+    if (!infile) {
       throw std::runtime_error("Cannot open model file: " + file_path);
     }
 
@@ -86,13 +70,11 @@ class ModelIO
     infile.read(reinterpret_cast<char*>(&dy), sizeof(float));
     infile.read(reinterpret_cast<char*>(&dz), sizeof(float));
 
-    if (!infile)
-    {
+    if (!infile) {
       throw std::runtime_error("Corrupted model file header: " + file_path);
     }
 
-    printf("Loaded geometry from %s: %dx%dx%d, spacing %.3fx%.3fx%.3f m\n",
-           file_path.c_str(), nx, ny, nz, dx, dy, dz);
+    printf("Loaded geometry from %s: %dx%dx%d, spacing %.3fx%.3fx%.3f m\n", file_path.c_str(), nx, ny, nz, dx, dy, dz);
 
     return GridGeometry(nx, ny, nz, dx, dy, dz);
   }
@@ -109,12 +91,9 @@ class ModelIO
    * @throws std::runtime_error if read fails or size mismatch
    */
   template <typename VectorType>
-  static void ReadVelocityModel(const std::string& file_path,
-                                const GridGeometry& geom, VectorType& data)
-  {
+  static void ReadVelocityModel(const std::string& file_path, const GridGeometry& geom, VectorType& data) {
     std::ifstream infile(file_path, std::ios::in | std::ios::binary);
-    if (!infile)
-    {
+    if (!infile) {
       throw std::runtime_error("Cannot open model file: " + file_path);
     }
 
@@ -124,37 +103,28 @@ class ModelIO
     size_t expected_size = geom.TotalPoints();
 
     // Resize if container supports it (std::vector)
-    if constexpr (detail::has_resize<VectorType>::value)
-    {
+    if constexpr (detail::has_resize<VectorType>::value) {
       data.resize(expected_size);
-    }
-    else
-    {
+    } else {
       // For Kokkos::View, check size matches
-      if (data.extent(0) != expected_size)
-      {
-        throw std::runtime_error("Kokkos::View size mismatch: expected " +
-                                 std::to_string(expected_size) + ", got " +
-                                 std::to_string(data.extent(0)) +
-                                 ". Pre-allocate view with correct size.");
+      if (data.extent(0) != expected_size) {
+        throw std::runtime_error("Kokkos::View size mismatch: expected " + std::to_string(expected_size) + ", got " +
+                                 std::to_string(data.extent(0)) + ". Pre-allocate view with correct size.");
       }
     }
 
     // Read into temporary buffer for Kokkos (host -> device transfer)
     std::vector<float> temp_buffer(expected_size);
-    infile.read(reinterpret_cast<char*>(temp_buffer.data()),
-                expected_size * sizeof(float));
+    infile.read(reinterpret_cast<char*>(temp_buffer.data()), expected_size * sizeof(float));
 
-    if (!infile)
-    {
+    if (!infile) {
       throw std::runtime_error("Failed to read velocity data: " + file_path);
     }
 
     // Copy to output (handles both std::vector and Kokkos::View)
     CopyData(temp_buffer, data, expected_size);
 
-    printf("Loaded %zu velocity values from %s\n", expected_size,
-           file_path.c_str());
+    printf("Loaded %zu velocity values from %s\n", expected_size, file_path.c_str());
   }
 
   /**
@@ -165,13 +135,9 @@ class ModelIO
    * @throws std::runtime_error if write fails
    */
   template <typename VectorType>
-  static void WriteVelocityModel(const std::string& file_path,
-                                 const GridGeometry& geom,
-                                 const VectorType& data)
-  {
+  static void WriteVelocityModel(const std::string& file_path, const GridGeometry& geom, const VectorType& data) {
     std::ofstream outfile(file_path, std::ios::out | std::ios::binary);
-    if (!outfile)
-    {
+    if (!outfile) {
       throw std::runtime_error("Cannot create model file: " + file_path);
     }
 
@@ -190,11 +156,9 @@ class ModelIO
     const float* write_ptr = GetDataPointer(data, temp_buffer);
 
     // Write data
-    outfile.write(reinterpret_cast<const char*>(write_ptr),
-                  data.extent(0) * sizeof(float));
+    outfile.write(reinterpret_cast<const char*>(write_ptr), data.extent(0) * sizeof(float));
 
-    if (!outfile)
-    {
+    if (!outfile) {
       throw std::runtime_error("Failed to write model file: " + file_path);
     }
 
@@ -207,18 +171,13 @@ class ModelIO
    * types)
    */
   template <typename SourceType, typename DestType>
-  static void CopyData(const SourceType& src, DestType& dest, size_t size)
-  {
+  static void CopyData(const SourceType& src, DestType& dest, size_t size) {
     // Direct copy for std::vector or containers with direct data access
-    if constexpr (detail::has_data<DestType>::value)
-    {
+    if constexpr (detail::has_data<DestType>::value) {
       std::copy(src.begin(), src.begin() + size, dest.data());
-    }
-    else
-    {
+    } else {
       // Element-wise copy for Kokkos::View (triggers host->device transfer)
-      for (size_t i = 0; i < size; ++i)
-      {
+      for (size_t i = 0; i < size; ++i) {
         dest(i) = src[i];
       }
     }
@@ -229,20 +188,14 @@ class ModelIO
    * needed
    */
   template <typename VectorType>
-  static const float* GetDataPointer(const VectorType& data,
-                                     std::vector<float>& temp_buffer)
-  {
-    if constexpr (detail::has_data<VectorType>::value)
-    {
+  static const float* GetDataPointer(const VectorType& data, std::vector<float>& temp_buffer) {
+    if constexpr (detail::has_data<VectorType>::value) {
       // std::vector or similar - direct access
       return data.data();
-    }
-    else
-    {
+    } else {
       // Kokkos::View - copy to host buffer first
       temp_buffer.resize(data.extent(0));
-      for (size_t i = 0; i < data.extent(0); ++i)
-      {
+      for (size_t i = 0; i < data.extent(0); ++i) {
         temp_buffer[i] = data(i);
       }
       return temp_buffer.data();

--- a/src/model/grid/include/fd_velocity_model.h
+++ b/src/model/grid/include/fd_velocity_model.h
@@ -10,10 +10,8 @@
 #include "fd_grid_geometry.h"
 // #include "fdtd_macros.h"
 
-namespace model
-{
-namespace fdgrid
-{
+namespace model {
+namespace fdgrid {
 
 /**
  * @brief Velocity model storage and initialization
@@ -21,8 +19,7 @@ namespace fdgrid
  * Manages P-wave and S-wave velocity fields and density.
  * Supports both synthetic model generation and file-based loading.
  */
-class VelocityModel
-{
+class VelocityModel {
  public:
   explicit VelocityModel(const GridGeometry& geom) : geom_(geom) {}
 
@@ -32,30 +29,21 @@ class VelocityModel
    * @param time_step Time step for wave equation (dt)
    * @throws std::runtime_error if allocation fails
    */
-  void Initialize(const fdtd::options::FdtdOptions& opt, float time_step)
-  {
+  void Initialize(const fdtd::options::FdtdOptions& opt, float time_step) {
     size_t model_volume = geom_.TotalPoints();
 
-    try
-    {
+    try {
       vp_ = allocateVector<vectorReal>(model_volume, "vp");
-    }
-    catch (const std::exception& e)
-    {
-      throw std::runtime_error("Failed to allocate velocity model: " +
-                               std::string(e.what()));
+    } catch (const std::exception& e) {
+      throw std::runtime_error("Failed to allocate velocity model: " + std::string(e.what()));
     }
 
     // Initialize with scaled velocity for wave equation
-    float init_vp_value =
-        opt.velocity.vmin * opt.velocity.vmin * time_step * time_step;
+    float init_vp_value = opt.velocity.vmin * opt.velocity.vmin * time_step * time_step;
 
-    if (opt.velocity.use_file_model && !opt.velocity.file_model.empty())
-    {
+    if (opt.velocity.use_file_model && !opt.velocity.file_model.empty()) {
       LoadFromFile(opt.velocity.file_model);
-    }
-    else
-    {
+    } else {
       InitializeSyntheticModel(init_vp_value);
     }
   }
@@ -64,19 +52,15 @@ class VelocityModel
    * @brief Create two-layer synthetic model for testing
    * @param init_vp_value Base velocity (v² * dt²)
    */
-  void InitializeSyntheticModel(float init_vp_value)
-  {
+  void InitializeSyntheticModel(float init_vp_value) {
     const int nx = geom_.nx();
     const int ny = geom_.ny();
     const int nz = geom_.nz();
 
     // Layer 1: Entire volume
-    for (int i = 0; i < nx; i++)
-    {
-      for (int j = 0; j < ny; j++)
-      {
-        for (int k = 0; k < nz; k++)
-        {
+    for (int i = 0; i < nx; i++) {
+      for (int j = 0; j < ny; j++) {
+        for (int k = 0; k < nz; k++) {
           vp_[geom_.Index3D(i, j, k)] = init_vp_value;
         }
       }
@@ -85,12 +69,9 @@ class VelocityModel
     // Layer 2: Lower half with doubled velocity
     constexpr float kVelocityRatio = 2.0f;
     const float layer2_vp = kVelocityRatio * init_vp_value;
-    for (int i = 0; i < nx; i++)
-    {
-      for (int j = 0; j < ny; j++)
-      {
-        for (int k = nz / 2; k < nz; k++)
-        {
+    for (int i = 0; i < nx; i++) {
+      for (int j = 0; j < ny; j++) {
+        for (int k = nz / 2; k < nz; k++) {
           vp_[geom_.Index3D(i, j, k)] = layer2_vp;
         }
       }
@@ -104,10 +85,7 @@ class VelocityModel
    * @param file_path Path to model file
    * @throws std::runtime_error if loading fails
    */
-  void LoadFromFile(const std::string& file_path)
-  {
-    ModelIO::ReadVelocityModel(file_path, geom_, vp_);
-  }
+  void LoadFromFile(const std::string& file_path) { ModelIO::ReadVelocityModel(file_path, geom_, vp_); }
 
   // Accessors
   [[nodiscard]] const vectorReal& vp() const noexcept { return vp_; }

--- a/src/model/mesh/api/include/builder.h
+++ b/src/model/mesh/api/include/builder.h
@@ -7,11 +7,9 @@
 
 #include <memory>
 
-namespace model
-{
+namespace model {
 template <typename FloatType, typename ScalarType>
-class ModelBuilderBase
-{
+class ModelBuilderBase {
  public:
   ModelBuilderBase() = default;
   ~ModelBuilderBase() = default;
@@ -24,8 +22,7 @@ class ModelBuilderBase
    * use damping on the top boundary.
    * @return A shared pointer to the model instance.
    */
-  virtual std::shared_ptr<model::ModelApi<FloatType, ScalarType>> getModel(
-      bool free_surface_on_top) const = 0;
+  virtual std::shared_ptr<model::ModelApi<FloatType, ScalarType>> getModel(bool free_surface_on_top) const = 0;
 };
 }  // namespace model
 

--- a/src/model/mesh/api/include/face_connectivity.h
+++ b/src/model/mesh/api/include/face_connectivity.h
@@ -2,16 +2,14 @@
 #define FUNTIDES_MODEL_MESH_API_INCLUDE_FACE_CONNECTIVITY_H_
 #include "model.h"
 
-namespace model
-{
+namespace model {
 
 /**
  * @brief Abstract interface for face connectivity
  *
  */
 template <typename FloatType, typename ScalarType>
-class FaceConnectivityApi
-{
+class FaceConnectivityApi {
  public:
   PROXY_HOST_DEVICE FaceConnectivityApi() = default;
   PROXY_HOST_DEVICE virtual ~FaceConnectivityApi() = default;
@@ -32,8 +30,7 @@ class FaceConnectivityApi
    * @param local_face Local face identifier
    * @return Global face ID
    */
-  PROXY_HOST_DEVICE virtual ScalarType getGlobalFace(
-      ScalarType elem, CubicFace local_face) const = 0;
+  PROXY_HOST_DEVICE virtual ScalarType getGlobalFace(ScalarType elem, CubicFace local_face) const = 0;
 
   /**
    * @brief Get global node index from face and local DOF
@@ -41,8 +38,7 @@ class FaceConnectivityApi
    * @param local_dof Local DOF index on face [0, (order+1)²)
    * @return Global node index
    */
-  PROXY_HOST_DEVICE virtual ScalarType getGlobalNodeFromFace(
-      ScalarType face_id, int local_dof) const = 0;
+  PROXY_HOST_DEVICE virtual ScalarType getGlobalNodeFromFace(ScalarType face_id, int local_dof) const = 0;
 
   /**
    * @brief Check if face is on domain boundary (no neighbor)
@@ -63,8 +59,7 @@ class FaceConnectivityApi
    * @param face_id Global face ID
    * @return Neighbor element index, or -1 if boundary
    */
-  PROXY_HOST_DEVICE virtual ScalarType elemNeighbor(
-      ScalarType face_id) const = 0;
+  PROXY_HOST_DEVICE virtual ScalarType elemNeighbor(ScalarType face_id) const = 0;
 
   /**
    * @brief Get local face index of the owner element

--- a/src/model/mesh/api/include/model.h
+++ b/src/model/mesh/api/include/model.h
@@ -8,8 +8,7 @@
  * @namespace model
  * @brief Namespace containing model and mesh representation classes
  */
-namespace model
-{
+namespace model {
 
 /**
  * @struct ModelDataBase
@@ -23,16 +22,14 @@ namespace model
  * @tparam ScalarType Integer type for indices (e.g., int, size_t)
  */
 template <typename FloatType, typename ScalarType>
-struct ModelDataBase
-{
+struct ModelDataBase {
   PROXY_HOST_DEVICE ModelDataBase() = default;
   PROXY_HOST_DEVICE ~ModelDataBase() = default;
   PROXY_HOST_DEVICE ModelDataBase(const ModelDataBase&) = default;
   PROXY_HOST_DEVICE ModelDataBase& operator=(const ModelDataBase&) = default;
 };
 
-enum BoundaryFlag : int
-{
+enum BoundaryFlag : int {
   InteriorNode = 0,  ///< Node inside the domain
   Damping = 1,       ///< Node in damping boundary zone
   Sponge = 2,        ///< Node in sponge layer
@@ -47,8 +44,7 @@ enum BoundaryFlag : int
  * Convention: even indices = minus faces, odd indices = plus faces.
  * Face normals point outward from the element.
  */
-enum class CubicFace : int
-{
+enum class CubicFace : int {
   kXMinus = 0,  ///< Face at x = x_min (left face, normal = [-1, 0, 0])
   kXPlus = 1,   ///< Face at x = x_max (right face, normal = [+1, 0, 0])
   kYMinus = 2,  ///< Face at y = y_min (front face, normal = [0, -1, 0])
@@ -62,8 +58,7 @@ enum class CubicFace : int
  * @brief Flags representing the anisotropy type of the medium at a mesh node or
  * element.
  */
-enum AnisotropyType : uint8_t
-{
+enum AnisotropyType : uint8_t {
   kIso = 0,       ///< Isotropic medium
   kVTI = 1 << 0,  ///< Vertically Transverse Isotropic medium
   kTTI = 1 << 1   ///< Tilted Transverse Isotropic medium
@@ -73,8 +68,7 @@ enum AnisotropyType : uint8_t
  * @brief Abstract base class representing a structured 3D mesh.
  */
 template <typename FloatType, typename ScalarType>
-class ModelApi
-{
+class ModelApi {
  public:
   PROXY_HOST_DEVICE ModelApi() = default;
 
@@ -82,9 +76,7 @@ class ModelApi
    * @brief Construct ModelApi from model data
    * @param data Model-specific data structure
    */
-  PROXY_HOST_DEVICE ModelApi(const ModelDataBase<ScalarType, FloatType>& data)
-  {
-  }
+  PROXY_HOST_DEVICE ModelApi(const ModelDataBase<ScalarType, FloatType>& data) {}
 
   PROXY_HOST_DEVICE ModelApi(const ModelApi&) = default;
   PROXY_HOST_DEVICE ModelApi& operator=(const ModelApi&) = default;
@@ -108,8 +100,7 @@ class ModelApi
    * @return Global node index
    */
   PROXY_HOST_DEVICE
-  virtual ScalarType globalNodeIndex(ScalarType e, int i, int j,
-                                     int k) const = 0;
+  virtual ScalarType globalNodeIndex(ScalarType e, int i, int j, int k) const = 0;
 
   /**
    * @brief Get the boundary type of a given node.
@@ -131,24 +122,21 @@ class ModelApi
    * @param e Element index
    * @return P-wave velocity (Vp) in m/s
    */
-  PROXY_HOST_DEVICE virtual FloatType getModelVpOnElement(
-      ScalarType e) const = 0;
+  PROXY_HOST_DEVICE virtual FloatType getModelVpOnElement(ScalarType e) const = 0;
 
   /**
    * @brief Get density at a node
    * @param n Node index
    * @return Density (rho) in kg/m³
    */
-  PROXY_HOST_DEVICE virtual FloatType getModelRhoOnNodes(
-      ScalarType n) const = 0;
+  PROXY_HOST_DEVICE virtual FloatType getModelRhoOnNodes(ScalarType n) const = 0;
 
   /**
    * @brief Get density for an element
    * @param e Element index
    * @return Density (rho) in kg/m³
    */
-  PROXY_HOST_DEVICE virtual FloatType getModelRhoOnElement(
-      ScalarType e) const = 0;
+  PROXY_HOST_DEVICE virtual FloatType getModelRhoOnElement(ScalarType e) const = 0;
 
   /**
    * @brief Get S-wave velocity at a node
@@ -162,8 +150,7 @@ class ModelApi
    * @param e Element index
    * @return S-wave velocity (Vs) in m/s
    */
-  PROXY_HOST_DEVICE virtual FloatType getModelVsOnElement(
-      ScalarType e) const = 0;
+  PROXY_HOST_DEVICE virtual FloatType getModelVsOnElement(ScalarType e) const = 0;
 
   /**
    * @brief Get P-wave quality factor at a node (attenuation)
@@ -177,8 +164,7 @@ class ModelApi
    * @param e Element index
    * @return Qp (dimensionless)
    */
-  PROXY_HOST_DEVICE virtual FloatType getModelQpOnElement(
-      ScalarType e) const = 0;
+  PROXY_HOST_DEVICE virtual FloatType getModelQpOnElement(ScalarType e) const = 0;
 
   /**
    * @brief Get S-wave quality factor at a node (attenuation)
@@ -192,88 +178,77 @@ class ModelApi
    * @param e Element index
    * @return Qs (dimensionless)
    */
-  PROXY_HOST_DEVICE virtual FloatType getModelQsOnElement(
-      ScalarType e) const = 0;
+  PROXY_HOST_DEVICE virtual FloatType getModelQsOnElement(ScalarType e) const = 0;
 
   /**
    * @brief Get Thomsen delta parameter at a node (anisotropy)
    * @param n Node index
    * @return Delta parameter (dimensionless)
    */
-  PROXY_HOST_DEVICE virtual FloatType getModelDeltaOnNodes(
-      ScalarType n) const = 0;
+  PROXY_HOST_DEVICE virtual FloatType getModelDeltaOnNodes(ScalarType n) const = 0;
 
   /**
    * @brief Get Thomsen delta parameter for an element (anisotropy)
    * @param e Element index
    * @return Delta parameter (dimensionless)
    */
-  PROXY_HOST_DEVICE virtual FloatType getModelDeltaOnElement(
-      ScalarType e) const = 0;
+  PROXY_HOST_DEVICE virtual FloatType getModelDeltaOnElement(ScalarType e) const = 0;
 
   /**
    * @brief Get Thomsen epsilon parameter at a node (anisotropy)
    * @param n Node index
    * @return Epsilon parameter (dimensionless)
    */
-  PROXY_HOST_DEVICE virtual FloatType getModelEpsilonOnNodes(
-      ScalarType n) const = 0;
+  PROXY_HOST_DEVICE virtual FloatType getModelEpsilonOnNodes(ScalarType n) const = 0;
 
   /**
    * @brief Get Thomsen epsilon parameter for an element (anisotropy)
    * @param e Element index
    * @return Epsilon parameter (dimensionless)
    */
-  PROXY_HOST_DEVICE virtual FloatType getModelEpsilonOnElement(
-      ScalarType e) const = 0;
+  PROXY_HOST_DEVICE virtual FloatType getModelEpsilonOnElement(ScalarType e) const = 0;
 
   /**
    * @brief Get Thomsen gamma parameter at a node (anisotropy)
    * @param n Node index
    * @return Gamma parameter (dimensionless)
    */
-  PROXY_HOST_DEVICE virtual FloatType getModelGammaOnNodes(
-      ScalarType n) const = 0;
+  PROXY_HOST_DEVICE virtual FloatType getModelGammaOnNodes(ScalarType n) const = 0;
 
   /**
    * @brief Get Thomsen gamma parameter for an element (anisotropy)
    * @param e Element index
    * @return Gamma parameter (dimensionless)
    */
-  PROXY_HOST_DEVICE virtual FloatType getModelGammaOnElement(
-      ScalarType e) const = 0;
+  PROXY_HOST_DEVICE virtual FloatType getModelGammaOnElement(ScalarType e) const = 0;
 
   /**
    * @brief Get theta angle at a node (anisotropy orientation)
    * @param n Node index
    * @return Theta angle in radians
    */
-  PROXY_HOST_DEVICE virtual ScalarType getModelThetaOnNodes(
-      ScalarType n) const = 0;
+  PROXY_HOST_DEVICE virtual ScalarType getModelThetaOnNodes(ScalarType n) const = 0;
 
   /**
    * @brief Get theta angle for an element (anisotropy orientation)
    * @param e Element index
    * @return Theta angle in radians
    */
-  PROXY_HOST_DEVICE virtual ScalarType getModelThetaOnElement(
-      ScalarType e) const = 0;
+  PROXY_HOST_DEVICE virtual ScalarType getModelThetaOnElement(ScalarType e) const = 0;
 
   /**
    * @brief Get phi angle at a node (anisotropy orientation)
    * @param n Node index
    * @return Phi angle in radians
    */
-  PROXY_HOST_DEVICE virtual ScalarType getModelPhiOnNodes(
-      ScalarType n) const = 0;
+  PROXY_HOST_DEVICE virtual ScalarType getModelPhiOnNodes(ScalarType n) const = 0;
 
   /**
    * @brief Get phi angle for an element (anisotropy orientation)
    * @param e Element index
    * @return Phi angle in radians
    */
-  PROXY_HOST_DEVICE virtual ScalarType getModelPhiOnElement(
-      ScalarType e) const = 0;
+  PROXY_HOST_DEVICE virtual ScalarType getModelPhiOnElement(ScalarType e) const = 0;
 
   /**
    * @brief Get the elasticity tensor for an element
@@ -281,8 +256,7 @@ class ModelApi
    * @param[out] CTTI 6x6 elasticity tensor in Voigt notation
    */
   PROXY_HOST_DEVICE
-  virtual void getCTensorOnElement(ScalarType e,
-                                   FloatType CTTI[6][6]) const = 0;
+  virtual void getCTensorOnElement(ScalarType e, FloatType CTTI[6][6]) const = 0;
 
   /**
    * @brief Initialize and compute elasticity tensors for all elements
@@ -323,8 +297,7 @@ class ModelApi
    * @param[out] v Output array (size 3) holding the normal vector [nx, ny, nz]
    */
   PROXY_HOST_DEVICE
-  virtual void faceNormal(ScalarType e, CubicFace face,
-                          FloatType v[3]) const = 0;
+  virtual void faceNormal(ScalarType e, CubicFace face, FloatType v[3]) const = 0;
 
   /**
    * @brief Get the domain size along a specific dimension
@@ -398,15 +371,13 @@ class ModelApi
    * @brief Get global face ID from element and local face
    */
   PROXY_HOST_DEVICE
-  virtual ScalarType getGlobalFace(ScalarType elem,
-                                   CubicFace local_face) const = 0;
+  virtual ScalarType getGlobalFace(ScalarType elem, CubicFace local_face) const = 0;
 
   /**
    * @brief Get global node index from face and local DOF
    */
   PROXY_HOST_DEVICE
-  virtual ScalarType getGlobalNodeFromFace(ScalarType face_global,
-                                           int local_dof) const = 0;
+  virtual ScalarType getGlobalNodeFromFace(ScalarType face_global, int local_dof) const = 0;
 };
 
 }  // namespace model

--- a/src/model/mesh/api/include/partitioning.h
+++ b/src/model/mesh/api/include/partitioning.h
@@ -2,8 +2,7 @@
 #define FUNTIDES_MODEL_MESH_API_INCLUDE_PARTITIONING_H_
 #include "cartesian_params.h"
 
-namespace model
-{
+namespace model {
 
 /** @brief Interface for domain decomposition strategy.
  * Responsible for determining local mesh parameters from global ones.
@@ -16,8 +15,7 @@ namespace model
  * CartesianParams, or a list of element IDs)
  */
 template <typename GlobalParams, typename LocalParams = GlobalParams>
-class PartitioningStrategy
-{
+class PartitioningStrategy {
  public:
   virtual ~PartitioningStrategy() = default;
 
@@ -39,8 +37,7 @@ class PartitioningStrategy
    * @throws std::invalid_argument if rank or
    * numRanks are invalid
    */
-  virtual LocalParams partition(const GlobalParams& globalParams, int rank,
-                                int numRanks) const = 0;
+  virtual LocalParams partition(const GlobalParams& globalParams, int rank, int numRanks) const = 0;
 };
 
 }  // namespace model

--- a/src/model/mesh/api/include/topology_factory.h
+++ b/src/model/mesh/api/include/topology_factory.h
@@ -16,8 +16,7 @@ using namespace utils;
  * Controls how TopologyFactory identifies boundary nodes by comparing
  * node coordinates to expected boundary locations.
  */
-struct TopologyTolerance
-{
+struct TopologyTolerance {
   double absolute = 1e-6;    //< Absolute tolerance for coordinate comparison
   bool auto_compute = true;  //< Auto-compute from element spacing if true
 };
@@ -46,8 +45,7 @@ struct TopologyTolerance
  * auto_compute=true for most cases, or provide a tolerance based on
  * element size.
  */
-class TopologyFactory
-{
+class TopologyFactory {
  public:
   /**
    * @brief Generates topology by inspecting mesh coordinates.
@@ -82,45 +80,32 @@ class TopologyFactory
    * For distributed execution, validates that all expected boundaries exist.
    */
   template <typename FloatType, typename ScalarType>
-  static ParallelTopology createFromMesh(
-      const model::ModelApi<FloatType, ScalarType>& mesh, int rank, int size,
-      FloatType origin_x, FloatType domain_width_x, TopologyTolerance tol = {})
-  {
+  static ParallelTopology createFromMesh(const model::ModelApi<FloatType, ScalarType>& mesh, int rank, int size,
+                                         FloatType origin_x, FloatType domain_width_x, TopologyTolerance tol = {}) {
     // Input validation
-    if (rank < 0 || rank >= size)
-    {
-      throw std::invalid_argument("Invalid rank " + std::to_string(rank) +
-                                  " for numRanks " + std::to_string(size));
+    if (rank < 0 || rank >= size) {
+      throw std::invalid_argument("Invalid rank " + std::to_string(rank) + " for numRanks " + std::to_string(size));
     }
-    if (domain_width_x <= 0)
-    {
-      throw std::invalid_argument(
-          "Invalid domain_width_x: " + std::to_string(domain_width_x) +
-          " (must be > 0)");
+    if (domain_width_x <= 0) {
+      throw std::invalid_argument("Invalid domain_width_x: " + std::to_string(domain_width_x) + " (must be > 0)");
     }
 
     ParallelTopology topo;
     topo.myRank = rank;
     topo.numRanks = size;
 
-    if (size <= 1)
-    {
+    if (size <= 1) {
       return topo;
     }
 
     // Auto-compute tolerance
-    if (tol.auto_compute)
-    {
-      try
-      {
+    if (tol.auto_compute) {
+      try {
         FloatType minDx = mesh.getMinSpacing();
-        if (minDx > 0)
-        {
+        if (minDx > 0) {
           tol.absolute = minDx * 1e-4;
         }
-      }
-      catch (...)
-      {
+      } catch (...) {
         tol.auto_compute = false;
       }
     }
@@ -133,39 +118,31 @@ class TopologyFactory
 
     ScalarType numNodes = mesh.getNumberOfNodes();
 
-    for (ScalarType i = 0; i < numNodes; ++i)
-    {
+    for (ScalarType i = 0; i < numNodes; ++i) {
       FloatType x = mesh.nodeCoord(i, 0);
 
       bool onLeft = hasLeft && (std::abs(x - left_x) < tol.absolute);
       bool onRight = hasRight && (std::abs(x - right_x) < tol.absolute);
 
-      if (onLeft && onRight)
-      {
+      if (onLeft && onRight) {
         throw std::logic_error("Topology Error: Node " + std::to_string(i) +
                                " detected on both left and right boundaries.");
       }
 
-      if (onLeft)
-      {
+      if (onLeft) {
         topo.sharedNodes[rank - 1].push_back(static_cast<int>(i));
       }
-      if (onRight)
-      {
+      if (onRight) {
         topo.sharedNodes[rank + 1].push_back(static_cast<int>(i));
       }
     }
 
     // Validation
-    if (hasLeft && topo.sharedNodes[rank - 1].empty())
-    {
-      throw std::logic_error("Topology Error: Rank " + std::to_string(rank) +
-                             " missing left boundary nodes.");
+    if (hasLeft && topo.sharedNodes[rank - 1].empty()) {
+      throw std::logic_error("Topology Error: Rank " + std::to_string(rank) + " missing left boundary nodes.");
     }
-    if (hasRight && topo.sharedNodes[rank + 1].empty())
-    {
-      throw std::logic_error("Topology Error: Rank " + std::to_string(rank) +
-                             " missing right boundary nodes.");
+    if (hasRight && topo.sharedNodes[rank + 1].empty()) {
+      throw std::logic_error("Topology Error: Rank " + std::to_string(rank) + " missing right boundary nodes.");
     }
 
     return topo;

--- a/src/model/mesh/impl/builder/cartesian/include/cartesian_params.h
+++ b/src/model/mesh/impl/builder/cartesian/include/cartesian_params.h
@@ -1,10 +1,8 @@
 #ifndef FUNTIDES_MODEL_MESH_IMPL_BUILDER_CARTESIAN_INCLUDE_CARTESIAN_PARAMS_H_
 #define FUNTIDES_MODEL_MESH_IMPL_BUILDER_CARTESIAN_INCLUDE_CARTESIAN_PARAMS_H_
-namespace model
-{
+namespace model {
 template <typename Coord, typename Index>
-struct CartesianParams
-{
+struct CartesianParams {
   int order;
   Index ex, ey, ez;
   Coord lx, ly, lz;
@@ -22,8 +20,8 @@ struct CartesianParams
 
   CartesianParams() = default;
 
-  CartesianParams(int order_, Index ex_, Index ey_, Index ez_, Coord lx_,
-                  Coord ly_, Coord lz_, bool isModelOnNodes_, bool isElastic_)
+  CartesianParams(int order_, Index ex_, Index ey_, Index ez_, Coord lx_, Coord ly_, Coord lz_, bool isModelOnNodes_,
+                  bool isElastic_)
       : order(order_),
         ex(ex_),
         ey(ey_),
@@ -32,9 +30,7 @@ struct CartesianParams
         ly(ly_),
         lz(lz_),
         isModelOnNodes(isModelOnNodes_),
-        isElastic(isElastic_)
-  {
-  }
+        isElastic(isElastic_) {}
 };
 }  // namespace model
 #endif  // FUNTIDES_MODEL_MESH_IMPL_BUILDER_CARTESIAN_INCLUDE_CARTESIAN_PARAMS_H_

--- a/src/model/mesh/impl/builder/cartesian/include/cartesian_partitioner.h
+++ b/src/model/mesh/impl/builder/cartesian/include/cartesian_partitioner.h
@@ -7,8 +7,7 @@
 #include "cartesian_params.h"
 #include "partitioning.h"
 
-namespace model
-{
+namespace model {
 
 /**
  * @brief 1D domain decomposition along X-axis.
@@ -36,9 +35,7 @@ namespace model
  * TopologyFactory can identify boundary nodes by comparing coordinates.
  */
 template <typename FloatType, typename ScalarType>
-class CartesianXPartitioner
-    : public PartitioningStrategy<CartesianParams<FloatType, ScalarType>>
-{
+class CartesianXPartitioner : public PartitioningStrategy<CartesianParams<FloatType, ScalarType>> {
  public:
   using Params = CartesianParams<FloatType, ScalarType>;
 
@@ -47,17 +44,13 @@ class CartesianXPartitioner
    * Matches the signature: LocalParams partition(const GlobalParams&, int, int)
    * const
    */
-  Params partition(const Params& global, int rank, int size) const override
-  {
+  Params partition(const Params& global, int rank, int size) const override {
     // Validation
-    if (size <= 0)
-    {
+    if (size <= 0) {
       throw std::invalid_argument("CartesianPartitioner: size must be > 0");
     }
-    if (rank < 0 || rank >= size)
-    {
-      throw std::invalid_argument(
-          "CartesianPartitioner: rank must be between 0 and size-1");
+    if (rank < 0 || rank >= size) {
+      throw std::invalid_argument("CartesianPartitioner: rank must be between 0 and size-1");
     }
 
     auto local = global;
@@ -70,8 +63,7 @@ class CartesianXPartitioner
     local.ex = base_ex + (rank < remainder ? 1 : 0);
 
     // Calculate Global Offset (in elements)
-    ScalarType element_offset_x =
-        rank * base_ex + std::min((ScalarType)rank, remainder);
+    ScalarType element_offset_x = rank * base_ex + std::min((ScalarType)rank, remainder);
 
     // Calculate Element Size
     FloatType dx = global.lx / global.ex;

--- a/src/model/mesh/impl/builder/cartesian/include/cartesian_struct_boundary_classifier.h
+++ b/src/model/mesh/impl/builder/cartesian/include/cartesian_struct_boundary_classifier.h
@@ -6,8 +6,7 @@
 
 #include <cmath>
 
-namespace model
-{
+namespace model {
 /**
  * @brief Classifies boundary flags for nodes of a structured Cartesian mesh.
  *
@@ -27,13 +26,10 @@ namespace model
  * @tparam ScalarType Integer type used to cast BoundaryFlag values
  */
 template <typename FloatType, typename ScalarType>
-class CartesianStructBoundaryClassifier
-{
+class CartesianStructBoundaryClassifier {
  public:
-  CartesianStructBoundaryClassifier(FloatType x_min, FloatType x_max,
-                                    FloatType y_min, FloatType y_max,
-                                    FloatType z_min, FloatType z_max,
-                                    FloatType tol, bool free_surface_on_top)
+  CartesianStructBoundaryClassifier(FloatType x_min, FloatType x_max, FloatType y_min, FloatType y_max, FloatType z_min,
+                                    FloatType z_max, FloatType tol, bool free_surface_on_top)
       : x_min_(x_min),
         x_max_(x_max),
         y_min_(y_min),
@@ -41,9 +37,7 @@ class CartesianStructBoundaryClassifier
         z_min_(z_min),
         z_max_(z_max),
         tol_(tol),
-        free_surface_on_top_(free_surface_on_top)
-  {
-  }
+        free_surface_on_top_(free_surface_on_top) {}
 
   /**
    * @brief Classify every node of the structured grid.
@@ -54,10 +48,8 @@ class CartesianStructBoundaryClassifier
    * @param lx, ly, lz  Local domain dimensions
    * @return VECTOR_INT_VIEW of size n_node with BoundaryFlag values
    */
-  VECTOR_INT_VIEW classify(int n_node, int nx, int ny, int nz, FloatType ox,
-                           FloatType oy, FloatType oz, FloatType lx,
-                           FloatType ly, FloatType lz) const
-  {
+  VECTOR_INT_VIEW classify(int n_node, int nx, int ny, int nz, FloatType ox, FloatType oy, FloatType oz, FloatType lx,
+                           FloatType ly, FloatType lz) const {
     const bool x_min_is_global = fabs(ox - x_min_) < tol_;
     const bool x_max_is_global = fabs((ox + lx) - x_max_) < tol_;
     const bool y_min_is_global = fabs(oy - y_min_) < tol_;
@@ -67,8 +59,7 @@ class CartesianStructBoundaryClassifier
 
     auto boundaries_t = allocateVector<VECTOR_INT_VIEW>(n_node, "boundaries_t");
 
-    for (int n = 0; n < n_node; ++n)
-    {
+    for (int n = 0; n < n_node; ++n) {
       const int i = n % nx;
       const int j = (n / nx) % ny;
       const int k = n / (nx * ny);
@@ -80,8 +71,7 @@ class CartesianStructBoundaryClassifier
       const bool at_zmin = z_min_is_global && (k == 0);
       const bool at_zmax = z_max_is_global && (k == nz - 1);
 
-      const bool on_boundary =
-          at_xmin || at_xmax || at_ymin || at_ymax || at_zmin || at_zmax;
+      const bool on_boundary = at_xmin || at_xmax || at_ymin || at_ymax || at_zmin || at_zmax;
 
       if (!on_boundary)
         boundaries_t(n) = static_cast<ScalarType>(BoundaryFlag::InteriorNode);

--- a/src/model/mesh/impl/builder/cartesian/include/cartesian_struct_builder.h
+++ b/src/model/mesh/impl/builder/cartesian/include/cartesian_struct_builder.h
@@ -8,20 +8,16 @@
 
 #include "cartesian_struct_boundary_classifier.h"
 
-namespace model
-{
+namespace model {
 template <typename FloatType, typename ScalarType, int Order>
-class CartesianStructBuilder : public ModelBuilderBase<FloatType, ScalarType>
-{
+class CartesianStructBuilder : public ModelBuilderBase<FloatType, ScalarType> {
  public:
-  CartesianStructBuilder(
-      ScalarType ex, FloatType lx, ScalarType ey, FloatType ly, ScalarType ez,
-      FloatType lz, bool isModelOnNodes, bool isElastic, FloatType ox = 0.0,
-      FloatType oy = 0.0, FloatType oz = 0.0, FloatType global_lx = -1.0,
-      FloatType global_ly = -1.0, FloatType global_lz = -1.0,
-      FloatType global_ox = 0.0, FloatType global_oy = 0.0,
-      FloatType global_oz = 0.0, bool isAcoustoElastic = false,
-      FloatType acoustoElasticBoundaryZ = static_cast<FloatType>(0))
+  CartesianStructBuilder(ScalarType ex, FloatType lx, ScalarType ey, FloatType ly, ScalarType ez, FloatType lz,
+                         bool isModelOnNodes, bool isElastic, FloatType ox = 0.0, FloatType oy = 0.0,
+                         FloatType oz = 0.0, FloatType global_lx = -1.0, FloatType global_ly = -1.0,
+                         FloatType global_lz = -1.0, FloatType global_ox = 0.0, FloatType global_oy = 0.0,
+                         FloatType global_oz = 0.0, bool isAcoustoElastic = false,
+                         FloatType acoustoElasticBoundaryZ = static_cast<FloatType>(0))
       : ex_(ex),
         ey_(ey),
         ez_(ez),
@@ -40,15 +36,11 @@ class CartesianStructBuilder : public ModelBuilderBase<FloatType, ScalarType>
         global_oy_(global_oy),
         global_oz_(global_oz),
         isAcoustoElastic_(isAcoustoElastic),
-        acoustoElasticBoundaryZ_(acoustoElasticBoundaryZ)
-  {
-  }
+        acoustoElasticBoundaryZ_(acoustoElasticBoundaryZ) {}
 
   ~CartesianStructBuilder() = default;
 
-  std::shared_ptr<model::ModelApi<FloatType, ScalarType>> getModel(
-      bool free_surface_on_top) const override
-  {
+  std::shared_ptr<model::ModelApi<FloatType, ScalarType>> getModel(bool free_surface_on_top) const override {
     model::ModelStructData<FloatType, ScalarType> data;
     data.ex_ = ex_;
     data.ey_ = ey_;
@@ -66,74 +58,46 @@ class CartesianStructBuilder : public ModelBuilderBase<FloatType, ScalarType>
     const int ny = static_cast<int>(ey_) * Order + 1;
     const int nz = static_cast<int>(ez_) * Order + 1;
     const int n_node = nx * ny * nz;
-    const FloatType tol = std::min({lx_ / ex_, ly_ / ey_, lz_ / ez_}) *
-                          static_cast<FloatType>(1e-4);
+    const FloatType tol = std::min({lx_ / ex_, ly_ / ey_, lz_ / ez_}) * static_cast<FloatType>(1e-4);
 
-    data.boundaries_t_ =
-        CartesianStructBoundaryClassifier<FloatType, ScalarType>(
-            global_ox_, global_ox_ + global_lx_, global_oy_,
-            global_oy_ + global_ly_, global_oz_, global_oz_ + global_lz_, tol,
-            free_surface_on_top)
-            .classify(n_node, nx, ny, nz, ox_, oy_, oz_, lx_, ly_, lz_);
+    data.boundaries_t_ = CartesianStructBoundaryClassifier<FloatType, ScalarType>(
+                             global_ox_, global_ox_ + global_lx_, global_oy_, global_oy_ + global_ly_, global_oz_,
+                             global_oz_ + global_lz_, tol, free_surface_on_top)
+                             .classify(n_node, nx, ny, nz, ox_, oy_, oz_, lx_, ly_, lz_);
 
     // Bicouche model for acoustoelastic: fluid layer (z >= boundary) vs solid.
     // vs=0 in the fluid → TagElements classifies it as acoustic.
-    if (isAcoustoElastic_)
-    {
+    if (isAcoustoElastic_) {
       auto temp_model = model::ModelStruct<FloatType, ScalarType, Order>(data);
 
-      if (isModelOnNodes_)
-      {
-        data.model_vp_node_ =
-            allocateVector<VECTOR_REAL_VIEW>(n_node, "model_vp_node");
-        data.model_vs_node_ =
-            allocateVector<VECTOR_REAL_VIEW>(n_node, "model_vs_node");
-        data.model_rho_node_ =
-            allocateVector<VECTOR_REAL_VIEW>(n_node, "model_rho_node");
+      if (isModelOnNodes_) {
+        data.model_vp_node_ = allocateVector<VECTOR_REAL_VIEW>(n_node, "model_vp_node");
+        data.model_vs_node_ = allocateVector<VECTOR_REAL_VIEW>(n_node, "model_vs_node");
+        data.model_rho_node_ = allocateVector<VECTOR_REAL_VIEW>(n_node, "model_rho_node");
 
-        for (int n = 0; n < n_node; ++n)
-        {
-          bool const is_fluid =
-              (temp_model.nodeCoord(n, 2) >= acoustoElasticBoundaryZ_);
-          data.model_vp_node_[n] = is_fluid ? static_cast<FloatType>(1500)
-                                            : static_cast<FloatType>(3400);
-          data.model_vs_node_[n] = is_fluid ? static_cast<FloatType>(0)
-                                            : static_cast<FloatType>(1963);
-          data.model_rho_node_[n] = is_fluid ? static_cast<FloatType>(1020)
-                                             : static_cast<FloatType>(2500);
+        for (int n = 0; n < n_node; ++n) {
+          bool const is_fluid = (temp_model.nodeCoord(n, 2) >= acoustoElasticBoundaryZ_);
+          data.model_vp_node_[n] = is_fluid ? static_cast<FloatType>(1500) : static_cast<FloatType>(3400);
+          data.model_vs_node_[n] = is_fluid ? static_cast<FloatType>(0) : static_cast<FloatType>(1963);
+          data.model_rho_node_[n] = is_fluid ? static_cast<FloatType>(1020) : static_cast<FloatType>(2500);
         }
-      }
-      else
-      {
+      } else {
         int const n_elem = ex_ * ey_ * ez_;
         FloatType const hz = lz_ / ez_;
 
-        data.model_vp_element_ =
-            allocateVector<VECTOR_REAL_VIEW>(n_elem, "model_vp_elem");
-        data.model_vs_element_ =
-            allocateVector<VECTOR_REAL_VIEW>(n_elem, "model_vs_elem");
-        data.model_rho_element_ =
-            allocateVector<VECTOR_REAL_VIEW>(n_elem, "model_rho_elem");
+        data.model_vp_element_ = allocateVector<VECTOR_REAL_VIEW>(n_elem, "model_vp_elem");
+        data.model_vs_element_ = allocateVector<VECTOR_REAL_VIEW>(n_elem, "model_vs_elem");
+        data.model_rho_element_ = allocateVector<VECTOR_REAL_VIEW>(n_elem, "model_rho_elem");
 
-        for (int k = 0; k < ez_; ++k)
-        {
-          FloatType const centroid_z =
-              oz_ + (k + static_cast<FloatType>(0.5)) * hz;
+        for (int k = 0; k < ez_; ++k) {
+          FloatType const centroid_z = oz_ + (k + static_cast<FloatType>(0.5)) * hz;
           bool const is_fluid = (centroid_z >= acoustoElasticBoundaryZ_);
-          for (int j = 0; j < ey_; ++j)
-          {
-            for (int i = 0; i < ex_; ++i)
-            {
+          for (int j = 0; j < ey_; ++j) {
+            for (int i = 0; i < ex_; ++i) {
               int const e = i + j * ex_ + k * ex_ * ey_;
-              data.model_vp_element_[e] = is_fluid
-                                              ? static_cast<FloatType>(1500)
-                                              : static_cast<FloatType>(3400);
-              data.model_vs_element_[e] = is_fluid
-                                              ? static_cast<FloatType>(0)
-                                              : static_cast<FloatType>(1963);
-              data.model_rho_element_[e] = is_fluid
-                                               ? static_cast<FloatType>(1020)
-                                               : static_cast<FloatType>(2500);
+              data.model_vp_element_[e] = is_fluid ? static_cast<FloatType>(1500) : static_cast<FloatType>(3400);
+              data.model_vs_element_[e] = is_fluid ? static_cast<FloatType>(0) : static_cast<FloatType>(1963);
+              data.model_rho_element_[e] = is_fluid ? static_cast<FloatType>(1020) : static_cast<FloatType>(2500);
             }
           }
         }
@@ -144,9 +108,7 @@ class CartesianStructBuilder : public ModelBuilderBase<FloatType, ScalarType>
     // Construct model with local coordinates and dimensions, but use global
     // boundaries for boundary classification.
     // -------------------------------------------------------------------------
-    auto model =
-        std::make_shared<model::ModelStruct<FloatType, ScalarType, Order>>(
-            data);
+    auto model = std::make_shared<model::ModelStruct<FloatType, ScalarType, Order>>(data);
 
     model->buildFaceConnectivity();
 
@@ -154,10 +116,10 @@ class CartesianStructBuilder : public ModelBuilderBase<FloatType, ScalarType>
   }
 
  private:
-  FloatType ox_, oy_, oz_;  // Local origin coordinate in 3D
+  FloatType ox_, oy_, oz_;                       // Local origin coordinate in 3D
   FloatType global_ox_, global_oy_, global_oz_;  // Global origin
-  ScalarType ex_, ey_, ez_;  // Number of elements for each axis (local)
-  FloatType lx_, ly_, lz_;   // Domain size (local)
+  ScalarType ex_, ey_, ez_;                      // Number of elements for each axis (local)
+  FloatType lx_, ly_, lz_;                       // Domain size (local)
   FloatType global_lx_, global_ly_, global_lz_;  // Domain size (global)
   bool isModelOnNodes_;
   bool isElastic_;

--- a/src/model/mesh/impl/builder/cartesian/include/cartesian_unstruct_boundary_classifier.h
+++ b/src/model/mesh/impl/builder/cartesian/include/cartesian_unstruct_boundary_classifier.h
@@ -6,8 +6,7 @@
 
 #include <cmath>
 
-namespace model
-{
+namespace model {
 /**
  * @brief Classifies boundary flags for nodes of an unstructured Cartesian mesh.
  *
@@ -25,17 +24,14 @@ namespace model
  * @tparam ScalarType Integer type used to cast BoundaryFlag values
  */
 template <typename FloatType, typename ScalarType>
-class CartesianUnstructBoundaryClassifier
-{
+class CartesianUnstructBoundaryClassifier {
  public:
   /**
    * @param tol Distance tolerance for boundary detection (typically
    *            min_grid_spacing * 1e-4)
    */
-  CartesianUnstructBoundaryClassifier(FloatType x_min, FloatType x_max,
-                                      FloatType y_min, FloatType y_max,
-                                      FloatType z_min, FloatType z_max,
-                                      FloatType tol, bool free_surface_on_top)
+  CartesianUnstructBoundaryClassifier(FloatType x_min, FloatType x_max, FloatType y_min, FloatType y_max,
+                                      FloatType z_min, FloatType z_max, FloatType tol, bool free_surface_on_top)
       : x_min_(x_min),
         x_max_(x_max),
         y_min_(y_min),
@@ -43,9 +39,7 @@ class CartesianUnstructBoundaryClassifier
         z_min_(z_min),
         z_max_(z_max),
         tol_(tol),
-        free_surface_on_top_(free_surface_on_top)
-  {
-  }
+        free_surface_on_top_(free_surface_on_top) {}
 
   /**
    * @brief Classify every node against the global domain bounds.
@@ -56,14 +50,11 @@ class CartesianUnstructBoundaryClassifier
    * @param coords_z Z-coordinates of each node
    * @return VECTOR_INT_VIEW of size @p n_node with BoundaryFlag values
    */
-  VECTOR_INT_VIEW classify(int n_node, VECTOR_REAL_VIEW coords_x,
-                           VECTOR_REAL_VIEW coords_y,
-                           VECTOR_REAL_VIEW coords_z) const
-  {
+  VECTOR_INT_VIEW classify(int n_node, VECTOR_REAL_VIEW coords_x, VECTOR_REAL_VIEW coords_y,
+                           VECTOR_REAL_VIEW coords_z) const {
     auto boundaries_t = allocateVector<VECTOR_INT_VIEW>(n_node, "boundaries_t");
 
-    for (int n = 0; n < n_node; ++n)
-    {
+    for (int n = 0; n < n_node; ++n) {
       const FloatType x = coords_x(n);
       const FloatType y = coords_y(n);
       const FloatType z = coords_z(n);
@@ -75,8 +66,7 @@ class CartesianUnstructBoundaryClassifier
       const bool at_zmin = (fabs(z - z_min_) < tol_);
       const bool at_zmax = (fabs(z - z_max_) < tol_);
 
-      const bool on_boundary =
-          at_xmin || at_xmax || at_ymin || at_ymax || at_zmin || at_zmax;
+      const bool on_boundary = at_xmin || at_xmax || at_ymin || at_ymax || at_zmin || at_zmax;
 
       if (!on_boundary)
         boundaries_t(n) = static_cast<ScalarType>(BoundaryFlag::InteriorNode);

--- a/src/model/mesh/impl/builder/cartesian/include/cartesian_unstruct_builder.h
+++ b/src/model/mesh/impl/builder/cartesian/include/cartesian_unstruct_builder.h
@@ -9,11 +9,9 @@
 #include "gllpoints.h"
 #include "model_unstruct.h"
 
-namespace model
-{
+namespace model {
 template <typename FloatType, typename ScalarType>
-class CartesianUnstructBuilder : public ModelBuilderBase<FloatType, ScalarType>
-{
+class CartesianUnstructBuilder : public ModelBuilderBase<FloatType, ScalarType> {
  public:
   using ModelBuilderBase<FloatType, ScalarType>::MAX_ORDER;
 
@@ -39,50 +37,38 @@ class CartesianUnstructBuilder : public ModelBuilderBase<FloatType, ScalarType>
         global_lz_(p.global_lz > 0 ? p.global_lz : p.lz),
         global_ox_(p.global_lx > 0 ? p.global_origin_x : p.origin_x),
         global_oy_(p.global_ly > 0 ? p.global_origin_y : p.origin_y),
-        global_oz_(p.global_lz > 0 ? p.global_origin_z : p.origin_z)
-  {
+        global_oz_(p.global_lz > 0 ? p.global_origin_z : p.origin_z) {
     initGlobalNodeList();
     initNodesCoords();
     initModels();
   }
 
-  std::shared_ptr<model::ModelApi<FloatType, ScalarType>> getModel(
-      bool free_surface_on_top) const override
-  {
-    const int n_node =
-        (ex_ * order_ + 1) * (ey_ * order_ + 1) * (ez_ * order_ + 1);
+  std::shared_ptr<model::ModelApi<FloatType, ScalarType>> getModel(bool free_surface_on_top) const override {
+    const int n_node = (ex_ * order_ + 1) * (ey_ * order_ + 1) * (ez_ * order_ + 1);
 
-    const FloatType tol = std::min({lx_ / ex_, ly_ / ey_, lz_ / ez_}) *
-                          static_cast<FloatType>(1e-4);
+    const FloatType tol = std::min({lx_ / ex_, ly_ / ey_, lz_ / ez_}) * static_cast<FloatType>(1e-4);
 
-    auto boundaries_t =
-        CartesianUnstructBoundaryClassifier<FloatType, ScalarType>(
-            global_ox_, global_ox_ + global_lx_, global_oy_,
-            global_oy_ + global_ly_, global_oz_, global_oz_ + global_lz_, tol,
-            free_surface_on_top)
-            .classify(n_node, nodes_coords_x_, nodes_coords_y_,
-                      nodes_coords_z_);
+    auto boundaries_t = CartesianUnstructBoundaryClassifier<FloatType, ScalarType>(
+                            global_ox_, global_ox_ + global_lx_, global_oy_, global_oy_ + global_ly_, global_oz_,
+                            global_oz_ + global_lz_, tol, free_surface_on_top)
+                            .classify(n_node, nodes_coords_x_, nodes_coords_y_, nodes_coords_z_);
 
     // -------------------------------------------------------------------------
     // Construct model with local coordinates and dimensions, but use global
     // boundaries for boundary classification.
     // -------------------------------------------------------------------------
     model::ModelUnstructData<FloatType, ScalarType> modelData(
-        order_, ex_ * ey_ * ez_, n_node, lx_, ly_, lz_, isModelOnNodes_,
-        isElastic_, global_node_index_, nodes_coords_x_, nodes_coords_y_,
-        nodes_coords_z_, model_vp_node_, model_vp_element_, model_rho_node_,
-        model_rho_element_, model_vs_node_, model_vs_element_,
-        model_delta_node_, model_delta_element_, model_epsilon_node_,
-        model_epsilon_element_, model_gamma_node_, model_gamma_element_,
-        model_theta_node_, model_theta_element_, model_phi_node_,
-        model_phi_element_, model_C_tensor_element_, boundaries_t);
+        order_, ex_ * ey_ * ez_, n_node, lx_, ly_, lz_, isModelOnNodes_, isElastic_, global_node_index_,
+        nodes_coords_x_, nodes_coords_y_, nodes_coords_z_, model_vp_node_, model_vp_element_, model_rho_node_,
+        model_rho_element_, model_vs_node_, model_vs_element_, model_delta_node_, model_delta_element_,
+        model_epsilon_node_, model_epsilon_element_, model_gamma_node_, model_gamma_element_, model_theta_node_,
+        model_theta_element_, model_phi_node_, model_phi_element_, model_C_tensor_element_, boundaries_t);
 
     modelData.ox_ = ox_;
     modelData.oy_ = oy_;
     modelData.oz_ = oz_;
 
-    auto model = std::make_shared<model::ModelUnstruct<FloatType, ScalarType>>(
-        modelData);
+    auto model = std::make_shared<model::ModelUnstruct<FloatType, ScalarType>>(modelData);
     model->buildFaceConnectivity();
 
     return model;
@@ -126,36 +112,27 @@ class CartesianUnstructBuilder : public ModelBuilderBase<FloatType, ScalarType>
   VECTOR_REAL_VIEW model_phi_element_;
   ARRAY3D_REAL_VIEW model_C_tensor_element_;
 
-  void initGlobalNodeList()
-  {
+  void initGlobalNodeList() {
     int nodes_x = order_ + 1;
     int nodes_y = order_ + 1;
     int nodes_z = order_ + 1;
     int total_nodes = nodes_x * nodes_y * nodes_z;
-    global_node_index_ = allocateArray2D<ARRAY_INT_VIEW>(
-        ex_ * ey_ * ez_, total_nodes, "global node index");
+    global_node_index_ = allocateArray2D<ARRAY_INT_VIEW>(ex_ * ey_ * ez_, total_nodes, "global node index");
     int nx = ex_ * order_ + 1;  // Total nodes in x direction
     int ny = ey_ * order_ + 1;  // Total nodes in y direction
     int nz = ez_ * order_ + 1;  // Total nodes in z direction
 
-    for (int k = 0; k < ez_; k++)
-    {
-      for (int j = 0; j < ey_; j++)
-      {
-        for (int i = 0; i < ex_; i++)
-        {
+    for (int k = 0; k < ez_; k++) {
+      for (int j = 0; j < ey_; j++) {
+        for (int i = 0; i < ex_; i++) {
           int elementNum = i + j * ex_ + k * ex_ * ey_;
           // Corrected offset calculation
           int offset = i * order_ + j * order_ * nx + k * order_ * nx * ny;
 
-          for (int m = 0; m < order_ + 1; m++)
-          {  // z-direction
-            for (int n = 0; n < order_ + 1; n++)
-            {  // y-direction
-              for (int l = 0; l < order_ + 1; l++)
-              {  // x-direction
-                int dofLocal =
-                    l + n * (order_ + 1) + m * (order_ + 1) * (order_ + 1);
+          for (int m = 0; m < order_ + 1; m++) {      // z-direction
+            for (int n = 0; n < order_ + 1; n++) {    // y-direction
+              for (int l = 0; l < order_ + 1; l++) {  // x-direction
+                int dofLocal = l + n * (order_ + 1) + m * (order_ + 1) * (order_ + 1);
                 int dofGlobal = offset + l + n * nx + m * nx * ny;
                 global_node_index_(elementNum, dofLocal) = dofGlobal;
               }
@@ -166,34 +143,25 @@ class CartesianUnstructBuilder : public ModelBuilderBase<FloatType, ScalarType>
     }
   }
 
-  void getCoordInOneDirection(FloatType h, const int& n_element, float* coord,
-                              FloatType offset)
-  {
+  void getCoordInOneDirection(FloatType h, const int& n_element, float* coord, FloatType offset) {
     if (order_ < 1 || order_ > MAX_GLL_ORDER)
-      throw std::runtime_error(
-          "Cartesian unstruct builder error: order not supported.");
+      throw std::runtime_error("Cartesian unstruct builder error: order not supported.");
 
     const FloatType elementStart = n_element * h;
-    for (int j = 0; j < order_ + 1; j++)
-    {
-      coord[j] =
-          elementStart + (GLLPoints::get(order_, j) + 1.0f) * h * 0.5f + offset;
+    for (int j = 0; j < order_ + 1; j++) {
+      coord[j] = elementStart + (GLLPoints::get(order_, j) + 1.0f) * h * 0.5f + offset;
     }
   }
-  void initNodesCoords()
-  {
+  void initNodesCoords() {
     int nodes_x = ex_ * order_ + 1;
     int nodes_y = ey_ * order_ + 1;
     int nodes_z = ez_ * order_ + 1;
     int total_nodes = nodes_x * nodes_y * nodes_z;
 
     // Init the structure within mesh
-    nodes_coords_x_ =
-        allocateVector<VECTOR_REAL_VIEW>(total_nodes, "nodes coords x");
-    nodes_coords_y_ =
-        allocateVector<VECTOR_REAL_VIEW>(total_nodes, "nodes coords y");
-    nodes_coords_z_ =
-        allocateVector<VECTOR_REAL_VIEW>(total_nodes, "nodes coords z");
+    nodes_coords_x_ = allocateVector<VECTOR_REAL_VIEW>(total_nodes, "nodes coords x");
+    nodes_coords_y_ = allocateVector<VECTOR_REAL_VIEW>(total_nodes, "nodes coords y");
+    nodes_coords_z_ = allocateVector<VECTOR_REAL_VIEW>(total_nodes, "nodes coords z");
 
     float coord_x[MAX_ORDER + 1];
     float coord_y[MAX_ORDER + 1];
@@ -203,32 +171,23 @@ class CartesianUnstructBuilder : public ModelBuilderBase<FloatType, ScalarType>
     auto hy = ly_ / ey_;
     auto hz = lz_ / ez_;
 
-    for (int n = 0; n < ez_; n++)
-    {
+    for (int n = 0; n < ez_; n++) {
       getCoordInOneDirection(hz, n, coord_z, 0);
-      for (int m = 0; m < ey_; m++)
-      {
+      for (int m = 0; m < ey_; m++) {
         getCoordInOneDirection(hy, m, coord_y, 0);
-        for (int l = 0; l < ex_; l++)
-        {
+        for (int l = 0; l < ex_; l++) {
           getCoordInOneDirection(hx, l, coord_x, 0);
 
-          for (int k = 0; k < order_ + 1; k++)
-          {
-            for (int j = 0; j < order_ + 1; j++)
-            {
-              for (int i = 0; i < order_ + 1; i++)
-              {
+          for (int k = 0; k < order_ + 1; k++) {
+            for (int j = 0; j < order_ + 1; j++) {
+              for (int i = 0; i < order_ + 1; i++) {
                 int global_i = l * order_ + i;
                 int global_j = m * order_ + j;
                 int global_k = n * order_ + k;
 
-                int global_node_index = global_i + global_j * nodes_x +
-                                        global_k * nodes_x * nodes_y;
+                int global_node_index = global_i + global_j * nodes_x + global_k * nodes_x * nodes_y;
 
-                if (global_i < nodes_x && global_j < nodes_y &&
-                    global_k < nodes_z)
-                {
+                if (global_i < nodes_x && global_j < nodes_y && global_k < nodes_z) {
                   nodes_coords_x_(global_node_index) = coord_x[i];
                   nodes_coords_y_(global_node_index) = coord_y[j];
                   nodes_coords_z_(global_node_index) = coord_z[k];
@@ -241,77 +200,51 @@ class CartesianUnstructBuilder : public ModelBuilderBase<FloatType, ScalarType>
     }
   }
 
-  void initModels()
-  {
+  void initModels() {
     // TODO: Currently this function is not doing much more than
     // creating uniforms model
     int n_element = ex_ * ey_ * ez_;
     int n_node = (ex_ * order_ + 1) * (ey_ * order_ + 1) * (ez_ * order_ + 1);
-    if (isModelOnNodes_)
-    {
-      model_rho_node_ =
-          allocateVector<VECTOR_REAL_VIEW>(n_node, "model rho node");
-      model_vp_node_ =
-          allocateVector<VECTOR_REAL_VIEW>(n_node, "model vp node");
+    if (isModelOnNodes_) {
+      model_rho_node_ = allocateVector<VECTOR_REAL_VIEW>(n_node, "model rho node");
+      model_vp_node_ = allocateVector<VECTOR_REAL_VIEW>(n_node, "model vp node");
 
-      if (isAcoustoElastic_)
-      {
+      if (isAcoustoElastic_) {
         // Bicouche: fluid layer (z >= boundary) + solid layer (z < boundary).
         // vs is used by the coupled solver to classify elements: vs=0 → fluid.
-        model_vs_node_ =
-            allocateVector<VECTOR_REAL_VIEW>(n_node, "model vs node");
-        model_delta_node_ =
-            allocateVector<VECTOR_REAL_VIEW>(n_node, "model delta node");
-        model_gamma_node_ =
-            allocateVector<VECTOR_REAL_VIEW>(n_node, "model gamma node");
-        model_epsilon_node_ =
-            allocateVector<VECTOR_REAL_VIEW>(n_node, "model epsilon node");
-        model_theta_node_ =
-            allocateVector<VECTOR_REAL_VIEW>(n_node, "model theta node");
-        model_phi_node_ =
-            allocateVector<VECTOR_REAL_VIEW>(n_node, "model phi node");
+        model_vs_node_ = allocateVector<VECTOR_REAL_VIEW>(n_node, "model vs node");
+        model_delta_node_ = allocateVector<VECTOR_REAL_VIEW>(n_node, "model delta node");
+        model_gamma_node_ = allocateVector<VECTOR_REAL_VIEW>(n_node, "model gamma node");
+        model_epsilon_node_ = allocateVector<VECTOR_REAL_VIEW>(n_node, "model epsilon node");
+        model_theta_node_ = allocateVector<VECTOR_REAL_VIEW>(n_node, "model theta node");
+        model_phi_node_ = allocateVector<VECTOR_REAL_VIEW>(n_node, "model phi node");
 
-        for (int n = 0; n < n_node; ++n)
-        {
+        for (int n = 0; n < n_node; ++n) {
           FloatType z = nodes_coords_z_(n);
           bool const is_fluid = (z >= acoustoElasticBoundaryZ_);
-          model_rho_node_[n] = is_fluid ? static_cast<FloatType>(1020)
-                                        : static_cast<FloatType>(2500);
-          model_vp_node_[n] = is_fluid ? static_cast<FloatType>(1500)
-                                       : static_cast<FloatType>(3000);
-          model_vs_node_[n] = is_fluid ? static_cast<FloatType>(0)
-                                       : static_cast<FloatType>(1500);
+          model_rho_node_[n] = is_fluid ? static_cast<FloatType>(1020) : static_cast<FloatType>(2500);
+          model_vp_node_[n] = is_fluid ? static_cast<FloatType>(1500) : static_cast<FloatType>(3000);
+          model_vs_node_[n] = is_fluid ? static_cast<FloatType>(0) : static_cast<FloatType>(1500);
           model_delta_node_[n] = 0;
           model_epsilon_node_[n] = 0;
           model_gamma_node_[n] = 0;
           model_theta_node_[n] = 0;
           model_phi_node_[n] = 0;
         }
-      }
-      else
-      {
-        for (int i = 0; i < n_node; i++)
-        {
+      } else {
+        for (int i = 0; i < n_node; i++) {
           model_rho_node_[i] = 1;
           model_vp_node_[i] = 1500;
         }
-        if (isElastic_)
-        {
-          model_vs_node_ =
-              allocateVector<VECTOR_REAL_VIEW>(n_node, "model vs node");
-          model_delta_node_ =
-              allocateVector<VECTOR_REAL_VIEW>(n_node, "model delta node");
-          model_gamma_node_ =
-              allocateVector<VECTOR_REAL_VIEW>(n_node, "model gamma node");
-          model_epsilon_node_ =
-              allocateVector<VECTOR_REAL_VIEW>(n_node, "model epsilon node");
-          model_theta_node_ =
-              allocateVector<VECTOR_REAL_VIEW>(n_node, "model theta node");
-          model_phi_node_ =
-              allocateVector<VECTOR_REAL_VIEW>(n_node, "model phi node");
+        if (isElastic_) {
+          model_vs_node_ = allocateVector<VECTOR_REAL_VIEW>(n_node, "model vs node");
+          model_delta_node_ = allocateVector<VECTOR_REAL_VIEW>(n_node, "model delta node");
+          model_gamma_node_ = allocateVector<VECTOR_REAL_VIEW>(n_node, "model gamma node");
+          model_epsilon_node_ = allocateVector<VECTOR_REAL_VIEW>(n_node, "model epsilon node");
+          model_theta_node_ = allocateVector<VECTOR_REAL_VIEW>(n_node, "model theta node");
+          model_phi_node_ = allocateVector<VECTOR_REAL_VIEW>(n_node, "model phi node");
 
-          for (int i = 0; i < n_node; i++)
-          {
+          for (int i = 0; i < n_node; i++) {
             model_vs_node_[i] = 755;
             model_delta_node_[i] = 0.0;
             model_epsilon_node_[i] = 0.0;
@@ -323,48 +256,31 @@ class CartesianUnstructBuilder : public ModelBuilderBase<FloatType, ScalarType>
       }
     }
 
-    else
-    {
-      model_rho_element_ =
-          allocateVector<VECTOR_REAL_VIEW>(n_element, "model rho elem");
-      model_vp_element_ =
-          allocateVector<VECTOR_REAL_VIEW>(n_element, "model vp elem");
+    else {
+      model_rho_element_ = allocateVector<VECTOR_REAL_VIEW>(n_element, "model rho elem");
+      model_vp_element_ = allocateVector<VECTOR_REAL_VIEW>(n_element, "model vp elem");
 
-      if (isAcoustoElastic_)
-      {
+      if (isAcoustoElastic_) {
         // Bicouche: fluid layer (centroid z >= boundary) + solid layer (z <
         // boundary). vs is used by the coupled solver to classify elements:
         // vs=0 → fluid.
-        model_vs_element_ =
-            allocateVector<VECTOR_REAL_VIEW>(n_element, "model vs element");
-        model_delta_element_ =
-            allocateVector<VECTOR_REAL_VIEW>(n_element, "model delta element");
-        model_gamma_element_ =
-            allocateVector<VECTOR_REAL_VIEW>(n_element, "model gamma element");
-        model_epsilon_element_ = allocateVector<VECTOR_REAL_VIEW>(
-            n_element, "model epsilon element");
-        model_theta_element_ =
-            allocateVector<VECTOR_REAL_VIEW>(n_element, "model theta element");
-        model_phi_element_ =
-            allocateVector<VECTOR_REAL_VIEW>(n_element, "model phi element");
+        model_vs_element_ = allocateVector<VECTOR_REAL_VIEW>(n_element, "model vs element");
+        model_delta_element_ = allocateVector<VECTOR_REAL_VIEW>(n_element, "model delta element");
+        model_gamma_element_ = allocateVector<VECTOR_REAL_VIEW>(n_element, "model gamma element");
+        model_epsilon_element_ = allocateVector<VECTOR_REAL_VIEW>(n_element, "model epsilon element");
+        model_theta_element_ = allocateVector<VECTOR_REAL_VIEW>(n_element, "model theta element");
+        model_phi_element_ = allocateVector<VECTOR_REAL_VIEW>(n_element, "model phi element");
 
         FloatType const hz = lz_ / ez_;
-        for (int k = 0; k < ez_; ++k)
-        {
-          FloatType const centroid_z =
-              oz_ + (k + static_cast<FloatType>(0.5)) * hz;
+        for (int k = 0; k < ez_; ++k) {
+          FloatType const centroid_z = oz_ + (k + static_cast<FloatType>(0.5)) * hz;
           bool const is_fluid = (centroid_z >= acoustoElasticBoundaryZ_);
-          for (int j = 0; j < ey_; ++j)
-          {
-            for (int i = 0; i < ex_; ++i)
-            {
+          for (int j = 0; j < ey_; ++j) {
+            for (int i = 0; i < ex_; ++i) {
               int const e = i + j * ex_ + k * ex_ * ey_;
-              model_rho_element_[e] = is_fluid ? static_cast<FloatType>(1000)
-                                               : static_cast<FloatType>(2000);
-              model_vp_element_[e] = is_fluid ? static_cast<FloatType>(1500)
-                                              : static_cast<FloatType>(3000);
-              model_vs_element_[e] = is_fluid ? static_cast<FloatType>(0)
-                                              : static_cast<FloatType>(1500);
+              model_rho_element_[e] = is_fluid ? static_cast<FloatType>(1000) : static_cast<FloatType>(2000);
+              model_vp_element_[e] = is_fluid ? static_cast<FloatType>(1500) : static_cast<FloatType>(3000);
+              model_vs_element_[e] = is_fluid ? static_cast<FloatType>(0) : static_cast<FloatType>(1500);
               model_delta_element_[e] = 0;
               model_epsilon_element_[e] = 0;
               model_gamma_element_[e] = 0;
@@ -373,32 +289,21 @@ class CartesianUnstructBuilder : public ModelBuilderBase<FloatType, ScalarType>
             }
           }
         }
-      }
-      else
-      {
-        for (int i = 0; i < n_element; i++)
-        {
+      } else {
+        for (int i = 0; i < n_element; i++) {
           model_rho_element_[i] = 1;
           model_vp_element_[i] = 1500;
         }
 
-        if (isElastic_)
-        {
-          model_vs_element_ =
-              allocateVector<VECTOR_REAL_VIEW>(n_element, "model vs element");
-          model_delta_element_ = allocateVector<VECTOR_REAL_VIEW>(
-              n_element, "model delta element");
-          model_gamma_element_ = allocateVector<VECTOR_REAL_VIEW>(
-              n_element, "model gamma element");
-          model_epsilon_element_ = allocateVector<VECTOR_REAL_VIEW>(
-              n_element, "model epsilon element");
-          model_theta_element_ = allocateVector<VECTOR_REAL_VIEW>(
-              n_element, "model theta element");
-          model_phi_element_ =
-              allocateVector<VECTOR_REAL_VIEW>(n_element, "model phi element");
+        if (isElastic_) {
+          model_vs_element_ = allocateVector<VECTOR_REAL_VIEW>(n_element, "model vs element");
+          model_delta_element_ = allocateVector<VECTOR_REAL_VIEW>(n_element, "model delta element");
+          model_gamma_element_ = allocateVector<VECTOR_REAL_VIEW>(n_element, "model gamma element");
+          model_epsilon_element_ = allocateVector<VECTOR_REAL_VIEW>(n_element, "model epsilon element");
+          model_theta_element_ = allocateVector<VECTOR_REAL_VIEW>(n_element, "model theta element");
+          model_phi_element_ = allocateVector<VECTOR_REAL_VIEW>(n_element, "model phi element");
 
-          for (int i = 0; i < n_element; i++)
-          {
+          for (int i = 0; i < n_element; i++) {
             model_vs_element_[i] = 755;
             model_delta_element_[i] = 0.0;
             model_epsilon_element_[i] = 0.0;

--- a/src/model/mesh/impl/common/include/elasticity_utils.h
+++ b/src/model/mesh/impl/common/include/elasticity_utils.h
@@ -6,11 +6,8 @@
  * @brief Compute isotropic elasticity coefficients (Lamé parameters)
  */
 template <typename FloatType>
-PROXY_HOST_DEVICE void computeIsotropicCoefficients(FloatType vp, FloatType vs,
-                                                    FloatType rho,
-                                                    FloatType& lambda,
-                                                    FloatType& mu)
-{
+PROXY_HOST_DEVICE void computeIsotropicCoefficients(FloatType vp, FloatType vs, FloatType rho, FloatType& lambda,
+                                                    FloatType& mu) {
   mu = rho * vs * vs;
   lambda = rho * (vp * vp - FloatType(2.0) * vs * vs);
 }
@@ -19,9 +16,7 @@ PROXY_HOST_DEVICE void computeIsotropicCoefficients(FloatType vp, FloatType vs,
  * @brief Build isotropic elasticity tensor in Voigt notation
  */
 template <typename FloatType>
-PROXY_HOST_DEVICE void buildIsotropicTensor(FloatType lambda, FloatType mu,
-                                            FloatType C[6][6])
-{
+PROXY_HOST_DEVICE void buildIsotropicTensor(FloatType lambda, FloatType mu, FloatType C[6][6]) {
   for (int i = 0; i < 6; i++)
     for (int j = 0; j < 6; j++) C[i][j] = FloatType(0.0);
 
@@ -45,11 +40,9 @@ PROXY_HOST_DEVICE void buildIsotropicTensor(FloatType lambda, FloatType mu,
  * @brief Compute VTI elasticity coefficients (no rotation)
  */
 template <typename FloatType>
-PROXY_HOST_DEVICE void computeVTICoefficients(
-    FloatType vp, FloatType vs, FloatType rho, FloatType delta,
-    FloatType epsilon, FloatType gamma, FloatType& c11, FloatType& c12,
-    FloatType& c13, FloatType& c33, FloatType& c44, FloatType& c66)
-{
+PROXY_HOST_DEVICE void computeVTICoefficients(FloatType vp, FloatType vs, FloatType rho, FloatType delta,
+                                              FloatType epsilon, FloatType gamma, FloatType& c11, FloatType& c12,
+                                              FloatType& c13, FloatType& c33, FloatType& c44, FloatType& c66) {
   FloatType const rho_vp2 = rho * vp * vp;
   FloatType const rho_vs2 = rho * vs * vs;
 
@@ -59,8 +52,7 @@ PROXY_HOST_DEVICE void computeVTICoefficients(
   c66 = rho_vs2 * (FloatType(1.0) + FloatType(2.0) * gamma);
 
   FloatType const vp2_vs2 = vp * vp - vs * vs;
-  FloatType const sqrt_arg =
-      vp2_vs2 * vp2_vs2 + FloatType(2.0) * rho_vp2 * delta * vp2_vs2;
+  FloatType const sqrt_arg = vp2_vs2 * vp2_vs2 + FloatType(2.0) * rho_vp2 * delta * vp2_vs2;
   c13 = rho * sqrt(sqrt_arg) - rho_vs2;
   c12 = c11 - FloatType(2.0) * c66;
 }
@@ -69,11 +61,8 @@ PROXY_HOST_DEVICE void computeVTICoefficients(
  * @brief Build VTI elasticity tensor in Voigt notation (no rotation)
  */
 template <typename FloatType>
-PROXY_HOST_DEVICE void buildVTITensor(FloatType c11, FloatType c12,
-                                      FloatType c13, FloatType c33,
-                                      FloatType c44, FloatType c66,
-                                      FloatType C[6][6])
-{
+PROXY_HOST_DEVICE void buildVTITensor(FloatType c11, FloatType c12, FloatType c13, FloatType c33, FloatType c44,
+                                      FloatType c66, FloatType C[6][6]) {
   for (int i = 0; i < 6; i++)
     for (int j = 0; j < 6; j++) C[i][j] = FloatType(0.0);
 
@@ -95,11 +84,8 @@ PROXY_HOST_DEVICE void buildVTITensor(FloatType c11, FloatType c12,
  * @brief Compute the full TTI elasticity tensor (VTI + rotation)
  */
 template <typename FloatType>
-PROXY_HOST_DEVICE void computeCTensor(FloatType vp, FloatType vs, FloatType rho,
-                                      FloatType delta, FloatType epsilon,
-                                      FloatType gamma, FloatType theta,
-                                      FloatType phi, FloatType CTTI[6][6])
-{
+PROXY_HOST_DEVICE void computeCTensor(FloatType vp, FloatType vs, FloatType rho, FloatType delta, FloatType epsilon,
+                                      FloatType gamma, FloatType theta, FloatType phi, FloatType CTTI[6][6]) {
   FloatType CVTI[6][6] = {0.0};
   CVTI[0][0] = rho * vp * vp * (1.0 + 2.0 * epsilon);
   CVTI[1][1] = CVTI[0][0];
@@ -182,8 +168,7 @@ PROXY_HOST_DEVICE void computeCTensor(FloatType vp, FloatType vs, FloatType rho,
       for (int k = 0; k < 6; k++) temp[i][j] += M[i][k] * CVTI[k][j];
 
   for (int i = 0; i < 6; i++)
-    for (int j = i; j < 6; j++)
-    {
+    for (int j = i; j < 6; j++) {
       CTTI[i][j] = 0.0;
       for (int k = 0; k < 6; k++) CTTI[i][j] += temp[i][k] * M[j][k];
       if (i != j) CTTI[j][i] = CTTI[i][j];

--- a/src/model/mesh/impl/model/struct/include/face_connectivity_struct.h
+++ b/src/model/mesh/impl/model/struct/include/face_connectivity_struct.h
@@ -2,8 +2,7 @@
 #define FUNTIDES_MODEL_MESH_IMPL_MODEL_STRUCT_INCLUDE_FACE_CONNECTIVITY_STRUCT_H_
 #include "face_connectivity.h"
 
-namespace model
-{
+namespace model {
 
 /**
  * @brief Face connectivity for structured Cartesian meshes — fully on-the-fly
@@ -16,15 +15,13 @@ namespace model
  * @tparam ScalarType Integer type for indexing
  */
 template <typename FloatType, typename ScalarType>
-class FaceConnectivityStruct : public FaceConnectivityApi<FloatType, ScalarType>
-{
+class FaceConnectivityStruct : public FaceConnectivityApi<FloatType, ScalarType> {
  public:
   PROXY_HOST_DEVICE FaceConnectivityStruct() = default;
 
   PROXY_HOST_DEVICE
   FaceConnectivityStruct(ScalarType ex, ScalarType ey, ScalarType ez, int order)
-      : ex_(ex), ey_(ey), ez_(ez), order_(order)
-  {
+      : ex_(ex), ey_(ey), ez_(ez), order_(order) {
     nx_ = order_ * ex_ + 1;
     ny_ = order_ * ey_ + 1;
     offset_y_ = (ex_ + 1) * ey_ * ez_;
@@ -35,26 +32,17 @@ class FaceConnectivityStruct : public FaceConnectivityApi<FloatType, ScalarType>
   // Implementation of FaceConnectivityApi — all on-the-fly
   // ==========================================================================
 
-  PROXY_HOST_DEVICE ScalarType getNumberOfFaces() const override
-  {
-    return offset_z_ + ex_ * ey_ * (ez_ + 1);
-  }
+  PROXY_HOST_DEVICE ScalarType getNumberOfFaces() const override { return offset_z_ + ex_ * ey_ * (ez_ + 1); }
 
-  PROXY_HOST_DEVICE int getDofsPerFace() const override
-  {
-    return (order_ + 1) * (order_ + 1);
-  }
+  PROXY_HOST_DEVICE int getDofsPerFace() const override { return (order_ + 1) * (order_ + 1); }
 
-  PROXY_HOST_DEVICE ScalarType
-  getGlobalFace(ScalarType elem, CubicFace local_face) const override
-  {
+  PROXY_HOST_DEVICE ScalarType getGlobalFace(ScalarType elem, CubicFace local_face) const override {
     ScalarType elem_k = elem / (ex_ * ey_);
     ScalarType tmp = elem % (ex_ * ey_);
     ScalarType elem_j = tmp / ex_;
     ScalarType elem_i = tmp % ex_;
 
-    switch (local_face)
-    {
+    switch (local_face) {
       case CubicFace::kXMinus:
         return elem_i + elem_j * (ex_ + 1) + elem_k * (ex_ + 1) * ey_;
       case CubicFace::kXPlus:
@@ -62,8 +50,7 @@ class FaceConnectivityStruct : public FaceConnectivityApi<FloatType, ScalarType>
       case CubicFace::kYMinus:
         return offset_y_ + elem_i + elem_j * ex_ + elem_k * ex_ * (ey_ + 1);
       case CubicFace::kYPlus:
-        return offset_y_ + elem_i + (elem_j + 1) * ex_ +
-               elem_k * ex_ * (ey_ + 1);
+        return offset_y_ + elem_i + (elem_j + 1) * ex_ + elem_k * ex_ * (ey_ + 1);
       case CubicFace::kZMinus:
         return offset_z_ + elem_i + elem_j * ex_ + elem_k * ex_ * ey_;
       case CubicFace::kZPlus:
@@ -82,9 +69,7 @@ class FaceConnectivityStruct : public FaceConnectivityApi<FloatType, ScalarType>
    * k*(order+1)+i Z-face : for j in [0,order], for i in [0,order] → local_dof =
    * j*(order+1)+i
    */
-  PROXY_HOST_DEVICE ScalarType
-  getGlobalNodeFromFace(ScalarType face_id, int local_dof) const override
-  {
+  PROXY_HOST_DEVICE ScalarType getGlobalNodeFromFace(ScalarType face_id, int local_dof) const override {
     ScalarType ix, iy, iz;
 
     if (face_id < offset_y_)  // X-face
@@ -99,8 +84,7 @@ class FaceConnectivityStruct : public FaceConnectivityApi<FloatType, ScalarType>
       ix = i_face * order_;
       iy = j_face * order_ + j_local;
       iz = k_face * order_ + k_local;
-    }
-    else if (face_id < offset_z_)  // Y-face
+    } else if (face_id < offset_z_)  // Y-face
     {
       ScalarType local = face_id - offset_y_;
       ScalarType i_face = local % ex_;
@@ -113,8 +97,7 @@ class FaceConnectivityStruct : public FaceConnectivityApi<FloatType, ScalarType>
       ix = i_face * order_ + i_local;
       iy = j_face * order_;
       iz = k_face * order_ + k_local;
-    }
-    else  // Z-face
+    } else  // Z-face
     {
       ScalarType local = face_id - offset_z_;
       ScalarType i_face = local % ex_;
@@ -139,21 +122,15 @@ class FaceConnectivityStruct : public FaceConnectivityApi<FloatType, ScalarType>
    *  - Z-face is boundary if k_face == 0 or k_face == ez
    * @return True if boundary face
    */
-  PROXY_HOST_DEVICE bool isBoundaryFace(ScalarType face_id) const override
-  {
-    if (face_id < offset_y_)
-    {
+  PROXY_HOST_DEVICE bool isBoundaryFace(ScalarType face_id) const override {
+    if (face_id < offset_y_) {
       ScalarType i = face_id % (ex_ + 1);
       return (i == 0 || i == ex_);
-    }
-    else if (face_id < offset_z_)
-    {
+    } else if (face_id < offset_z_) {
       ScalarType local = face_id - offset_y_;
       ScalarType j = (local / ex_) % (ey_ + 1);
       return (j == 0 || j == ey_);
-    }
-    else
-    {
+    } else {
       ScalarType local = face_id - offset_z_;
       ScalarType k = local / (ex_ * ey_);
       return (k == 0 || k == ez_);
@@ -165,27 +142,21 @@ class FaceConnectivityStruct : public FaceConnectivityApi<FloatType, ScalarType>
    * @param face_id Global face ID
    * @return Owner element index or -1 if boundary
    */
-  PROXY_HOST_DEVICE ScalarType elemOwner(ScalarType face_id) const override
-  {
-    if (face_id < offset_y_)
-    {
+  PROXY_HOST_DEVICE ScalarType elemOwner(ScalarType face_id) const override {
+    if (face_id < offset_y_) {
       ScalarType i = face_id % (ex_ + 1);
       ScalarType j = (face_id / (ex_ + 1)) % ey_;
       ScalarType k = face_id / ((ex_ + 1) * ey_);
       ScalarType ei = (i < ex_) ? i : i - 1;
       return ei + j * ex_ + k * ex_ * ey_;
-    }
-    else if (face_id < offset_z_)
-    {
+    } else if (face_id < offset_z_) {
       ScalarType local = face_id - offset_y_;
       ScalarType i = local % ex_;
       ScalarType j = (local / ex_) % (ey_ + 1);
       ScalarType k = local / (ex_ * (ey_ + 1));
       ScalarType ej = (j < ey_) ? j : j - 1;
       return i + ej * ex_ + k * ex_ * ey_;
-    }
-    else
-    {
+    } else {
       ScalarType local = face_id - offset_z_;
       ScalarType i = local % ex_;
       ScalarType j = (local / ex_) % ey_;
@@ -200,27 +171,21 @@ class FaceConnectivityStruct : public FaceConnectivityApi<FloatType, ScalarType>
    * * @param face_id Global face ID
    * * @return Neighbor element index or -1 if boundary
    */
-  PROXY_HOST_DEVICE ScalarType elemNeighbor(ScalarType face_id) const override
-  {
+  PROXY_HOST_DEVICE ScalarType elemNeighbor(ScalarType face_id) const override {
     if (isBoundaryFace(face_id)) return -1;
 
-    if (face_id < offset_y_)
-    {
+    if (face_id < offset_y_) {
       ScalarType i = face_id % (ex_ + 1);
       ScalarType j = (face_id / (ex_ + 1)) % ey_;
       ScalarType k = face_id / ((ex_ + 1) * ey_);
       return (i - 1) + j * ex_ + k * ex_ * ey_;
-    }
-    else if (face_id < offset_z_)
-    {
+    } else if (face_id < offset_z_) {
       ScalarType local = face_id - offset_y_;
       ScalarType i = local % ex_;
       ScalarType j = (local / ex_) % (ey_ + 1);
       ScalarType k = local / (ex_ * (ey_ + 1));
       return i + (j - 1) * ex_ + k * ex_ * ey_;
-    }
-    else
-    {
+    } else {
       ScalarType local = face_id - offset_z_;
       ScalarType i = local % ex_;
       ScalarType j = (local / ex_) % ey_;
@@ -234,27 +199,18 @@ class FaceConnectivityStruct : public FaceConnectivityApi<FloatType, ScalarType>
    * @param face_id Global face ID
    * @return Local face index (0-5) in owner element
    */
-  PROXY_HOST_DEVICE int localFaceOwner(ScalarType face_id) const override
-  {
-    if (face_id < offset_y_)
-    {
+  PROXY_HOST_DEVICE int localFaceOwner(ScalarType face_id) const override {
+    if (face_id < offset_y_) {
       ScalarType i = face_id % (ex_ + 1);
-      return (i < ex_) ? static_cast<int>(CubicFace::kXMinus)
-                       : static_cast<int>(CubicFace::kXPlus);
-    }
-    else if (face_id < offset_z_)
-    {
+      return (i < ex_) ? static_cast<int>(CubicFace::kXMinus) : static_cast<int>(CubicFace::kXPlus);
+    } else if (face_id < offset_z_) {
       ScalarType local = face_id - offset_y_;
       ScalarType j = (local / ex_) % (ey_ + 1);
-      return (j < ey_) ? static_cast<int>(CubicFace::kYMinus)
-                       : static_cast<int>(CubicFace::kYPlus);
-    }
-    else
-    {
+      return (j < ey_) ? static_cast<int>(CubicFace::kYMinus) : static_cast<int>(CubicFace::kYPlus);
+    } else {
       ScalarType local = face_id - offset_z_;
       ScalarType k = local / (ex_ * ey_);
-      return (k < ez_) ? static_cast<int>(CubicFace::kZMinus)
-                       : static_cast<int>(CubicFace::kZPlus);
+      return (k < ez_) ? static_cast<int>(CubicFace::kZMinus) : static_cast<int>(CubicFace::kZPlus);
     }
   }
 
@@ -263,11 +219,9 @@ class FaceConnectivityStruct : public FaceConnectivityApi<FloatType, ScalarType>
    * @param face_id Global face ID
    * @return Local face index (0-5) in neighbor element, or -1 if boundary
    */
-  PROXY_HOST_DEVICE int localFaceNeighbor(ScalarType face_id) const override
-  {
+  PROXY_HOST_DEVICE int localFaceNeighbor(ScalarType face_id) const override {
     if (isBoundaryFace(face_id)) return -1;
-    return localFaceOwner(face_id) ^
-           1;  // XMinus↔XPlus, YMinus↔YPlus, ZMinus↔ZPlus
+    return localFaceOwner(face_id) ^ 1;  // XMinus↔XPlus, YMinus↔YPlus, ZMinus↔ZPlus
   }
 
  private:

--- a/src/model/mesh/impl/model/struct/include/gllpoints.h
+++ b/src/model/mesh/impl/model/struct/include/gllpoints.h
@@ -5,25 +5,18 @@
 
 constexpr int MAX_GLL_ORDER = 9;
 
-struct GLLPoints
-{
+struct GLLPoints {
   /// Return the number of points for given order
-  PROXY_HOST_DEVICE static constexpr int num_points(int order)
-  {
-    return order + 1;
-  }
+  PROXY_HOST_DEVICE static constexpr int num_points(int order) { return order + 1; }
 
   /// Return the i-th GLL point for given order (reference element [-1, 1])
-  PROXY_HOST_DEVICE static float get(int order, int i)
-  {
+  PROXY_HOST_DEVICE static float get(int order, int i) {
     if (order < 1 || order > MAX_GLL_ORDER) return 0.0f;
     if (i < 0 || i >= (order + 1)) return 0.0f;
 
-    switch (order)
-    {
+    switch (order) {
       case 1:
-        switch (i)
-        {
+        switch (i) {
           case 0:
             return -1.0f;
           case 1:
@@ -32,8 +25,7 @@ struct GLLPoints
         break;
 
       case 2:
-        switch (i)
-        {
+        switch (i) {
           case 0:
             return -1.0f;
           case 1:
@@ -45,8 +37,7 @@ struct GLLPoints
 
       case 3:
         // interior: ±1/√5
-        switch (i)
-        {
+        switch (i) {
           case 0:
             return -1.0f;
           case 1:
@@ -60,8 +51,7 @@ struct GLLPoints
 
       case 4:
         // interior: ±√(3/7), 0
-        switch (i)
-        {
+        switch (i) {
           case 0:
             return -1.0f;
           case 1:
@@ -76,8 +66,7 @@ struct GLLPoints
         break;
 
       case 5:
-        switch (i)
-        {
+        switch (i) {
           case 0:
             return -1.0f;
           case 1:
@@ -94,8 +83,7 @@ struct GLLPoints
         break;
 
       case 6:
-        switch (i)
-        {
+        switch (i) {
           case 0:
             return -1.0f;
           case 1:
@@ -114,8 +102,7 @@ struct GLLPoints
         break;
 
       case 7:
-        switch (i)
-        {
+        switch (i) {
           case 0:
             return -1.0f;
           case 1:
@@ -136,8 +123,7 @@ struct GLLPoints
         break;
 
       case 8:
-        switch (i)
-        {
+        switch (i) {
           case 0:
             return -1.0f;
           case 1:
@@ -160,8 +146,7 @@ struct GLLPoints
         break;
 
       case 9:
-        switch (i)
-        {
+        switch (i) {
           case 0:
             return -1.0f;
           case 1:

--- a/src/model/mesh/impl/model/struct/include/model_struct.h
+++ b/src/model/mesh/impl/model/struct/include/model_struct.h
@@ -6,21 +6,18 @@
 #include "face_connectivity_struct.h"
 #include "gllpoints.h"
 
-namespace model
-{
+namespace model {
 
 /**
  * @brief Data structure for structured Cartesian mesh initialization
  */
 template <typename FloatType, typename ScalarType>
-struct ModelStructData final : public ModelDataBase<FloatType, ScalarType>
-{
+struct ModelStructData final : public ModelDataBase<FloatType, ScalarType> {
  public:
   PROXY_HOST_DEVICE ModelStructData() = default;
   PROXY_HOST_DEVICE ~ModelStructData() = default;
   PROXY_HOST_DEVICE ModelStructData(const ModelStructData&) = default;
-  PROXY_HOST_DEVICE ModelStructData& operator=(const ModelStructData&) =
-      default;
+  PROXY_HOST_DEVICE ModelStructData& operator=(const ModelStructData&) = default;
 
   ScalarType ex_, ey_, ez_;
   FloatType dx_, dy_, dz_;
@@ -57,15 +54,13 @@ struct ModelStructData final : public ModelDataBase<FloatType, ScalarType>
  * @tparam Order Polynomial order of spectral elements
  */
 template <typename FloatType, typename ScalarType, int Order>
-class ModelStruct final : public ModelApi<FloatType, ScalarType>
-{
+class ModelStruct final : public ModelApi<FloatType, ScalarType> {
  public:
   using IndexType = std::array<int, 3>;
 
   PROXY_HOST_DEVICE ModelStruct() = default;
 
-  PROXY_HOST_DEVICE ModelStruct(
-      const ModelStructData<FloatType, ScalarType>& data)
+  PROXY_HOST_DEVICE ModelStruct(const ModelStructData<FloatType, ScalarType>& data)
       : ex_(data.ex_),
         ey_(data.ey_),
         ez_(data.ez_),
@@ -88,8 +83,7 @@ class ModelStruct final : public ModelApi<FloatType, ScalarType>
         model_qp_element_(data.model_qp_element_),
         model_qs_element_(data.model_qs_element_),
         model_qp_node_(data.model_qp_node_),
-        model_qs_node_(data.model_qs_node_)
-  {
+        model_qs_node_(data.model_qs_node_) {
     nx_ = Order * ex_ + 1;
     ny_ = Order * ey_ + 1;
     nz_ = Order * ez_ + 1;
@@ -108,8 +102,7 @@ class ModelStruct final : public ModelApi<FloatType, ScalarType>
   // ============================================================================
 
   PROXY_HOST_DEVICE
-  IndexType elementIndex(const int linearIndex) const
-  {
+  IndexType elementIndex(const int linearIndex) const {
     IndexType elemIndex;
     elemIndex[2] = linearIndex / (ex_ * ey_);
     int const rem = linearIndex - elemIndex[2] * (ex_ * ey_);
@@ -119,23 +112,19 @@ class ModelStruct final : public ModelApi<FloatType, ScalarType>
   }
 
   PROXY_HOST_DEVICE
-  IndexType globalVertexIndex(IndexType e, int const i, int const j,
-                              int const k) const
-  {
+  IndexType globalVertexIndex(IndexType e, int const i, int const j, int const k) const {
     return {e[0] + i, e[1] + j, e[2] + k};
   }
 
   PROXY_HOST_DEVICE
-  void vertexCoords(IndexType dofGlobal, FloatType* const coords) const
-  {
+  void vertexCoords(IndexType dofGlobal, FloatType* const coords) const {
     coords[0] = dofGlobal[0] * hx_ + ox_;
     coords[1] = dofGlobal[1] * hy_ + oy_;
     coords[2] = dofGlobal[2] * hz_ + oz_;
   }
 
   PROXY_HOST_DEVICE
-  FloatType nodeCoord(ScalarType dofGlobal, int dim) const final
-  {
+  FloatType nodeCoord(ScalarType dofGlobal, int dim) const final {
     int nodesPerDim[3];
     nodesPerDim[0] = (ex_ * Order) + 1;
     nodesPerDim[1] = (ey_ * Order) + 1;
@@ -150,9 +139,7 @@ class ModelStruct final : public ModelApi<FloatType, ScalarType>
     int elemIdx = nodeIdx[dim] / Order;
     int localIdx = nodeIdx[dim] % Order;
 
-    if (localIdx == Order &&
-        elemIdx < (dim == 0 ? ex_ : (dim == 1 ? ey_ : ez_)) - 1)
-    {
+    if (localIdx == Order && elemIdx < (dim == 0 ? ex_ : (dim == 1 ? ey_ : ez_)) - 1) {
       elemIdx++;
       localIdx = 0;
     }
@@ -160,11 +147,9 @@ class ModelStruct final : public ModelApi<FloatType, ScalarType>
     FloatType gllPoint = GLLPoints::get(Order, localIdx);
     FloatType elementSize = (dim == 0) ? hx_ : ((dim == 1) ? hy_ : hz_);
     FloatType elementStart = elemIdx * elementSize;
-    FloatType physicalCoord =
-        elementStart + (gllPoint + 1.0) * elementSize * 0.5;
+    FloatType physicalCoord = elementStart + (gllPoint + 1.0) * elementSize * 0.5;
 
-    switch (dim)
-    {
+    switch (dim) {
       case 0:
         physicalCoord += ox_;
         break;
@@ -180,8 +165,7 @@ class ModelStruct final : public ModelApi<FloatType, ScalarType>
   }
 
   PROXY_HOST_DEVICE
-  ScalarType globalNodeIndex(ScalarType e, int i, int j, int k) const final
-  {
+  ScalarType globalNodeIndex(ScalarType e, int i, int j, int k) const final {
     ScalarType elemZ = e / (ex_ * ey_);
     ScalarType tmp = e % (ex_ * ey_);
     ScalarType elemY = tmp / ex_;
@@ -200,42 +184,36 @@ class ModelStruct final : public ModelApi<FloatType, ScalarType>
 
   /// @brief Returns Vp at node @p n. Uses stored array when available, else
   /// 1500.
-  PROXY_HOST_DEVICE FloatType getModelVpOnNodes(ScalarType n) const final
-  {
+  PROXY_HOST_DEVICE FloatType getModelVpOnNodes(ScalarType n) const final {
     if (model_vp_node_.extent(0) > 0) return model_vp_node_[n];
     return static_cast<FloatType>(1500);
   }
   /// @brief Returns Vp of element @p e. Uses stored array when available, else
   /// 1500.
-  PROXY_HOST_DEVICE FloatType getModelVpOnElement(ScalarType e) const final
-  {
+  PROXY_HOST_DEVICE FloatType getModelVpOnElement(ScalarType e) const final {
     if (model_vp_element_.extent(0) > 0) return model_vp_element_[e];
     return static_cast<FloatType>(1500);
   }
   /// @brief Returns rho at node @p n. Uses stored array when available, else 1.
-  PROXY_HOST_DEVICE FloatType getModelRhoOnNodes(ScalarType n) const final
-  {
+  PROXY_HOST_DEVICE FloatType getModelRhoOnNodes(ScalarType n) const final {
     if (model_rho_node_.extent(0) > 0) return model_rho_node_[n];
     return static_cast<FloatType>(1);
   }
   /// @brief Returns rho of element @p e. Uses stored array when available,
   /// else 1.
-  PROXY_HOST_DEVICE FloatType getModelRhoOnElement(ScalarType e) const final
-  {
+  PROXY_HOST_DEVICE FloatType getModelRhoOnElement(ScalarType e) const final {
     if (model_rho_element_.extent(0) > 0) return model_rho_element_[e];
     return static_cast<FloatType>(1);
   }
   /// @brief Returns Vs at node @p n. Uses stored array when available, else
   /// 755.
-  PROXY_HOST_DEVICE FloatType getModelVsOnNodes(ScalarType n) const final
-  {
+  PROXY_HOST_DEVICE FloatType getModelVsOnNodes(ScalarType n) const final {
     if (model_vs_node_.extent(0) > 0) return model_vs_node_[n];
     return static_cast<FloatType>(755);
   }
   /// @brief Returns Vs of element @p e. Uses stored array when available, else
   /// 755.
-  PROXY_HOST_DEVICE FloatType getModelVsOnElement(ScalarType e) const final
-  {
+  PROXY_HOST_DEVICE FloatType getModelVsOnElement(ScalarType e) const final {
     if (model_vs_element_.extent(0) > 0) return model_vs_element_[e];
     return static_cast<FloatType>(755);
   }
@@ -249,88 +227,48 @@ class ModelStruct final : public ModelApi<FloatType, ScalarType>
   /// @param vp  P-wave velocity (m/s).
   /// @param vs  S-wave velocity (m/s).
   /// @param rho Density (kg/m³).
-  void setModelNodeProps(ScalarType n, FloatType vp, FloatType vs,
-                         FloatType rho)
-  {
+  void setModelNodeProps(ScalarType n, FloatType vp, FloatType vs, FloatType rho) {
     if (model_vp_node_.extent(0) > 0) model_vp_node_[n] = vp;
     if (model_vs_node_.extent(0) > 0) model_vs_node_[n] = vs;
     if (model_rho_node_.extent(0) > 0) model_rho_node_[n] = rho;
   }
-  PROXY_HOST_DEVICE FloatType getModelQpOnNodes(ScalarType n) const final
-  {
+  PROXY_HOST_DEVICE FloatType getModelQpOnNodes(ScalarType n) const final {
     if (model_qp_node_.extent(0) > 0) return model_qp_node_[n];
     return static_cast<FloatType>(1.0e9);
   }
-  PROXY_HOST_DEVICE FloatType getModelQpOnElement(ScalarType e) const final
-  {
+  PROXY_HOST_DEVICE FloatType getModelQpOnElement(ScalarType e) const final {
     if (model_qp_element_.extent(0) > 0) return model_qp_element_[e];
     return static_cast<FloatType>(1.0e9);
   }
-  PROXY_HOST_DEVICE FloatType getModelQsOnNodes(ScalarType n) const final
-  {
+  PROXY_HOST_DEVICE FloatType getModelQsOnNodes(ScalarType n) const final {
     if (model_qs_node_.extent(0) > 0) return model_qs_node_[n];
     return static_cast<FloatType>(1.0e9);
   }
-  PROXY_HOST_DEVICE FloatType getModelQsOnElement(ScalarType e) const final
-  {
+  PROXY_HOST_DEVICE FloatType getModelQsOnElement(ScalarType e) const final {
     if (model_qs_element_.extent(0) > 0) return model_qs_element_[e];
     return static_cast<FloatType>(1.0e9);
   }
-  PROXY_HOST_DEVICE FloatType getModelDeltaOnNodes(ScalarType n) const final
-  {
-    return 0.0;
-  }
-  PROXY_HOST_DEVICE FloatType getModelDeltaOnElement(ScalarType e) const final
-  {
-    return 0.0;
-  }
-  PROXY_HOST_DEVICE FloatType getModelEpsilonOnNodes(ScalarType n) const final
-  {
-    return 0.0;
-  }
-  PROXY_HOST_DEVICE FloatType getModelEpsilonOnElement(ScalarType e) const final
-  {
-    return 0.0;
-  }
-  PROXY_HOST_DEVICE FloatType getModelGammaOnNodes(ScalarType n) const final
-  {
-    return 0.0;
-  }
-  PROXY_HOST_DEVICE FloatType getModelGammaOnElement(ScalarType e) const final
-  {
-    return 0.0;
-  }
-  PROXY_HOST_DEVICE ScalarType getModelThetaOnNodes(ScalarType n) const final
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE ScalarType getModelThetaOnElement(ScalarType e) const final
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE ScalarType getModelPhiOnNodes(ScalarType n) const final
-  {
-    return 0.0;
-  }
-  PROXY_HOST_DEVICE ScalarType getModelPhiOnElement(ScalarType e) const final
-  {
-    return 0.0;
-  }
+  PROXY_HOST_DEVICE FloatType getModelDeltaOnNodes(ScalarType n) const final { return 0.0; }
+  PROXY_HOST_DEVICE FloatType getModelDeltaOnElement(ScalarType e) const final { return 0.0; }
+  PROXY_HOST_DEVICE FloatType getModelEpsilonOnNodes(ScalarType n) const final { return 0.0; }
+  PROXY_HOST_DEVICE FloatType getModelEpsilonOnElement(ScalarType e) const final { return 0.0; }
+  PROXY_HOST_DEVICE FloatType getModelGammaOnNodes(ScalarType n) const final { return 0.0; }
+  PROXY_HOST_DEVICE FloatType getModelGammaOnElement(ScalarType e) const final { return 0.0; }
+  PROXY_HOST_DEVICE ScalarType getModelThetaOnNodes(ScalarType n) const final { return 0; }
+  PROXY_HOST_DEVICE ScalarType getModelThetaOnElement(ScalarType e) const final { return 0; }
+  PROXY_HOST_DEVICE ScalarType getModelPhiOnNodes(ScalarType n) const final { return 0.0; }
+  PROXY_HOST_DEVICE ScalarType getModelPhiOnElement(ScalarType e) const final { return 0.0; }
 
-  void initElasticityTensors(AnisotropyType anisotropy_type) override
-  {
+  void initElasticityTensors(AnisotropyType anisotropy_type) override {
     if (!isElastic_) return;
 
-    if (anisotropy_type == AnisotropyType::kIso ||
-        anisotropy_type == AnisotropyType::kVTI)
-    {
+    if (anisotropy_type == AnisotropyType::kIso || anisotropy_type == AnisotropyType::kVTI) {
       // No precomputation needed for ISOTROPIC and VTI, computed on-the-fly
       // inside solver
       return;
     }
 
-    if (anisotropy_type == AnisotropyType::kTTI)
-    {
+    if (anisotropy_type == AnisotropyType::kTTI) {
       int n_element = ex_ * ey_ * ez_;
 
       model_C_tensor_element_ = allocateArray3D<array3DReal>(n_element, 6, 6);
@@ -339,9 +277,7 @@ class ModelStruct final : public ModelApi<FloatType, ScalarType>
 
       Kokkos::parallel_for(
           "Model init ElasticTensors",
-          Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock,
-                                                   LaunchMinBlocksPerSM>>(
-              0, n_element),
+          Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(0, n_element),
           KOKKOS_LAMBDA(const int i) {
             FloatType CTTI[6][6];
 
@@ -354,8 +290,7 @@ class ModelStruct final : public ModelApi<FloatType, ScalarType>
             FloatType theta = 0.0;
             FloatType phi = 0.0;
 
-            computeCTensor(vp, vs, rho, delta, epsilon, gamma, theta, phi,
-                           CTTI);
+            computeCTensor(vp, vs, rho, delta, epsilon, gamma, theta, phi, CTTI);
 
             for (int k = 0; k < 6; k++)
               for (int l = 0; l < 6; l++) C_tensor(i, k, l) = CTTI[k][l];
@@ -364,8 +299,7 @@ class ModelStruct final : public ModelApi<FloatType, ScalarType>
   }
 
   PROXY_HOST_DEVICE
-  void getCTensorOnElement(ScalarType e, FloatType CTTI[6][6]) const final
-  {
+  void getCTensorOnElement(ScalarType e, FloatType CTTI[6][6]) const final {
     for (int i = 0; i < 6; i++)
       for (int j = 0; j < 6; j++) CTTI[i][j] = model_C_tensor_element_(e, i, j);
   }
@@ -374,24 +308,15 @@ class ModelStruct final : public ModelApi<FloatType, ScalarType>
   // MESH QUERIES
   // ============================================================================
 
-  PROXY_HOST_DEVICE ScalarType getNumberOfElements() const final
-  {
-    return ex_ * ey_ * ez_;
-  }
-  PROXY_HOST_DEVICE ScalarType getNumberOfNodes() const final
-  {
+  PROXY_HOST_DEVICE ScalarType getNumberOfElements() const final { return ex_ * ey_ * ez_; }
+  PROXY_HOST_DEVICE ScalarType getNumberOfNodes() const final {
     return (Order * ex_ + 1) * (Order * ey_ + 1) * (Order * ez_ + 1);
   }
-  PROXY_HOST_DEVICE int getNumberOfPointsPerElement() const final
-  {
-    return (Order + 1) * (Order + 1) * (Order + 1);
-  }
+  PROXY_HOST_DEVICE int getNumberOfPointsPerElement() const final { return (Order + 1) * (Order + 1) * (Order + 1); }
   PROXY_HOST_DEVICE int getOrder() const final { return Order; }
 
   PROXY_HOST_DEVICE
-  void faceNormal(ScalarType e, CubicFace local_face,
-                  FloatType v[3]) const final
-  {
+  void faceNormal(ScalarType e, CubicFace local_face, FloatType v[3]) const final {
     v[0] = 0.0;
     v[1] = 0.0;
     v[2] = 0.0;
@@ -400,10 +325,8 @@ class ModelStruct final : public ModelApi<FloatType, ScalarType>
     v[direction] = sign;
   }
 
-  PROXY_HOST_DEVICE FloatType domainSize(int dim) const final
-  {
-    switch (dim)
-    {
+  PROXY_HOST_DEVICE FloatType domainSize(int dim) const final {
+    switch (dim) {
       case 0:
         return lx_;
       case 1:
@@ -415,8 +338,7 @@ class ModelStruct final : public ModelApi<FloatType, ScalarType>
     }
   }
 
-  PROXY_HOST_DEVICE FloatType getMinSpacing() const final
-  {
+  PROXY_HOST_DEVICE FloatType getMinSpacing() const final {
     const FloatType h = min(hx_, min(hy_, hz_));
     if constexpr (Order == 1) return h;
     if constexpr (Order == 2) return h * 0.5000000000;
@@ -431,10 +353,7 @@ class ModelStruct final : public ModelApi<FloatType, ScalarType>
   }
 
   FloatType getMaxSpeed() const final { return 1500; }
-  PROXY_HOST_DEVICE bool isModelOnNodes() const final
-  {
-    return isModelOnNodes_;
-  }
+  PROXY_HOST_DEVICE bool isModelOnNodes() const final { return isModelOnNodes_; }
   PROXY_HOST_DEVICE bool isElastic() const final { return isElastic_; }
 
   // ============================================================================
@@ -442,28 +361,22 @@ class ModelStruct final : public ModelApi<FloatType, ScalarType>
   // ============================================================================
 
   PROXY_HOST_DEVICE
-  BoundaryFlag boundaryType(ScalarType n) const override
-  {
+  BoundaryFlag boundaryType(ScalarType n) const override {
     if (boundaries_t_.extent(0) == 0) return BoundaryFlag::InteriorNode;
     return static_cast<BoundaryFlag>(boundaries_t_(n));
   }
 
   PROXY_HOST_DEVICE
-  bool isFreeSurface(ScalarType n) const override
-  {
+  bool isFreeSurface(ScalarType n) const override {
     if (boundaries_t_.extent(0) == 0) return false;
     return boundaries_t_(n) == static_cast<ScalarType>(BoundaryFlag::Surface);
   }
 
-  void setQualityFactors(FloatType qp, FloatType qs) override
-  {
+  void setQualityFactors(FloatType qp, FloatType qs) override {
     ScalarType nElem = getNumberOfElements();
-    model_qp_element_ =
-        allocateVector<VECTOR_REAL_VIEW>(nElem, "model_qp_element");
-    model_qs_element_ =
-        allocateVector<VECTOR_REAL_VIEW>(nElem, "model_qs_element");
-    for (ScalarType e = 0; e < nElem; ++e)
-    {
+    model_qp_element_ = allocateVector<VECTOR_REAL_VIEW>(nElem, "model_qp_element");
+    model_qs_element_ = allocateVector<VECTOR_REAL_VIEW>(nElem, "model_qs_element");
+    for (ScalarType e = 0; e < nElem; ++e) {
       model_qp_element_(e) = qp;
       model_qs_element_(e) = qs;
     }
@@ -475,60 +388,39 @@ class ModelStruct final : public ModelApi<FloatType, ScalarType>
    * Pour ModelStruct : réinitialise FaceConnectivityStruct avec ex/ey/ez.
    * Aucune allocation — tout sera calculé à la volée par formules cartésiennes.
    */
-  void buildFaceConnectivity() override
-  {
-    face_connectivity_ =
-        FaceConnectivityStruct<FloatType, ScalarType>(ex_, ey_, ez_, Order);
+  void buildFaceConnectivity() override {
+    face_connectivity_ = FaceConnectivityStruct<FloatType, ScalarType>(ex_, ey_, ez_, Order);
   }
 
-  PROXY_HOST_DEVICE ScalarType getNumberOfFaces() const override
-  {
-    return face_connectivity_.getNumberOfFaces();
-  }
+  PROXY_HOST_DEVICE ScalarType getNumberOfFaces() const override { return face_connectivity_.getNumberOfFaces(); }
 
-  PROXY_HOST_DEVICE ScalarType
-  getGlobalFace(ScalarType elem, CubicFace local_face) const override
-  {
+  PROXY_HOST_DEVICE ScalarType getGlobalFace(ScalarType elem, CubicFace local_face) const override {
     return face_connectivity_.getGlobalFace(elem, local_face);
   }
 
-  PROXY_HOST_DEVICE ScalarType
-  getGlobalNodeFromFace(ScalarType face_id, int local_dof) const override
-  {
+  PROXY_HOST_DEVICE ScalarType getGlobalNodeFromFace(ScalarType face_id, int local_dof) const override {
     return face_connectivity_.getGlobalNodeFromFace(face_id, local_dof);
   }
 
-  PROXY_HOST_DEVICE bool isBoundaryFace(ScalarType face_id) const override
-  {
-    if (boundaries_t_.extent(0) == 0)
-      return face_connectivity_.isBoundaryFace(face_id);
+  PROXY_HOST_DEVICE bool isBoundaryFace(ScalarType face_id) const override {
+    if (boundaries_t_.extent(0) == 0) return face_connectivity_.isBoundaryFace(face_id);
     int const n_dofs = face_connectivity_.getDofsPerFace();
-    for (int q = 0; q < n_dofs; ++q)
-    {
-      if (boundaries_t_(getGlobalNodeFromFace(face_id, q)) ==
-          static_cast<ScalarType>(BoundaryFlag::InteriorNode))
+    for (int q = 0; q < n_dofs; ++q) {
+      if (boundaries_t_(getGlobalNodeFromFace(face_id, q)) == static_cast<ScalarType>(BoundaryFlag::InteriorNode))
         return false;
     }
     return true;
   }
 
-  PROXY_HOST_DEVICE ScalarType elemOwner(ScalarType face_id) const
-  {
-    return face_connectivity_.elemOwner(face_id);
-  }
+  PROXY_HOST_DEVICE ScalarType elemOwner(ScalarType face_id) const { return face_connectivity_.elemOwner(face_id); }
 
-  PROXY_HOST_DEVICE ScalarType elemNeighbor(ScalarType face_id) const
-  {
+  PROXY_HOST_DEVICE ScalarType elemNeighbor(ScalarType face_id) const {
     return face_connectivity_.elemNeighbor(face_id);
   }
 
-  PROXY_HOST_DEVICE int localFaceOwner(ScalarType face_id) const
-  {
-    return face_connectivity_.localFaceOwner(face_id);
-  }
+  PROXY_HOST_DEVICE int localFaceOwner(ScalarType face_id) const { return face_connectivity_.localFaceOwner(face_id); }
 
-  PROXY_HOST_DEVICE int localFaceNeighbor(ScalarType face_id) const
-  {
+  PROXY_HOST_DEVICE int localFaceNeighbor(ScalarType face_id) const {
     return face_connectivity_.localFaceNeighbor(face_id);
   }
 

--- a/src/model/mesh/impl/model/struct/src/model_struct.cc
+++ b/src/model/mesh/impl/model/struct/src/model_struct.cc
@@ -1,7 +1,6 @@
 #include "model_struct.h"
 
-namespace model
-{
+namespace model {
 template class ModelStruct<float, int, 1>;
 template class ModelStruct<float, int, 2>;
 template class ModelStruct<float, int, 3>;

--- a/src/model/mesh/impl/model/unstruct/include/face_connectivity_unstruct.h
+++ b/src/model/mesh/impl/model/unstruct/include/face_connectivity_unstruct.h
@@ -6,8 +6,7 @@
 
 #include "face_connectivity.h"
 
-namespace model
-{
+namespace model {
 
 /**
  * @brief Data structure for unstructured face connectivity initialization
@@ -16,8 +15,7 @@ namespace model
  * Same pattern as ModelUnstructData.
  */
 template <typename FloatType, typename ScalarType>
-struct FaceConnectivityUnstructData
-{
+struct FaceConnectivityUnstructData {
   ScalarType n_faces = 0;
   int ndofs_per_face = 0;
 
@@ -39,9 +37,7 @@ struct FaceConnectivityUnstructData
  * @tparam ScalarType Integer type for indexing
  */
 template <typename FloatType, typename ScalarType>
-class FaceConnectivityUnstruct
-    : public FaceConnectivityApi<FloatType, ScalarType>
-{
+class FaceConnectivityUnstruct : public FaceConnectivityApi<FloatType, ScalarType> {
  public:
   FaceConnectivityUnstruct() = default;
 
@@ -49,8 +45,7 @@ class FaceConnectivityUnstruct
    * @brief Construct from data structure (for Python injection)
    */
   PROXY_HOST_DEVICE
-  FaceConnectivityUnstruct(
-      const FaceConnectivityUnstructData<FloatType, ScalarType>& data)
+  FaceConnectivityUnstruct(const FaceConnectivityUnstructData<FloatType, ScalarType>& data)
       : n_faces_(data.n_faces),
         ndofs_per_face_(data.ndofs_per_face),
         elem_to_faces_(data.elem_to_faces),
@@ -58,9 +53,7 @@ class FaceConnectivityUnstruct
         face_elem_owner_(data.face_elem_owner),
         face_elem_neighbor_(data.face_elem_neighbor),
         face_local_owner_(data.face_local_owner),
-        face_local_neighbor_(data.face_local_neighbor)
-  {
-  }
+        face_local_neighbor_(data.face_local_neighbor) {}
 
   /**
    * @brief Build face connectivity from mesh
@@ -68,8 +61,7 @@ class FaceConnectivityUnstruct
    * Extracts faces from elements, identifies unique faces, and fills
    * connectivity tables using a map-based approach.
    */
-  void build(const ModelApi<FloatType, ScalarType>& mesh)
-  {
+  void build(const ModelApi<FloatType, ScalarType>& mesh) {
     const ScalarType n_element = mesh.getNumberOfElements();
     const int order = mesh.getOrder();
     const ScalarType max_faces = n_element * 6;
@@ -77,8 +69,7 @@ class FaceConnectivityUnstruct
 
     // Temporary arrays at maximum size
     auto elem_to_faces_temp = allocateArray2D<ARRAY_INT_VIEW>(n_element, 6);
-    auto face_dofs_temp =
-        allocateArray2D<ARRAY_INT_VIEW>(max_faces, ndofs_per_face_);
+    auto face_dofs_temp = allocateArray2D<ARRAY_INT_VIEW>(max_faces, ndofs_per_face_);
     auto face_elem_owner_temp = allocateVector<VECTOR_INT_VIEW>(max_faces);
     auto face_elem_neighbor_temp = allocateVector<VECTOR_INT_VIEW>(max_faces);
     auto face_local_owner_temp = allocateVector<VECTOR_INT_VIEW>(max_faces);
@@ -90,68 +81,53 @@ class FaceConnectivityUnstruct
     std::map<FaceKey, ScalarType> face_map;
     ScalarType face_count = 0;
 
-    for (ScalarType elem = 0; elem < n_element; ++elem)
-    {
-      for (int lf = 0; lf < 6; ++lf)
-      {
+    for (ScalarType elem = 0; elem < n_element; ++elem) {
+      for (int lf = 0; lf < 6; ++lf) {
         CubicFace local_face = static_cast<CubicFace>(lf);
         auto corners = extractFaceCorners(mesh, elem, local_face);
         auto face_key = makeFaceKey(corners);
 
         auto it = face_map.find(face_key);
-        if (it == face_map.end())
-        {
+        if (it == face_map.end()) {
           ScalarType face_id = face_count++;
           face_map[face_key] = face_id;
 
           // Fill face DOFs
           int idx = 0;
-          switch (local_face)
-          {
+          switch (local_face) {
             case CubicFace::kXMinus:
               for (int k = 0; k <= order; ++k)
-                for (int j = 0; j <= order; ++j)
-                  face_dofs_temp(face_id, idx++) =
-                      mesh.globalNodeIndex(elem, 0, j, k);
+                for (int j = 0; j <= order; ++j) face_dofs_temp(face_id, idx++) = mesh.globalNodeIndex(elem, 0, j, k);
               break;
             case CubicFace::kXPlus:
               for (int k = 0; k <= order; ++k)
                 for (int j = 0; j <= order; ++j)
-                  face_dofs_temp(face_id, idx++) =
-                      mesh.globalNodeIndex(elem, order, j, k);
+                  face_dofs_temp(face_id, idx++) = mesh.globalNodeIndex(elem, order, j, k);
               break;
             case CubicFace::kYMinus:
               for (int k = 0; k <= order; ++k)
-                for (int i = 0; i <= order; ++i)
-                  face_dofs_temp(face_id, idx++) =
-                      mesh.globalNodeIndex(elem, i, 0, k);
+                for (int i = 0; i <= order; ++i) face_dofs_temp(face_id, idx++) = mesh.globalNodeIndex(elem, i, 0, k);
               break;
             case CubicFace::kYPlus:
               for (int k = 0; k <= order; ++k)
                 for (int i = 0; i <= order; ++i)
-                  face_dofs_temp(face_id, idx++) =
-                      mesh.globalNodeIndex(elem, i, order, k);
+                  face_dofs_temp(face_id, idx++) = mesh.globalNodeIndex(elem, i, order, k);
               break;
             case CubicFace::kZMinus:
               for (int j = 0; j <= order; ++j)
-                for (int i = 0; i <= order; ++i)
-                  face_dofs_temp(face_id, idx++) =
-                      mesh.globalNodeIndex(elem, i, j, 0);
+                for (int i = 0; i <= order; ++i) face_dofs_temp(face_id, idx++) = mesh.globalNodeIndex(elem, i, j, 0);
               break;
             case CubicFace::kZPlus:
               for (int j = 0; j <= order; ++j)
                 for (int i = 0; i <= order; ++i)
-                  face_dofs_temp(face_id, idx++) =
-                      mesh.globalNodeIndex(elem, i, j, order);
+                  face_dofs_temp(face_id, idx++) = mesh.globalNodeIndex(elem, i, j, order);
               break;
           }
 
           face_elem_owner_temp(face_id) = elem;
           face_local_owner_temp(face_id) = lf;
           elem_to_faces_temp(elem, lf) = face_id;
-        }
-        else
-        {
+        } else {
           ScalarType face_id = it->second;
           face_elem_neighbor_temp(face_id) = elem;
           face_local_neighbor_temp(face_id) = lf;
@@ -170,17 +146,14 @@ class FaceConnectivityUnstruct
     face_local_neighbor_ = allocateVector<VECTOR_INT_VIEW>(face_count);
 
     for (ScalarType elem = 0; elem < n_element; ++elem)
-      for (int lf = 0; lf < 6; ++lf)
-        elem_to_faces_(elem, lf) = elem_to_faces_temp(elem, lf);
+      for (int lf = 0; lf < 6; ++lf) elem_to_faces_(elem, lf) = elem_to_faces_temp(elem, lf);
 
-    for (ScalarType f = 0; f < face_count; ++f)
-    {
+    for (ScalarType f = 0; f < face_count; ++f) {
       face_elem_owner_(f) = face_elem_owner_temp(f);
       face_elem_neighbor_(f) = face_elem_neighbor_temp(f);
       face_local_owner_(f) = face_local_owner_temp(f);
       face_local_neighbor_(f) = face_local_neighbor_temp(f);
-      for (int dof = 0; dof < ndofs_per_face_; ++dof)
-        face_dofs_(f, dof) = face_dofs_temp(f, dof);
+      for (int dof = 0; dof < ndofs_per_face_; ++dof) face_dofs_(f, dof) = face_dofs_temp(f, dof);
     }
   }
 
@@ -188,52 +161,29 @@ class FaceConnectivityUnstruct
   // FaceConnectivityApi implementation
   // ==========================================================================
 
-  PROXY_HOST_DEVICE ScalarType getNumberOfFaces() const override
-  {
-    return n_faces_;
-  }
+  PROXY_HOST_DEVICE ScalarType getNumberOfFaces() const override { return n_faces_; }
 
-  PROXY_HOST_DEVICE int getDofsPerFace() const override
-  {
-    return ndofs_per_face_;
-  }
+  PROXY_HOST_DEVICE int getDofsPerFace() const override { return ndofs_per_face_; }
 
-  PROXY_HOST_DEVICE ScalarType
-  getGlobalFace(ScalarType elem, CubicFace local_face) const override
-  {
+  PROXY_HOST_DEVICE ScalarType getGlobalFace(ScalarType elem, CubicFace local_face) const override {
     return elem_to_faces_(elem, static_cast<int>(local_face));
   }
 
-  PROXY_HOST_DEVICE ScalarType
-  getGlobalNodeFromFace(ScalarType face_id, int local_dof) const override
-  {
+  PROXY_HOST_DEVICE ScalarType getGlobalNodeFromFace(ScalarType face_id, int local_dof) const override {
     return face_dofs_(face_id, local_dof);
   }
 
-  PROXY_HOST_DEVICE bool isBoundaryFace(ScalarType face_id) const override
-  {
+  PROXY_HOST_DEVICE bool isBoundaryFace(ScalarType face_id) const override {
     return face_elem_neighbor_(face_id) == -1;
   }
 
-  PROXY_HOST_DEVICE ScalarType elemOwner(ScalarType face_id) const override
-  {
-    return face_elem_owner_(face_id);
-  }
+  PROXY_HOST_DEVICE ScalarType elemOwner(ScalarType face_id) const override { return face_elem_owner_(face_id); }
 
-  PROXY_HOST_DEVICE ScalarType elemNeighbor(ScalarType face_id) const override
-  {
-    return face_elem_neighbor_(face_id);
-  }
+  PROXY_HOST_DEVICE ScalarType elemNeighbor(ScalarType face_id) const override { return face_elem_neighbor_(face_id); }
 
-  PROXY_HOST_DEVICE int localFaceOwner(ScalarType face_id) const override
-  {
-    return face_local_owner_(face_id);
-  }
+  PROXY_HOST_DEVICE int localFaceOwner(ScalarType face_id) const override { return face_local_owner_(face_id); }
 
-  PROXY_HOST_DEVICE int localFaceNeighbor(ScalarType face_id) const override
-  {
-    return face_local_neighbor_(face_id);
-  }
+  PROXY_HOST_DEVICE int localFaceNeighbor(ScalarType face_id) const override { return face_local_neighbor_(face_id); }
 
  private:
   ScalarType n_faces_ = 0;
@@ -247,50 +197,33 @@ class FaceConnectivityUnstruct
   VECTOR_INT_VIEW face_local_neighbor_;
 
   // Helper methods for build()
-  static std::array<ScalarType, 4> extractFaceCorners(
-      const ModelApi<FloatType, ScalarType>& mesh, ScalarType elem,
-      CubicFace local_face)
-  {
+  static std::array<ScalarType, 4> extractFaceCorners(const ModelApi<FloatType, ScalarType>& mesh, ScalarType elem,
+                                                      CubicFace local_face) {
     const int o = mesh.getOrder();
-    switch (local_face)
-    {
+    switch (local_face) {
       case CubicFace::kXMinus:
-        return {mesh.globalNodeIndex(elem, 0, 0, 0),
-                mesh.globalNodeIndex(elem, 0, o, 0),
-                mesh.globalNodeIndex(elem, 0, o, o),
-                mesh.globalNodeIndex(elem, 0, 0, o)};
+        return {mesh.globalNodeIndex(elem, 0, 0, 0), mesh.globalNodeIndex(elem, 0, o, 0),
+                mesh.globalNodeIndex(elem, 0, o, o), mesh.globalNodeIndex(elem, 0, 0, o)};
       case CubicFace::kXPlus:
-        return {mesh.globalNodeIndex(elem, o, 0, 0),
-                mesh.globalNodeIndex(elem, o, o, 0),
-                mesh.globalNodeIndex(elem, o, o, o),
-                mesh.globalNodeIndex(elem, o, 0, o)};
+        return {mesh.globalNodeIndex(elem, o, 0, 0), mesh.globalNodeIndex(elem, o, o, 0),
+                mesh.globalNodeIndex(elem, o, o, o), mesh.globalNodeIndex(elem, o, 0, o)};
       case CubicFace::kYMinus:
-        return {mesh.globalNodeIndex(elem, 0, 0, 0),
-                mesh.globalNodeIndex(elem, o, 0, 0),
-                mesh.globalNodeIndex(elem, o, 0, o),
-                mesh.globalNodeIndex(elem, 0, 0, o)};
+        return {mesh.globalNodeIndex(elem, 0, 0, 0), mesh.globalNodeIndex(elem, o, 0, 0),
+                mesh.globalNodeIndex(elem, o, 0, o), mesh.globalNodeIndex(elem, 0, 0, o)};
       case CubicFace::kYPlus:
-        return {mesh.globalNodeIndex(elem, 0, o, 0),
-                mesh.globalNodeIndex(elem, o, o, 0),
-                mesh.globalNodeIndex(elem, o, o, o),
-                mesh.globalNodeIndex(elem, 0, o, o)};
+        return {mesh.globalNodeIndex(elem, 0, o, 0), mesh.globalNodeIndex(elem, o, o, 0),
+                mesh.globalNodeIndex(elem, o, o, o), mesh.globalNodeIndex(elem, 0, o, o)};
       case CubicFace::kZMinus:
-        return {mesh.globalNodeIndex(elem, 0, 0, 0),
-                mesh.globalNodeIndex(elem, o, 0, 0),
-                mesh.globalNodeIndex(elem, o, o, 0),
-                mesh.globalNodeIndex(elem, 0, o, 0)};
+        return {mesh.globalNodeIndex(elem, 0, 0, 0), mesh.globalNodeIndex(elem, o, 0, 0),
+                mesh.globalNodeIndex(elem, o, o, 0), mesh.globalNodeIndex(elem, 0, o, 0)};
       case CubicFace::kZPlus:
-        return {mesh.globalNodeIndex(elem, 0, 0, o),
-                mesh.globalNodeIndex(elem, o, 0, o),
-                mesh.globalNodeIndex(elem, o, o, o),
-                mesh.globalNodeIndex(elem, 0, o, o)};
+        return {mesh.globalNodeIndex(elem, 0, 0, o), mesh.globalNodeIndex(elem, o, 0, o),
+                mesh.globalNodeIndex(elem, o, o, o), mesh.globalNodeIndex(elem, 0, o, o)};
     }
     return {};
   }
 
-  static std::array<ScalarType, 4> makeFaceKey(
-      std::array<ScalarType, 4> corners)
-  {
+  static std::array<ScalarType, 4> makeFaceKey(std::array<ScalarType, 4> corners) {
     std::sort(corners.begin(), corners.end());
     return corners;
   }

--- a/src/model/mesh/impl/model/unstruct/include/model_unstruct.h
+++ b/src/model/mesh/impl/model/unstruct/include/model_unstruct.h
@@ -9,46 +9,35 @@
 
 #include "face_connectivity_unstruct.h"
 
-namespace model
-{
+namespace model {
 
 /**
  * @brief Data structure for unstructured mesh initialization
  */
 template <typename FloatType, typename ScalarType>
-struct ModelUnstructData : public ModelDataBase<FloatType, ScalarType>
-{
+struct ModelUnstructData : public ModelDataBase<FloatType, ScalarType> {
   PROXY_HOST_DEVICE ModelUnstructData() = default;
   PROXY_HOST_DEVICE ~ModelUnstructData() = default;
   PROXY_HOST_DEVICE ModelUnstructData(const ModelUnstructData&) = default;
-  PROXY_HOST_DEVICE ModelUnstructData& operator=(const ModelUnstructData&) =
-      default;
+  PROXY_HOST_DEVICE ModelUnstructData& operator=(const ModelUnstructData&) = default;
 
   /**
    * @brief Full constructor with all mesh data
    */
   PROXY_HOST_DEVICE
   ModelUnstructData(
-      ScalarType order, ScalarType n_element, ScalarType n_node, FloatType lx,
-      FloatType ly, FloatType lz, bool isModelOnNodes, bool isElastic,
-      ARRAY_INT_VIEW global_node_index, VECTOR_REAL_VIEW nodes_coords_x,
-      VECTOR_REAL_VIEW nodes_coords_y, VECTOR_REAL_VIEW nodes_coords_z,
-      VECTOR_REAL_VIEW model_vp_node, VECTOR_REAL_VIEW model_vp_element,
-      VECTOR_REAL_VIEW model_rho_node, VECTOR_REAL_VIEW model_rho_element,
-      VECTOR_REAL_VIEW model_vs_node, VECTOR_REAL_VIEW model_vs_element,
-      VECTOR_REAL_VIEW model_delta_node, VECTOR_REAL_VIEW model_delta_element,
-      VECTOR_REAL_VIEW model_epsilon_node,
-      VECTOR_REAL_VIEW model_epsilon_element, VECTOR_REAL_VIEW model_gamma_node,
-      VECTOR_REAL_VIEW model_gamma_element, VECTOR_REAL_VIEW model_theta_node,
-      VECTOR_REAL_VIEW model_theta_element, VECTOR_REAL_VIEW model_phi_node,
-      VECTOR_REAL_VIEW model_phi_element,
+      ScalarType order, ScalarType n_element, ScalarType n_node, FloatType lx, FloatType ly, FloatType lz,
+      bool isModelOnNodes, bool isElastic, ARRAY_INT_VIEW global_node_index, VECTOR_REAL_VIEW nodes_coords_x,
+      VECTOR_REAL_VIEW nodes_coords_y, VECTOR_REAL_VIEW nodes_coords_z, VECTOR_REAL_VIEW model_vp_node,
+      VECTOR_REAL_VIEW model_vp_element, VECTOR_REAL_VIEW model_rho_node, VECTOR_REAL_VIEW model_rho_element,
+      VECTOR_REAL_VIEW model_vs_node, VECTOR_REAL_VIEW model_vs_element, VECTOR_REAL_VIEW model_delta_node,
+      VECTOR_REAL_VIEW model_delta_element, VECTOR_REAL_VIEW model_epsilon_node, VECTOR_REAL_VIEW model_epsilon_element,
+      VECTOR_REAL_VIEW model_gamma_node, VECTOR_REAL_VIEW model_gamma_element, VECTOR_REAL_VIEW model_theta_node,
+      VECTOR_REAL_VIEW model_theta_element, VECTOR_REAL_VIEW model_phi_node, VECTOR_REAL_VIEW model_phi_element,
       ARRAY3D_REAL_VIEW model_C_tensor_element, VECTOR_INT_VIEW boundaries_t,
-      VECTOR_REAL_VIEW model_qp_node = VECTOR_REAL_VIEW(),
-      VECTOR_REAL_VIEW model_qp_element = VECTOR_REAL_VIEW(),
-      VECTOR_REAL_VIEW model_qs_node = VECTOR_REAL_VIEW(),
-      VECTOR_REAL_VIEW model_qs_element = VECTOR_REAL_VIEW(),
-      FaceConnectivityUnstructData<FloatType, ScalarType> face_connectivity =
-          {})
+      VECTOR_REAL_VIEW model_qp_node = VECTOR_REAL_VIEW(), VECTOR_REAL_VIEW model_qp_element = VECTOR_REAL_VIEW(),
+      VECTOR_REAL_VIEW model_qs_node = VECTOR_REAL_VIEW(), VECTOR_REAL_VIEW model_qs_element = VECTOR_REAL_VIEW(),
+      FaceConnectivityUnstructData<FloatType, ScalarType> face_connectivity = {})
       : order_(order),
         n_element_(n_element),
         n_node_(n_node),
@@ -83,9 +72,7 @@ struct ModelUnstructData : public ModelDataBase<FloatType, ScalarType>
         model_phi_element_(model_phi_element),
         model_C_tensor_element_(model_C_tensor_element),
         boundaries_t_(boundaries_t),
-        face_connectivity_(face_connectivity)
-  {
-  }
+        face_connectivity_(face_connectivity) {}
 
   FloatType origin_x_{0}, origin_y_{0}, origin_z_{0};
   FloatType ox_, oy_, oz_;  // Local origin
@@ -131,8 +118,7 @@ struct ModelUnstructData : public ModelDataBase<FloatType, ScalarType>
  * @brief Unstructured 3D hexahedral mesh implementation
  */
 template <typename FloatType, typename ScalarType>
-class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
-{
+class ModelUnstruct final : public ModelApi<FloatType, ScalarType> {
  public:
   using IndexType = int;
 
@@ -141,8 +127,7 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
   /**
    * @brief Construct from data structure
    */
-  PROXY_HOST_DEVICE ModelUnstruct(
-      const ModelUnstructData<FloatType, ScalarType>& data)
+  PROXY_HOST_DEVICE ModelUnstruct(const ModelUnstructData<FloatType, ScalarType>& data)
       : order_(data.order_),
         n_element_(data.n_element_),
         n_node_(data.n_node_),
@@ -181,9 +166,7 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
         model_C_tensor_element_(data.model_C_tensor_element_),
         boundaries_t_(data.boundaries_t_),
         face_connectivity_(data.face_connectivity_),
-        n_points_per_element_((order_ + 1) * (order_ + 1) * (order_ + 1))
-  {
-  }
+        n_points_per_element_((order_ + 1) * (order_ + 1) * (order_ + 1)) {}
 
   PROXY_HOST_DEVICE ModelUnstruct& operator=(const ModelUnstruct&) = default;
   PROXY_HOST_DEVICE ~ModelUnstruct() = default;
@@ -205,14 +188,11 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
    * @return Global vertex index
    */
   PROXY_HOST_DEVICE
-  IndexType globalVertexIndex(IndexType e, int const i, int const j,
-                              int const k) const
-  {
+  IndexType globalVertexIndex(IndexType e, int const i, int const j, int const k) const {
     int local_i = i * order_;
     int local_j = j * order_;
     int local_k = k * order_;
-    const auto localDofIndex = local_i + local_j * (order_ + 1) +
-                               local_k * (order_ + 1) * (order_ + 1);
+    const auto localDofIndex = local_i + local_j * (order_ + 1) + local_k * (order_ + 1) * (order_ + 1);
     return global_node_index_(e, localDofIndex);
   }
 
@@ -222,8 +202,7 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
    * @param coords Output array for coordinates [x, y, z]
    */
   PROXY_HOST_DEVICE
-  void vertexCoords(IndexType dofGlobal, FloatType* const coords) const
-  {
+  void vertexCoords(IndexType dofGlobal, FloatType* const coords) const {
     coords[0] = nodes_coords_x_[dofGlobal];
     coords[1] = nodes_coords_y_[dofGlobal];
     coords[2] = nodes_coords_z_[dofGlobal];
@@ -236,10 +215,8 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
    * @return Coordinate value
    */
   PROXY_HOST_DEVICE
-  FloatType nodeCoord(ScalarType dofGlobal, int dim) const final
-  {
-    switch (dim)
-    {
+  FloatType nodeCoord(ScalarType dofGlobal, int dim) const final {
+    switch (dim) {
       case 0: {
         return nodes_coords_x_[dofGlobal];
       }
@@ -263,10 +240,8 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
    * @return Global node index
    */
   PROXY_HOST_DEVICE
-  ScalarType globalNodeIndex(ScalarType e, int i, int j, int k) const final
-  {
-    const auto localDofIndex =
-        i + j * (order_ + 1) + k * (order_ + 1) * (order_ + 1);
+  ScalarType globalNodeIndex(ScalarType e, int i, int j, int k) const final {
+    const auto localDofIndex = i + j * (order_ + 1) + k * (order_ + 1) * (order_ + 1);
     return global_node_index_(e, localDofIndex);
   }
 
@@ -275,60 +250,42 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
    * @param n Node index
    * @return P-wave velocity (m/s)
    */
-  PROXY_HOST_DEVICE FloatType getModelVpOnNodes(ScalarType n) const final
-  {
-    return model_vp_node_[n];
-  }
+  PROXY_HOST_DEVICE FloatType getModelVpOnNodes(ScalarType n) const final { return model_vp_node_[n]; }
 
   /**
    * @brief Get P-wave velocity at element
    * @param e Element index
    * @return P-wave velocity (m/s)
    */
-  PROXY_HOST_DEVICE FloatType getModelVpOnElement(ScalarType e) const final
-  {
-    return model_vp_element_[e];
-  }
+  PROXY_HOST_DEVICE FloatType getModelVpOnElement(ScalarType e) const final { return model_vp_element_[e]; }
 
   /**
    * @brief Get density at node
    * @param n Node index
    * @return Density (kg/m³)
    */
-  PROXY_HOST_DEVICE FloatType getModelRhoOnNodes(ScalarType n) const final
-  {
-    return model_rho_node_[n];
-  }
+  PROXY_HOST_DEVICE FloatType getModelRhoOnNodes(ScalarType n) const final { return model_rho_node_[n]; }
 
   /**
    * @brief Get density at element
    * @param e Element index
    * @return Density (kg/m³)
    */
-  PROXY_HOST_DEVICE FloatType getModelRhoOnElement(ScalarType e) const final
-  {
-    return model_rho_element_[e];
-  }
+  PROXY_HOST_DEVICE FloatType getModelRhoOnElement(ScalarType e) const final { return model_rho_element_[e]; }
 
   /**
    * @brief Get S-wave velocity at node
    * @param n Node index
    * @return S-wave velocity (m/s)
    */
-  PROXY_HOST_DEVICE FloatType getModelVsOnNodes(ScalarType n) const final
-  {
-    return model_vs_node_[n];
-  }
+  PROXY_HOST_DEVICE FloatType getModelVsOnNodes(ScalarType n) const final { return model_vs_node_[n]; }
 
   /**
    * @brief Get S-wave velocity at element
    * @param e Element index
    * @return S-wave velocity (m/s)
    */
-  PROXY_HOST_DEVICE FloatType getModelVsOnElement(ScalarType e) const final
-  {
-    return model_vs_element_[e];
-  }
+  PROXY_HOST_DEVICE FloatType getModelVsOnElement(ScalarType e) const final { return model_vs_element_[e]; }
 
   /**
    * @brief Override per-node material properties at node @p n.
@@ -342,34 +299,28 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
    * @param vs  S-wave velocity (m/s).
    * @param rho Density (kg/m³).
    */
-  void setModelNodeProps(ScalarType n, FloatType vp, FloatType vs,
-                         FloatType rho)
-  {
+  void setModelNodeProps(ScalarType n, FloatType vp, FloatType vs, FloatType rho) {
     model_vp_node_[n] = vp;
     model_vs_node_[n] = vs;
     model_rho_node_[n] = rho;
   }
 
-  PROXY_HOST_DEVICE FloatType getModelQpOnNodes(ScalarType n) const final
-  {
+  PROXY_HOST_DEVICE FloatType getModelQpOnNodes(ScalarType n) const final {
     if (model_qp_node_.extent(0) > 0) return model_qp_node_[n];
     return static_cast<FloatType>(1.0e9);
   }
 
-  PROXY_HOST_DEVICE FloatType getModelQpOnElement(ScalarType e) const final
-  {
+  PROXY_HOST_DEVICE FloatType getModelQpOnElement(ScalarType e) const final {
     if (model_qp_element_.extent(0) > 0) return model_qp_element_[e];
     return static_cast<FloatType>(1.0e9);
   }
 
-  PROXY_HOST_DEVICE FloatType getModelQsOnNodes(ScalarType n) const final
-  {
+  PROXY_HOST_DEVICE FloatType getModelQsOnNodes(ScalarType n) const final {
     if (model_qs_node_.extent(0) > 0) return model_qs_node_[n];
     return static_cast<FloatType>(1.0e9);
   }
 
-  PROXY_HOST_DEVICE FloatType getModelQsOnElement(ScalarType e) const final
-  {
+  PROXY_HOST_DEVICE FloatType getModelQsOnElement(ScalarType e) const final {
     if (model_qs_element_.extent(0) > 0) return model_qs_element_[e];
     return static_cast<FloatType>(1.0e9);
   }
@@ -379,100 +330,70 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
    * @param n Node index
    * @return Thomsen delta (dimensionless)
    */
-  PROXY_HOST_DEVICE FloatType getModelDeltaOnNodes(ScalarType n) const final
-  {
-    return model_delta_node_[n];
-  }
+  PROXY_HOST_DEVICE FloatType getModelDeltaOnNodes(ScalarType n) const final { return model_delta_node_[n]; }
 
   /**
    * @brief Get Thomsen delta parameter at element
    * @param e Element index
    * @return Thomsen delta (dimensionless)
    */
-  PROXY_HOST_DEVICE FloatType getModelDeltaOnElement(ScalarType e) const final
-  {
-    return model_delta_element_[e];
-  }
+  PROXY_HOST_DEVICE FloatType getModelDeltaOnElement(ScalarType e) const final { return model_delta_element_[e]; }
 
   /**
    * @brief Get Thomsen epsilon parameter at node
    * @param n Node index
    * @return Thomsen epsilon (dimensionless)
    */
-  PROXY_HOST_DEVICE FloatType getModelEpsilonOnNodes(ScalarType n) const final
-  {
-    return model_epsilon_node_[n];
-  }
+  PROXY_HOST_DEVICE FloatType getModelEpsilonOnNodes(ScalarType n) const final { return model_epsilon_node_[n]; }
 
   /**
    * @brief Get Thomsen epsilon parameter at element
    * @param e Element index
    * @return Thomsen epsilon (dimensionless)
    */
-  PROXY_HOST_DEVICE FloatType getModelEpsilonOnElement(ScalarType e) const final
-  {
-    return model_epsilon_element_[e];
-  }
+  PROXY_HOST_DEVICE FloatType getModelEpsilonOnElement(ScalarType e) const final { return model_epsilon_element_[e]; }
 
   /**
    * @brief Get Thomsen gamma parameter at node
    * @param n Node index
    * @return Thomsen gamma (dimensionless)
    */
-  PROXY_HOST_DEVICE FloatType getModelGammaOnNodes(ScalarType n) const final
-  {
-    return model_gamma_node_[n];
-  }
+  PROXY_HOST_DEVICE FloatType getModelGammaOnNodes(ScalarType n) const final { return model_gamma_node_[n]; }
 
   /**
    * @brief Get Thomsen gamma parameter at element
    * @param e Element index
    * @return Thomsen gamma (dimensionless)
    */
-  PROXY_HOST_DEVICE FloatType getModelGammaOnElement(ScalarType e) const final
-  {
-    return model_gamma_element_[e];
-  }
+  PROXY_HOST_DEVICE FloatType getModelGammaOnElement(ScalarType e) const final { return model_gamma_element_[e]; }
 
   /**
    * @brief Get azimuth angle at node
    * @param n Node index
    * @return Azimuth angle phi (radians)
    */
-  PROXY_HOST_DEVICE ScalarType getModelPhiOnNodes(ScalarType n) const final
-  {
-    return model_phi_node_[n];
-  }
+  PROXY_HOST_DEVICE ScalarType getModelPhiOnNodes(ScalarType n) const final { return model_phi_node_[n]; }
 
   /**
    * @brief Get azimuth angle at element
    * @param e Element index
    * @return Azimuth angle phi (radians)
    */
-  PROXY_HOST_DEVICE ScalarType getModelPhiOnElement(ScalarType e) const final
-  {
-    return model_phi_element_[e];
-  }
+  PROXY_HOST_DEVICE ScalarType getModelPhiOnElement(ScalarType e) const final { return model_phi_element_[e]; }
 
   /**
    * @brief Get tilt angle at node
    * @param n Node index
    * @return Tilt angle theta (radians)
    */
-  PROXY_HOST_DEVICE ScalarType getModelThetaOnNodes(ScalarType n) const final
-  {
-    return model_theta_node_[n];
-  }
+  PROXY_HOST_DEVICE ScalarType getModelThetaOnNodes(ScalarType n) const final { return model_theta_node_[n]; }
 
   /**
    * @brief Get tilt angle at element
    * @param e Element index
    * @return Tilt angle theta (radians)
    */
-  PROXY_HOST_DEVICE ScalarType getModelThetaOnElement(ScalarType e) const final
-  {
-    return model_theta_element_[e];
-  }
+  PROXY_HOST_DEVICE ScalarType getModelThetaOnElement(ScalarType e) const final { return model_theta_element_[e]; }
 
   /**
    * @brief Initialize elasticity tensors for all elements
@@ -480,20 +401,16 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
    * Computes the 6x6 Voigt elasticity tensor from material properties.
    * Only executed if isElastic_ is true.
    */
-  void initElasticityTensors(AnisotropyType anisotropy_type) final
-  {
+  void initElasticityTensors(AnisotropyType anisotropy_type) final {
     if (!isElastic_) return;
 
-    if (anisotropy_type == AnisotropyType::kIso ||
-        anisotropy_type == AnisotropyType::kVTI)
-    {
+    if (anisotropy_type == AnisotropyType::kIso || anisotropy_type == AnisotropyType::kVTI) {
       // No precomputation needed for ISOTROPIC and VTI, computed on-the-fly
       // inside solver
       return;
     }
 
-    if (anisotropy_type == AnisotropyType::kTTI)
-    {
+    if (anisotropy_type == AnisotropyType::kTTI) {
       model_C_tensor_element_ = allocateArray3D<array3DReal>(n_element_, 6, 6);
 
       auto C_tensor = model_C_tensor_element_;
@@ -508,9 +425,7 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
 
       Kokkos::parallel_for(
           "Model init ElasticTensors",
-          Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock,
-                                                   LaunchMinBlocksPerSM>>(
-              0, n_element_),
+          Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(0, n_element_),
           KOKKOS_LAMBDA(const int i) {
             FloatType CTTI[6][6];
             FloatType vp_val = static_cast<FloatType>(vp[i]);
@@ -522,8 +437,7 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
             FloatType theta_val = static_cast<FloatType>(theta[i]);
             FloatType phi_val = static_cast<FloatType>(phi[i]);
 
-            computeCTensor(vp_val, vs_val, rho_val, delta_val, epsilon_val,
-                           gamma_val, theta_val, phi_val, CTTI);
+            computeCTensor(vp_val, vs_val, rho_val, delta_val, epsilon_val, gamma_val, theta_val, phi_val, CTTI);
 
             for (int k = 0; k < 6; k++)
               for (int l = 0; l < 6; l++) C_tensor(i, k, l) = CTTI[k][l];
@@ -537,8 +451,7 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
    * @param CTTI Output 6x6 Voigt elasticity tensor
    */
   PROXY_HOST_DEVICE
-  void getCTensorOnElement(ScalarType e, FloatType CTTI[6][6]) const final
-  {
+  void getCTensorOnElement(ScalarType e, FloatType CTTI[6][6]) const final {
     for (int i = 0; i < 6; i++)
       for (int j = 0; j < 6; j++) CTTI[i][j] = model_C_tensor_element_(e, i, j);
   }
@@ -547,10 +460,7 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
    * @brief Check if material properties are stored on nodes
    * @return True if on nodes, false if on elements
    */
-  PROXY_HOST_DEVICE bool isModelOnNodes() const final
-  {
-    return isModelOnNodes_;
-  }
+  PROXY_HOST_DEVICE bool isModelOnNodes() const final { return isModelOnNodes_; }
 
   /**
    * @brief Check if mesh is for elastic wave propagation
@@ -562,37 +472,25 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
    * @brief Get total number of elements
    * @return Number of elements
    */
-  PROXY_HOST_DEVICE ScalarType getNumberOfElements() const final
-  {
-    return n_element_;
-  }
+  PROXY_HOST_DEVICE ScalarType getNumberOfElements() const final { return n_element_; }
 
   /**
    * @brief Get total number of nodes
    * @return Number of nodes
    */
-  PROXY_HOST_DEVICE ScalarType getNumberOfNodes() const final
-  {
-    return n_node_;
-  }
+  PROXY_HOST_DEVICE ScalarType getNumberOfNodes() const final { return n_node_; }
 
   /**
    * @brief Get number of nodes per element
    * @return (order+1)³ nodes per element
    */
-  PROXY_HOST_DEVICE int getNumberOfPointsPerElement() const final
-  {
-    return n_points_per_element_;
-  }
+  PROXY_HOST_DEVICE int getNumberOfPointsPerElement() const final { return n_points_per_element_; }
 
   /**
    * @brief Get polynomial order of elements
    * @return Element order
    */
-  PROXY_HOST_DEVICE int getOrder() const final
-  {
-    return static_cast<int>(order_);
-  }
+  PROXY_HOST_DEVICE int getOrder() const final { return static_cast<int>(order_); }
 
   /**
    * @brief Compute outward normal vector for element face
@@ -601,14 +499,11 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
    * @param v Output normal vector [nx, ny, nz] (normalized)
    */
   PROXY_HOST_DEVICE
-  void faceNormal(ScalarType e, CubicFace local_face,
-                  FloatType v[3]) const final
-  {
+  void faceNormal(ScalarType e, CubicFace local_face, FloatType v[3]) const final {
     ScalarType n0, n1, n2;
     const int o = order_;
 
-    switch (local_face)
-    {
+    switch (local_face) {
       case CubicFace::kXMinus:
         n0 = globalNodeIndex(e, 0, 0, 0);
         n1 = globalNodeIndex(e, 0, o, 0);
@@ -642,8 +537,7 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
     }
 
     FloatType p0[3], p1[3], p2[3];
-    for (int d = 0; d < 3; ++d)
-    {
+    for (int d = 0; d < 3; ++d) {
       p0[d] = nodeCoord(n0, d);
       p1[d] = nodeCoord(n1, d);
       p2[d] = nodeCoord(n2, d);
@@ -662,8 +556,7 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
     v[2] = t1[0] * t2[1] - t1[1] * t2[0];
 
     FloatType norm = sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
-    if (norm > 1e-12)
-    {
+    if (norm > 1e-12) {
       v[0] /= norm;
       v[1] /= norm;
       v[2] /= norm;
@@ -676,8 +569,7 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
    * @return BoundaryFlag enum value
    */
   PROXY_HOST_DEVICE
-  BoundaryFlag boundaryType(ScalarType n) const override
-  {
+  BoundaryFlag boundaryType(ScalarType n) const override {
     if (boundaries_t_.extent(0) == 0) return BoundaryFlag::InteriorNode;
     return static_cast<BoundaryFlag>(boundaries_t_[n]);
   }
@@ -687,10 +579,8 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
    * @param dim Dimension (0=x, 1=y, 2=z)
    * @return Domain size (meters)
    */
-  PROXY_HOST_DEVICE FloatType domainSize(int dim) const final
-  {
-    switch (dim)
-    {
+  PROXY_HOST_DEVICE FloatType domainSize(int dim) const final {
+    switch (dim) {
       case 0:
         return lx_;
       case 1:
@@ -706,15 +596,13 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
    * @brief Compute minimum node spacing in mesh
    * @return Minimum spacing between adjacent nodes (meters)
    */
-  PROXY_HOST_DEVICE FloatType getMinSpacing() const final
-  {
+  PROXY_HOST_DEVICE FloatType getMinSpacing() const final {
     FloatType minSpacing = std::numeric_limits<FloatType>::max();
     constexpr ScalarType e = 0;
 
     for (int k = 0; k <= order_; ++k)
       for (int j = 0; j <= order_; ++j)
-        for (int i = 0; i < order_; ++i)
-        {
+        for (int i = 0; i < order_; ++i) {
           ScalarType node1 = globalNodeIndex(e, i, j, k);
           ScalarType node2 = globalNodeIndex(e, i + 1, j, k);
           FloatType dx = nodeCoord(node2, 0) - nodeCoord(node1, 0);
@@ -725,8 +613,7 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
 
     for (int k = 0; k <= order_; ++k)
       for (int i = 0; i <= order_; ++i)
-        for (int j = 0; j < order_; ++j)
-        {
+        for (int j = 0; j < order_; ++j) {
           ScalarType node1 = globalNodeIndex(e, i, j, k);
           ScalarType node2 = globalNodeIndex(e, i, j + 1, k);
           FloatType dx = nodeCoord(node2, 0) - nodeCoord(node1, 0);
@@ -737,8 +624,7 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
 
     for (int j = 0; j <= order_; ++j)
       for (int i = 0; i <= order_; ++i)
-        for (int k = 0; k < order_; ++k)
-        {
+        for (int k = 0; k < order_; ++k) {
           ScalarType node1 = globalNodeIndex(e, i, j, k);
           ScalarType node2 = globalNodeIndex(e, i, j, k + 1);
           FloatType dx = nodeCoord(node2, 0) - nodeCoord(node1, 0);
@@ -754,23 +640,16 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
    * @brief Find maximum wave speed in mesh
    * @return Maximum P-wave velocity (m/s)
    */
-  FloatType getMaxSpeed() const final
-  {
+  FloatType getMaxSpeed() const final {
     FloatType maxSpeedNode = std::numeric_limits<FloatType>::lowest();
     FloatType maxSpeedElem = std::numeric_limits<FloatType>::lowest();
 
-    if (model_vp_node_.extent(0) > 0)
-    {
+    if (model_vp_node_.extent(0) > 0) {
       FIND_MAX_1D(model_vp_node_, n_node_, maxSpeedNode);
-    }
-    else if (model_vp_element_.extent(0) > 0)
-    {
+    } else if (model_vp_element_.extent(0) > 0) {
       FIND_MAX_1D(model_vp_element_, n_element_, maxSpeedElem);
-    }
-    else
-    {
-      throw std::runtime_error(
-          "No model initialized (model unstruct getMaxSpeed).");
+    } else {
+      throw std::runtime_error("No model initialized (model unstruct getMaxSpeed).");
     }
     return max(maxSpeedElem, maxSpeedNode);
   }
@@ -791,8 +670,7 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
    * Must be called before using face-related query functions.
    * Complexity: O(N_elem) with map-based face matching.
    */
-  void buildFaceConnectivity() override
-  {
+  void buildFaceConnectivity() override {
     if (face_connectivity_.getNumberOfFaces() > 0) return;
 
     face_connectivity_.build(*this);
@@ -804,8 +682,7 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
    * @return Global face ID
    */
   PROXY_HOST_DEVICE
-  ScalarType getGlobalFace(ScalarType elem, CubicFace local_face) const override
-  {
+  ScalarType getGlobalFace(ScalarType elem, CubicFace local_face) const override {
     return face_connectivity_.getGlobalFace(elem, local_face);
   }
 
@@ -816,9 +693,7 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
    * @return Global node index
    */
   PROXY_HOST_DEVICE
-  ScalarType getGlobalNodeFromFace(ScalarType face_global,
-                                   int local_dof) const override
-  {
+  ScalarType getGlobalNodeFromFace(ScalarType face_global, int local_dof) const override {
     return face_connectivity_.getGlobalNodeFromFace(face_global, local_dof);
   }
 
@@ -828,15 +703,11 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
    * @return True if boundary face (no neighbor element)
    */
   PROXY_HOST_DEVICE
-  bool isBoundaryFace(ScalarType face_global) const override
-  {
-    if (boundaries_t_.extent(0) == 0)
-      return face_connectivity_.isBoundaryFace(face_global);
+  bool isBoundaryFace(ScalarType face_global) const override {
+    if (boundaries_t_.extent(0) == 0) return face_connectivity_.isBoundaryFace(face_global);
     int const n_dofs = face_connectivity_.getDofsPerFace();
-    for (int q = 0; q < n_dofs; ++q)
-    {
-      if (boundaries_t_[getGlobalNodeFromFace(face_global, q)] ==
-          static_cast<ScalarType>(BoundaryFlag::InteriorNode))
+    for (int q = 0; q < n_dofs; ++q) {
+      if (boundaries_t_[getGlobalNodeFromFace(face_global, q)] == static_cast<ScalarType>(BoundaryFlag::InteriorNode))
         return false;
     }
     return true;
@@ -847,10 +718,7 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
    * @return Number of unique faces
    */
   PROXY_HOST_DEVICE
-  ScalarType getNumberOfFaces() const override
-  {
-    return face_connectivity_.getNumberOfFaces();
-  }
+  ScalarType getNumberOfFaces() const override { return face_connectivity_.getNumberOfFaces(); }
 
   /**
    * @brief Check if node is on free surface
@@ -858,21 +726,16 @@ class ModelUnstruct final : public ModelApi<FloatType, ScalarType>
    * @return True if free surface node, false otherwise
    */
   PROXY_HOST_DEVICE
-  bool isFreeSurface(ScalarType n) const override
-  {
+  bool isFreeSurface(ScalarType n) const override {
     if (boundaries_t_.extent(0) == 0) return false;
     return boundaries_t_[n] == static_cast<ScalarType>(BoundaryFlag::Surface);
   }
 
-  void setQualityFactors(FloatType qp, FloatType qs) override
-  {
+  void setQualityFactors(FloatType qp, FloatType qs) override {
     ScalarType nElem = getNumberOfElements();
-    model_qp_element_ =
-        allocateVector<VECTOR_REAL_VIEW>(nElem, "model_qp_element");
-    model_qs_element_ =
-        allocateVector<VECTOR_REAL_VIEW>(nElem, "model_qs_element");
-    for (ScalarType e = 0; e < nElem; ++e)
-    {
+    model_qp_element_ = allocateVector<VECTOR_REAL_VIEW>(nElem, "model_qp_element");
+    model_qs_element_ = allocateVector<VECTOR_REAL_VIEW>(nElem, "model_qs_element");
+    for (ScalarType e = 0; e < nElem; ++e) {
       model_qp_element_(e) = qp;
       model_qs_element_(e) = qs;
     }

--- a/src/model/mesh/impl/model/unstruct/src/model_unstruct.cc
+++ b/src/model/mesh/impl/model/unstruct/src/model_unstruct.cc
@@ -1,7 +1,6 @@
 #include "model_unstruct.h"
 
-namespace model
-{
+namespace model {
 template class ModelUnstruct<float, int>;
 template class ModelUnstruct<float, long>;
 template class ModelUnstruct<double, int>;

--- a/src/model/mesh/pywrap/include/bindings_builder.h
+++ b/src/model/mesh/pywrap/include/bindings_builder.h
@@ -16,16 +16,13 @@
 
 namespace py = pybind11;
 
-namespace model
-{
+namespace model {
 
 // template binder for ModelBuilderBase
 template <typename FloatType, typename ScalarType>
-void bind_modelbuilderbase(py::module_ &m)
-{
+void bind_modelbuilderbase(py::module_ &m) {
   using T = model::ModelBuilderBase<FloatType, ScalarType>;
-  std::string name =
-      model_class_name<FloatType, ScalarType>("ModelBuilderBase");
+  std::string name = model_class_name<FloatType, ScalarType>("ModelBuilderBase");
 
   py::class_<T, std::shared_ptr<T>>(m, name.c_str())
       .def_static("max_order", []() { return T::MAX_ORDER; })
@@ -34,61 +31,47 @@ void bind_modelbuilderbase(py::module_ &m)
 
 // template binder for CartesianStructBuilder
 template <typename FloatType, typename ScalarType, int Order>
-void bind_cartesian_struct_builder(py::module_ &m)
-{
+void bind_cartesian_struct_builder(py::module_ &m) {
   using Base = model::ModelBuilderBase<FloatType, ScalarType>;
   using T = model::CartesianStructBuilder<FloatType, ScalarType, Order>;
-  std::string name =
-      model_class_name<FloatType, ScalarType, Order>("CartesianStructBuilder");
+  std::string name = model_class_name<FloatType, ScalarType, Order>("CartesianStructBuilder");
 
   py::class_<T, Base, std::shared_ptr<T>>(m, name.c_str())
       // Standard constructor (no acousto-elastic).
-      .def(py::init<ScalarType, FloatType, ScalarType, FloatType, ScalarType,
-                    FloatType, bool, bool, FloatType, FloatType, FloatType>(),
-           py::arg("ex"), py::arg("hx"), py::arg("ey"), py::arg("hy"),
-           py::arg("ez"), py::arg("hz"), py::arg("is_model_on_nodes"),
-           py::arg("is_elastic"), py::arg("ox") = static_cast<FloatType>(0),
-           py::arg("oy") = static_cast<FloatType>(0),
-           py::arg("oz") = static_cast<FloatType>(0))
+      .def(py::init<ScalarType, FloatType, ScalarType, FloatType, ScalarType, FloatType, bool, bool, FloatType,
+                    FloatType, FloatType>(),
+           py::arg("ex"), py::arg("hx"), py::arg("ey"), py::arg("hy"), py::arg("ez"), py::arg("hz"),
+           py::arg("is_model_on_nodes"), py::arg("is_elastic"), py::arg("ox") = static_cast<FloatType>(0),
+           py::arg("oy") = static_cast<FloatType>(0), py::arg("oz") = static_cast<FloatType>(0))
       // Acousto-elastic constructor: exposes the two AE parameters while
       // leaving global domain metrics at their defaults (local = global),
       // which is correct for single-rank / non-MPI usage.
       // For multi-rank, a third overload exposing global_lx/ly/lz would be
       // needed.
-      .def(py::init([](ScalarType ex, FloatType hx, ScalarType ey, FloatType hy,
-                       ScalarType ez, FloatType hz, bool is_model_on_nodes,
-                       bool is_elastic, FloatType ox, FloatType oy,
-                       FloatType oz, bool is_acousto_elastic,
-                       FloatType acousto_elastic_boundary_z) {
-             return T(ex, hx, ey, hy, ez, hz, is_model_on_nodes, is_elastic, ox,
-                      oy, oz, static_cast<FloatType>(-1),
-                      static_cast<FloatType>(-1), static_cast<FloatType>(-1),
-                      static_cast<FloatType>(0), static_cast<FloatType>(0),
-                      static_cast<FloatType>(0), is_acousto_elastic,
+      .def(py::init([](ScalarType ex, FloatType hx, ScalarType ey, FloatType hy, ScalarType ez, FloatType hz,
+                       bool is_model_on_nodes, bool is_elastic, FloatType ox, FloatType oy, FloatType oz,
+                       bool is_acousto_elastic, FloatType acousto_elastic_boundary_z) {
+             return T(ex, hx, ey, hy, ez, hz, is_model_on_nodes, is_elastic, ox, oy, oz, static_cast<FloatType>(-1),
+                      static_cast<FloatType>(-1), static_cast<FloatType>(-1), static_cast<FloatType>(0),
+                      static_cast<FloatType>(0), static_cast<FloatType>(0), is_acousto_elastic,
                       acousto_elastic_boundary_z);
            }),
-           py::arg("ex"), py::arg("hx"), py::arg("ey"), py::arg("hy"),
-           py::arg("ez"), py::arg("hz"), py::arg("is_model_on_nodes"),
-           py::arg("is_elastic"), py::arg("ox") = static_cast<FloatType>(0),
-           py::arg("oy") = static_cast<FloatType>(0),
-           py::arg("oz") = static_cast<FloatType>(0),
-           py::arg("is_acousto_elastic") = false,
-           py::arg("acousto_elastic_boundary_z") = static_cast<FloatType>(0));
+           py::arg("ex"), py::arg("hx"), py::arg("ey"), py::arg("hy"), py::arg("ez"), py::arg("hz"),
+           py::arg("is_model_on_nodes"), py::arg("is_elastic"), py::arg("ox") = static_cast<FloatType>(0),
+           py::arg("oy") = static_cast<FloatType>(0), py::arg("oz") = static_cast<FloatType>(0),
+           py::arg("is_acousto_elastic") = false, py::arg("acousto_elastic_boundary_z") = static_cast<FloatType>(0));
 }
 
 // template binder for CartesianParams
 template <typename FloatType, typename ScalarType>
-void bind_cartesian_unstruct_params(py::module_ &m)
-{
+void bind_cartesian_unstruct_params(py::module_ &m) {
   using Params = model::CartesianParams<FloatType, ScalarType>;
   std::string name = model_class_name<FloatType, ScalarType>("CartesianParams");
 
   py::class_<Params, std::shared_ptr<Params>>(m, name.c_str())
       .def(py::init<>())
-      .def(py::init<int, ScalarType, ScalarType, ScalarType, FloatType,
-                    FloatType, FloatType, bool, bool>(),
-           py::arg("order"), py::arg("ex"), py::arg("ey"), py::arg("ez"),
-           py::arg("lx"), py::arg("ly"), py::arg("lz"),
+      .def(py::init<int, ScalarType, ScalarType, ScalarType, FloatType, FloatType, FloatType, bool, bool>(),
+           py::arg("order"), py::arg("ex"), py::arg("ey"), py::arg("ez"), py::arg("lx"), py::arg("ly"), py::arg("lz"),
            py::arg("is_model_on_nodes"), py::arg("is_elastic"))
       .def_readwrite("order", &Params::order)
       .def_readwrite("ex", &Params::ex)
@@ -103,18 +86,15 @@ void bind_cartesian_unstruct_params(py::module_ &m)
       .def_readwrite("is_model_on_nodes", &Params::isModelOnNodes)
       .def_readwrite("is_elastic", &Params::isElastic)
       .def_readwrite("is_acousto_elastic", &Params::isAcoustoElastic)
-      .def_readwrite("acousto_elastic_boundary_z",
-                     &Params::acoustoElasticBoundaryZ);
+      .def_readwrite("acousto_elastic_boundary_z", &Params::acoustoElasticBoundaryZ);
 }
 
 // template binder for CartesianUnstructBuilder
 template <typename FloatType, typename ScalarType>
-void bind_cartesian_unstruct_builder(py::module_ &m)
-{
+void bind_cartesian_unstruct_builder(py::module_ &m) {
   using Base = model::ModelBuilderBase<FloatType, ScalarType>;
   using T = model::CartesianUnstructBuilder<FloatType, ScalarType>;
-  std::string name =
-      model_class_name<FloatType, ScalarType>("CartesianUnstructBuilder");
+  std::string name = model_class_name<FloatType, ScalarType>("CartesianUnstructBuilder");
 
   py::class_<T, Base, std::shared_ptr<T>>(m, name.c_str())
       .def(py::init<>())

--- a/src/model/mesh/pywrap/include/bindings_face_connectivity.h
+++ b/src/model/mesh/pywrap/include/bindings_face_connectivity.h
@@ -8,20 +8,15 @@
 
 namespace py = pybind11;
 
-namespace bindings
-{
+namespace bindings {
 
 template <typename FloatType, typename ScalarType>
-void bindFaceConnectivityUnstruct(py::module &m)
-{
-  using FaceConnData =
-      model::FaceConnectivityUnstructData<FloatType, ScalarType>;
+void bindFaceConnectivityUnstruct(py::module &m) {
+  using FaceConnData = model::FaceConnectivityUnstructData<FloatType, ScalarType>;
   using FaceConn = model::FaceConnectivityUnstruct<FloatType, ScalarType>;
 
-  std::string data_name = model::model_class_name<FloatType, ScalarType>(
-      "FaceConnectivityUnstructData");
-  std::string class_name = model::model_class_name<FloatType, ScalarType>(
-      "FaceConnectivityUnstruct");
+  std::string data_name = model::model_class_name<FloatType, ScalarType>("FaceConnectivityUnstructData");
+  std::string class_name = model::model_class_name<FloatType, ScalarType>("FaceConnectivityUnstruct");
 
   // Bind Data struct
   py::class_<FaceConnData>(m, data_name.c_str())
@@ -30,63 +25,57 @@ void bindFaceConnectivityUnstruct(py::module &m)
       .def_readwrite("ndofs_per_face", &FaceConnData::ndofs_per_face)
       .def_property(
           "elem_to_faces",
-          [](FaceConnData &self) -> Kokkos::Experimental::python_view_type_t<
-                                     decltype(self.elem_to_faces)> {
+          [](FaceConnData &self) -> Kokkos::Experimental::python_view_type_t<decltype(self.elem_to_faces)> {
             return self.elem_to_faces;
           },
-          [](FaceConnData &self, Kokkos::Experimental::python_view_type_t<
-                                     decltype(self.elem_to_faces)>
-                                     v) { self.elem_to_faces = v; })
+          [](FaceConnData &self, Kokkos::Experimental::python_view_type_t<decltype(self.elem_to_faces)> v) {
+            self.elem_to_faces = v;
+          })
 
       .def_property(
           "face_dofs",
-          [](FaceConnData &self) -> Kokkos::Experimental::python_view_type_t<
-                                     decltype(self.face_dofs)> {
+          [](FaceConnData &self) -> Kokkos::Experimental::python_view_type_t<decltype(self.face_dofs)> {
             return self.face_dofs;
           },
-          [](FaceConnData &self,
-             Kokkos::Experimental::python_view_type_t<decltype(self.face_dofs)>
-                 v) { self.face_dofs = v; })
+          [](FaceConnData &self, Kokkos::Experimental::python_view_type_t<decltype(self.face_dofs)> v) {
+            self.face_dofs = v;
+          })
 
       .def_property(
           "face_elem_owner",
-          [](FaceConnData &self) -> Kokkos::Experimental::python_view_type_t<
-                                     decltype(self.face_elem_owner)> {
+          [](FaceConnData &self) -> Kokkos::Experimental::python_view_type_t<decltype(self.face_elem_owner)> {
             return self.face_elem_owner;
           },
-          [](FaceConnData &self, Kokkos::Experimental::python_view_type_t<
-                                     decltype(self.face_elem_owner)>
-                                     v) { self.face_elem_owner = v; })
+          [](FaceConnData &self, Kokkos::Experimental::python_view_type_t<decltype(self.face_elem_owner)> v) {
+            self.face_elem_owner = v;
+          })
 
       .def_property(
           "face_elem_neighbor",
-          [](FaceConnData &self) -> Kokkos::Experimental::python_view_type_t<
-                                     decltype(self.face_elem_neighbor)> {
+          [](FaceConnData &self) -> Kokkos::Experimental::python_view_type_t<decltype(self.face_elem_neighbor)> {
             return self.face_elem_neighbor;
           },
-          [](FaceConnData &self, Kokkos::Experimental::python_view_type_t<
-                                     decltype(self.face_elem_neighbor)>
-                                     v) { self.face_elem_neighbor = v; })
+          [](FaceConnData &self, Kokkos::Experimental::python_view_type_t<decltype(self.face_elem_neighbor)> v) {
+            self.face_elem_neighbor = v;
+          })
 
       .def_property(
           "face_local_owner",
-          [](FaceConnData &self) -> Kokkos::Experimental::python_view_type_t<
-                                     decltype(self.face_local_owner)> {
+          [](FaceConnData &self) -> Kokkos::Experimental::python_view_type_t<decltype(self.face_local_owner)> {
             return self.face_local_owner;
           },
-          [](FaceConnData &self, Kokkos::Experimental::python_view_type_t<
-                                     decltype(self.face_local_owner)>
-                                     v) { self.face_local_owner = v; })
+          [](FaceConnData &self, Kokkos::Experimental::python_view_type_t<decltype(self.face_local_owner)> v) {
+            self.face_local_owner = v;
+          })
 
       .def_property(
           "face_local_neighbor",
-          [](FaceConnData &self) -> Kokkos::Experimental::python_view_type_t<
-                                     decltype(self.face_local_neighbor)> {
+          [](FaceConnData &self) -> Kokkos::Experimental::python_view_type_t<decltype(self.face_local_neighbor)> {
             return self.face_local_neighbor;
           },
-          [](FaceConnData &self, Kokkos::Experimental::python_view_type_t<
-                                     decltype(self.face_local_neighbor)>
-                                     v) { self.face_local_neighbor = v; });
+          [](FaceConnData &self, Kokkos::Experimental::python_view_type_t<decltype(self.face_local_neighbor)> v) {
+            self.face_local_neighbor = v;
+          });
   // Bind Class
   py::class_<FaceConn>(m, class_name.c_str())
       .def(py::init<>())

--- a/src/model/mesh/pywrap/include/bindings_model.h
+++ b/src/model/mesh/pywrap/include/bindings_model.h
@@ -19,13 +19,11 @@
 
 namespace py = pybind11;
 
-namespace model
-{
+namespace model {
 
 // template binder for ModelAPI
 template <typename FloatType, typename ScalarType>
-void bind_modelapi(py::module_ &m)
-{
+void bind_modelapi(py::module_ &m) {
   using T = model::ModelApi<FloatType, ScalarType>;
   std::string name = model_class_name<FloatType, ScalarType>("ModelApi");
 
@@ -66,30 +64,25 @@ void bind_modelapi(py::module_ &m)
       .def("is_boundary_face", &T::isBoundaryFace)
       .def("get_global_node_from_face", &T::getGlobalNodeFromFace)
       .def("get_global_face", &T::getGlobalFace)
-      .def("set_quality_factors", &T::setQualityFactors, py::arg("qp"),
-           py::arg("qs"))
+      .def("set_quality_factors", &T::setQualityFactors, py::arg("qp"), py::arg("qs"))
       .def("is_free_surface", &T::isFreeSurface);
 }
 
 // templated binder for one ModelStruct instantiation
 template <typename FloatType, typename ScalarType, int Order>
-void bind_modelstruct(py::module_ &m)
-{
+void bind_modelstruct(py::module_ &m) {
   using Base = model::ModelApi<FloatType, ScalarType>;
   using T = model::ModelStruct<FloatType, ScalarType, Order>;
   using Data = model::ModelStructData<FloatType, ScalarType>;
 
-  std::string name =
-      model_class_name<FloatType, ScalarType, Order>("ModelStruct");
+  std::string name = model_class_name<FloatType, ScalarType, Order>("ModelStruct");
 
-  py::class_<T, Base, std::shared_ptr<T>>(m, name.c_str())
-      .def(py::init<const Data &>());
+  py::class_<T, Base, std::shared_ptr<T>>(m, name.c_str()).def(py::init<const Data &>());
 }
 
 // templated binder for ModelStructData
 template <typename FloatType, typename ScalarType>
-void bind_modelstructdata(py::module_ &m)
-{
+void bind_modelstructdata(py::module_ &m) {
   using Data = model::ModelStructData<FloatType, ScalarType>;
   std::string name = model_class_name<FloatType, ScalarType>("ModelStructData");
 
@@ -105,68 +98,57 @@ void bind_modelstructdata(py::module_ &m)
 
 // templated binder for ModelUnstruct
 template <typename FloatType, typename ScalarType>
-void bind_modelunstruct(py::module_ &m)
-{
+void bind_modelunstruct(py::module_ &m) {
   using Base = model::ModelApi<FloatType, ScalarType>;
   using T = model::ModelUnstruct<FloatType, ScalarType>;
   using Data = model::ModelUnstructData<FloatType, ScalarType>;
 
   std::string name = model_class_name<FloatType, ScalarType>("ModelUnstruct");
 
-  py::class_<T, Base, std::shared_ptr<T>>(m, name.c_str())
-      .def(py::init<const Data &>());
+  py::class_<T, Base, std::shared_ptr<T>>(m, name.c_str()).def(py::init<const Data &>());
 }
 
 // template binder for ModelUnstructData
 template <typename FloatType, typename ScalarType>
-void bind_modelunstructdata(py::module_ &m)
-{
+void bind_modelunstructdata(py::module_ &m) {
   using Data = model::ModelUnstructData<FloatType, ScalarType>;
 
-  std::string name =
-      model_class_name<FloatType, ScalarType>("ModelUnstructData");
+  std::string name = model_class_name<FloatType, ScalarType>("ModelUnstructData");
 
   py::class_<Data>(m, name.c_str())
       // Constructeur existant INCHANGÉ (sans face_connectivity)
-      .def(
-          py::init<ScalarType, ScalarType, ScalarType, FloatType, FloatType,
-                   FloatType, bool, bool,
-                   Kokkos::Experimental::python_view_type_t<ARRAY_INT_VIEW>,
-                   Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-                   Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-                   Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-                   Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-                   Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-                   Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-                   Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-                   Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-                   Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-                   Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-                   Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-                   Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-                   Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-                   Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-                   Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-                   Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-                   Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-                   Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-                   Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-                   Kokkos::Experimental::python_view_type_t<ARRAY3D_REAL_VIEW>,
-                   Kokkos::Experimental::python_view_type_t<VECTOR_INT_VIEW>>(),
-          py::arg("order"), py::arg("n_element"), py::arg("n_node"),
-          py::arg("lx"), py::arg("ly"), py::arg("lz"),
-          py::arg("is_model_on_nodes"), py::arg("is_elastic"),
-          py::arg("global_node_index"), py::arg("nodes_coords_x"),
-          py::arg("nodes_coords_y"), py::arg("nodes_coords_z"),
-          py::arg("model_vp_node"), py::arg("model_vp_element"),
-          py::arg("model_rho_node"), py::arg("model_rho_element"),
-          py::arg("model_vs_node"), py::arg("model_vs_element"),
-          py::arg("model_delta_node"), py::arg("model_delta_element"),
-          py::arg("model_epsilon_node"), py::arg("model_epsilon_element"),
-          py::arg("model_gamma_node"), py::arg("model_gamma_element"),
-          py::arg("model_theta_node"), py::arg("model_theta_element"),
-          py::arg("model_phi_node"), py::arg("model_phi_element"),
-          py::arg("model_C_tensor_element"), py::arg("boundaries_t"))
+      .def(py::init<ScalarType, ScalarType, ScalarType, FloatType, FloatType, FloatType, bool, bool,
+                    Kokkos::Experimental::python_view_type_t<ARRAY_INT_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<ARRAY3D_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_INT_VIEW>>(),
+           py::arg("order"), py::arg("n_element"), py::arg("n_node"), py::arg("lx"), py::arg("ly"), py::arg("lz"),
+           py::arg("is_model_on_nodes"), py::arg("is_elastic"), py::arg("global_node_index"), py::arg("nodes_coords_x"),
+           py::arg("nodes_coords_y"), py::arg("nodes_coords_z"), py::arg("model_vp_node"), py::arg("model_vp_element"),
+           py::arg("model_rho_node"), py::arg("model_rho_element"), py::arg("model_vs_node"),
+           py::arg("model_vs_element"), py::arg("model_delta_node"), py::arg("model_delta_element"),
+           py::arg("model_epsilon_node"), py::arg("model_epsilon_element"), py::arg("model_gamma_node"),
+           py::arg("model_gamma_element"), py::arg("model_theta_node"), py::arg("model_theta_element"),
+           py::arg("model_phi_node"), py::arg("model_phi_element"), py::arg("model_C_tensor_element"),
+           py::arg("boundaries_t"))
 
       .def_readwrite("face_connectivity", &Data::face_connectivity_);
 }

--- a/src/model/mesh/pywrap/include/bindings_partionner.h
+++ b/src/model/mesh/pywrap/include/bindings_partionner.h
@@ -10,25 +10,21 @@
 
 namespace py = pybind11;
 
-namespace model
-{
+namespace model {
 
 // template binder for CartesianXPartitioner
 template <typename FloatType, typename ScalarType>
-void bind_cartesian_partitioner(py::module_ &m)
-{
+void bind_cartesian_partitioner(py::module_ &m) {
   // Define alias for the class we are binding
   using Partitioner = model::CartesianXPartitioner<FloatType, ScalarType>;
 
   // Generate the Python class name (e.g., CartesianXPartitioner_f32_i32)
-  std::string name =
-      model_class_name<FloatType, ScalarType>("CartesianXPartitioner");
+  std::string name = model_class_name<FloatType, ScalarType>("CartesianXPartitioner");
 
   // Bind the class
   py::class_<Partitioner>(m, name.c_str())
       .def(py::init<>())
-      .def("partition", &Partitioner::partition, py::arg("global_params"),
-           py::arg("rank"), py::arg("size"));
+      .def("partition", &Partitioner::partition, py::arg("global_params"), py::arg("rank"), py::arg("size"));
 }
 
 }  // namespace model

--- a/src/model/mesh/pywrap/include/bindings_utils.h
+++ b/src/model/mesh/pywrap/include/bindings_utils.h
@@ -5,38 +5,31 @@
 
 #include <string>
 
-namespace model
-{
+namespace model {
 
 // helper to make a readable suffix for class names (specialize as needed)
 template <typename FloatType, typename ScalarType>
 constexpr const char* type_suffix();
 template <>
-constexpr const char* type_suffix<float, int>()
-{
+constexpr const char* type_suffix<float, int>() {
   return "f32_i32";
 }
 template <>
-constexpr const char* type_suffix<double, int>()
-{
+constexpr const char* type_suffix<double, int>() {
   return "f64_i32";
 }
 template <>
-constexpr const char* type_suffix<float, long>()
-{
+constexpr const char* type_suffix<float, long>() {
   return "f32_i64";
 }
 template <>
-constexpr const char* type_suffix<double, long>()
-{
+constexpr const char* type_suffix<double, long>() {
   return "f64_i64";
 }
 
 // helper to make a readable suffix for order
-constexpr const char* order_suffix(int order)
-{
-  switch (order)
-  {
+constexpr const char* order_suffix(int order) {
+  switch (order) {
     case 1:
       return "O1";
     case 2:
@@ -56,16 +49,13 @@ constexpr const char* order_suffix(int order)
     case 9:
       return "O9";
     default:
-      throw std::runtime_error("Unsupported order for binding: " +
-                               std::to_string(order));
+      throw std::runtime_error("Unsupported order for binding: " + std::to_string(order));
   }
 }
 
 template <typename FUNC>
-auto orderDispatch(int const order, FUNC&& func)
-{
-  switch (order)
-  {
+auto orderDispatch(int const order, FUNC&& func) {
+  switch (order) {
     case 1:
       return func(std::integral_constant<int, 1>{});
     case 2:
@@ -85,23 +75,19 @@ auto orderDispatch(int const order, FUNC&& func)
     case 9:
       return func(std::integral_constant<int, 9>{});
     default:
-      throw std::invalid_argument("Unsupported order for binding: " +
-                                  std::to_string(order));
+      throw std::invalid_argument("Unsupported order for binding: " + std::to_string(order));
   }
 }
 
 // helper to generate class name
 template <typename FloatType, typename ScalarType, int Order>
-std::string model_class_name(std::string basename)
-{
-  return basename + "_" + type_suffix<FloatType, ScalarType>() + "_" +
-         order_suffix(Order);
+std::string model_class_name(std::string basename) {
+  return basename + "_" + type_suffix<FloatType, ScalarType>() + "_" + order_suffix(Order);
 }
 
 // helper to generate class name
 template <typename FloatType, typename ScalarType>
-std::string model_class_name(std::string basename)
-{
+std::string model_class_name(std::string basename) {
   return basename + "_" + type_suffix<FloatType, ScalarType>();
 }
 

--- a/src/model/mesh/pywrap/src/bindings.cpp
+++ b/src/model/mesh/pywrap/src/bindings.cpp
@@ -12,8 +12,7 @@
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(model, m)
-{
+PYBIND11_MODULE(model, m) {
   // Create submodule 'model'
   m.attr("__name__") = "pyfuntides.model";
 
@@ -29,8 +28,7 @@ PYBIND11_MODULE(model, m)
   model::bind_modelapi<double, long>(m);
 
   // Bind ModelStruct
-  for (int order = 1; order <= 9; ++order)
-  {
+  for (int order = 1; order <= 9; ++order) {
     model::orderDispatch(order, [&](auto order_tag) {
       constexpr int ord = decltype(order_tag)::value;
       model::bind_modelstruct<float, int, ord>(m);
@@ -66,8 +64,7 @@ PYBIND11_MODULE(model, m)
   model::bind_modelbuilderbase<double, long>(m);
 
   // Bind CartesianStructBuilder
-  for (int order = 1; order <= 9; ++order)
-  {
+  for (int order = 1; order <= 9; ++order) {
     model::orderDispatch(order, [&](auto order_tag) {
       constexpr int ord = decltype(order_tag)::value;
       model::bind_cartesian_struct_builder<float, int, ord>(m);

--- a/src/solver/fd/include/fd_solver.h
+++ b/src/solver/fd/include/fd_solver.h
@@ -25,25 +25,20 @@
  * @class fdtd_solver
  */
 
-class FdtdSolver
-{
+class FdtdSolver {
  public:
   /**
    * @brief Constructor of the SEMproxy class
    */
 
-  FdtdSolver(model::fdgrid::FdtdGrids& grids,
-             fdtd::kernel::FdtdKernels& kernels,
-             fdtd::abckernel::FdtdAbcKernels& abckernels,
-             fdtd::stencils::FdtdStencils& stencils,
+  FdtdSolver(model::fdgrid::FdtdGrids& grids, fdtd::kernel::FdtdKernels& kernels,
+             fdtd::abckernel::FdtdAbcKernels& abckernels, fdtd::stencils::FdtdStencils& stencils,
              FdtdSourceReceivers& source_receivers)
       : m_grids(grids),
         m_kernels(kernels),
         m_abckernels(abckernels),
         m_stencils(stencils),
-        m_source_receivers(source_receivers)
-  {
-  }
+        m_source_receivers(source_receivers) {}
 
   /**
    * @brief Destructor of the SEMproxy class

--- a/src/solver/fd/include/fd_source_receivers.h
+++ b/src/solver/fd/include/fd_source_receivers.h
@@ -5,8 +5,7 @@
 #include "fd_macros.h"
 #include "fd_options.h"
 
-struct FdtdSourceReceivers
-{
+struct FdtdSourceReceivers {
   // source location
   int xsrc{-1}, ysrc{-1}, zsrc{-1};
 };

--- a/src/solver/fd/src/fd_solver.cc
+++ b/src/solver/fd/src/fd_solver.cc
@@ -45,102 +45,72 @@
  * @see FdtdSolver::inner3D()
  * @see FdtdSolver::applySponge()
  */
-void FdtdSolver::compute_one_stepSB(int itime, int i1, int i2)
-{
-  m_kernels.addRHS(itime, i2, m_grids.nx(), m_grids.ny(), m_grids.nz(),
-                   m_stencils.lx, m_stencils.ly, m_stencils.lz,
-                   m_source_receivers.xsrc, m_source_receivers.ysrc,
-                   m_source_receivers.zsrc, m_grids.vp(), m_kernels.RHSTerm,
-                   m_kernels.pnGlobal);
+void FdtdSolver::compute_one_stepSB(int itime, int i1, int i2) {
+  m_kernels.addRHS(itime, i2, m_grids.nx(), m_grids.ny(), m_grids.nz(), m_stencils.lx, m_stencils.ly, m_stencils.lz,
+                   m_source_receivers.xsrc, m_source_receivers.ysrc, m_source_receivers.zsrc, m_grids.vp(),
+                   m_kernels.RHSTerm, m_kernels.pnGlobal);
 
   // printf("addRHS done\n");
   FDFENCE
   // inner points
 
-  m_kernels.inner3D(i1, i2, m_grids.nx(), m_grids.ny(), m_grids.nz(),
-                    m_stencils.lx, m_stencils.ly, m_stencils.lz, m_grids.x3(),
-                    m_grids.x4(), m_grids.y3(), m_grids.y4(), m_grids.z3(),
-                    m_grids.z4(), m_stencils.coef0, m_stencils.coefx,
-                    m_stencils.coefy, m_stencils.coefz, m_grids.vp(),
+  m_kernels.inner3D(i1, i2, m_grids.nx(), m_grids.ny(), m_grids.nz(), m_stencils.lx, m_stencils.ly, m_stencils.lz,
+                    m_grids.x3(), m_grids.x4(), m_grids.y3(), m_grids.y4(), m_grids.z3(), m_grids.z4(),
+                    m_stencils.coef0, m_stencils.coefx, m_stencils.coefy, m_stencils.coefz, m_grids.vp(),
                     m_kernels.pnGlobal);
   // printf("inner3D done\n");
   FDFENCE
   // apply sponge boundary to wavefield
-  m_kernels.applySponge(i1, i2, m_grids.nx(), m_grids.ny(), m_grids.nz(),
-                        m_stencils.lx, m_stencils.ly, m_stencils.lz,
-                        m_grids.x3(), m_grids.x4(), m_grids.y3(), m_grids.y4(),
-                        m_grids.z3(), m_grids.z4(), m_abckernels.spongeArray,
-                        m_kernels.pnGlobal);
+  m_kernels.applySponge(i1, i2, m_grids.nx(), m_grids.ny(), m_grids.nz(), m_stencils.lx, m_stencils.ly, m_stencils.lz,
+                        m_grids.x3(), m_grids.x4(), m_grids.y3(), m_grids.y4(), m_grids.z3(), m_grids.z4(),
+                        m_abckernels.spongeArray, m_kernels.pnGlobal);
   // printf("applySponge done\n");
   FDFENCE
 }
 
-void FdtdSolver::compute_one_stepPML(int itime, int i1, int i2)
-{
-  m_kernels.addRHS(itime, i2, m_grids.nx(), m_grids.ny(), m_grids.nz(),
-                   m_stencils.lx, m_stencils.ly, m_stencils.lz,
-                   m_source_receivers.xsrc, m_source_receivers.ysrc,
-                   m_source_receivers.zsrc, m_grids.vp(), m_kernels.RHSTerm,
-                   m_kernels.pnGlobal);
+void FdtdSolver::compute_one_stepPML(int itime, int i1, int i2) {
+  m_kernels.addRHS(itime, i2, m_grids.nx(), m_grids.ny(), m_grids.nz(), m_stencils.lx, m_stencils.ly, m_stencils.lz,
+                   m_source_receivers.xsrc, m_source_receivers.ysrc, m_source_receivers.zsrc, m_grids.vp(),
+                   m_kernels.RHSTerm, m_kernels.pnGlobal);
 
   // printf("addRHS done\n");
   FDFENCE
 
   // update PML
   // up
-  m_kernels.pml3D(i1, i2, m_grids.nx(), m_grids.ny(), m_grids.nz(),
-                  m_stencils.lx, m_stencils.ly, m_stencils.lz, m_grids.x1(),
-                  m_grids.x6(), m_grids.y1(), m_grids.y6(), m_grids.z1(),
-                  m_grids.z2(), m_stencils.coef0, m_grids.hdx_2(),
-                  m_grids.hdy_2(), m_grids.hdz_2(), m_stencils.coefx,
-                  m_stencils.coefy, m_stencils.coefz, m_grids.vp(),
-                  m_abckernels.eta, m_kernels.phi, m_kernels.pnGlobal);
+  m_kernels.pml3D(i1, i2, m_grids.nx(), m_grids.ny(), m_grids.nz(), m_stencils.lx, m_stencils.ly, m_stencils.lz,
+                  m_grids.x1(), m_grids.x6(), m_grids.y1(), m_grids.y6(), m_grids.z1(), m_grids.z2(), m_stencils.coef0,
+                  m_grids.hdx_2(), m_grids.hdy_2(), m_grids.hdz_2(), m_stencils.coefx, m_stencils.coefy,
+                  m_stencils.coefz, m_grids.vp(), m_abckernels.eta, m_kernels.phi, m_kernels.pnGlobal);
   // update front
-  m_kernels.pml3D(i1, i2, m_grids.nx(), m_grids.ny(), m_grids.nz(),
-                  m_stencils.lx, m_stencils.ly, m_stencils.lz, m_grids.x1(),
-                  m_grids.x6(), m_grids.y1(), m_grids.y2(), m_grids.z3(),
-                  m_grids.z4(), m_stencils.coef0, m_grids.hdx_2(),
-                  m_grids.hdy_2(), m_grids.hdz_2(), m_stencils.coefx,
-                  m_stencils.coefy, m_stencils.coefz, m_grids.vp(),
-                  m_abckernels.eta, m_kernels.phi, m_kernels.pnGlobal);
+  m_kernels.pml3D(i1, i2, m_grids.nx(), m_grids.ny(), m_grids.nz(), m_stencils.lx, m_stencils.ly, m_stencils.lz,
+                  m_grids.x1(), m_grids.x6(), m_grids.y1(), m_grids.y2(), m_grids.z3(), m_grids.z4(), m_stencils.coef0,
+                  m_grids.hdx_2(), m_grids.hdy_2(), m_grids.hdz_2(), m_stencils.coefx, m_stencils.coefy,
+                  m_stencils.coefz, m_grids.vp(), m_abckernels.eta, m_kernels.phi, m_kernels.pnGlobal);
   // update left
-  m_kernels.pml3D(i1, i2, m_grids.nx(), m_grids.ny(), m_grids.nz(),
-                  m_stencils.lx, m_stencils.ly, m_stencils.lz, m_grids.x1(),
-                  m_grids.x2(), m_grids.y3(), m_grids.y4(), m_grids.z3(),
-                  m_grids.z4(), m_stencils.coef0, m_grids.hdx_2(),
-                  m_grids.hdy_2(), m_grids.hdz_2(), m_stencils.coefx,
-                  m_stencils.coefy, m_stencils.coefz, m_grids.vp(),
-                  m_abckernels.eta, m_kernels.phi, m_kernels.pnGlobal);
+  m_kernels.pml3D(i1, i2, m_grids.nx(), m_grids.ny(), m_grids.nz(), m_stencils.lx, m_stencils.ly, m_stencils.lz,
+                  m_grids.x1(), m_grids.x2(), m_grids.y3(), m_grids.y4(), m_grids.z3(), m_grids.z4(), m_stencils.coef0,
+                  m_grids.hdx_2(), m_grids.hdy_2(), m_grids.hdz_2(), m_stencils.coefx, m_stencils.coefy,
+                  m_stencils.coefz, m_grids.vp(), m_abckernels.eta, m_kernels.phi, m_kernels.pnGlobal);
   // inner points
-  m_kernels.inner3D(i1, i2, m_grids.nx(), m_grids.ny(), m_grids.nz(),
-                    m_stencils.lx, m_stencils.ly, m_stencils.lz, m_grids.x3(),
-                    m_grids.x4(), m_grids.y3(), m_grids.y4(), m_grids.z3(),
-                    m_grids.z4(), m_stencils.coef0, m_stencils.coefx,
-                    m_stencils.coefy, m_stencils.coefz, m_grids.vp(),
+  m_kernels.inner3D(i1, i2, m_grids.nx(), m_grids.ny(), m_grids.nz(), m_stencils.lx, m_stencils.ly, m_stencils.lz,
+                    m_grids.x3(), m_grids.x4(), m_grids.y3(), m_grids.y4(), m_grids.z3(), m_grids.z4(),
+                    m_stencils.coef0, m_stencils.coefx, m_stencils.coefy, m_stencils.coefz, m_grids.vp(),
                     m_kernels.pnGlobal);
   // update right
-  m_kernels.pml3D(i1, i2, m_grids.nx(), m_grids.ny(), m_grids.nz(),
-                  m_stencils.lx, m_stencils.ly, m_stencils.lz, m_grids.x5(),
-                  m_grids.x6(), m_grids.y3(), m_grids.y4(), m_grids.z3(),
-                  m_grids.z4(), m_stencils.coef0, m_grids.hdx_2(),
-                  m_grids.hdy_2(), m_grids.hdz_2(), m_stencils.coefx,
-                  m_stencils.coefy, m_stencils.coefz, m_grids.vp(),
-                  m_abckernels.eta, m_kernels.phi, m_kernels.pnGlobal);
+  m_kernels.pml3D(i1, i2, m_grids.nx(), m_grids.ny(), m_grids.nz(), m_stencils.lx, m_stencils.ly, m_stencils.lz,
+                  m_grids.x5(), m_grids.x6(), m_grids.y3(), m_grids.y4(), m_grids.z3(), m_grids.z4(), m_stencils.coef0,
+                  m_grids.hdx_2(), m_grids.hdy_2(), m_grids.hdz_2(), m_stencils.coefx, m_stencils.coefy,
+                  m_stencils.coefz, m_grids.vp(), m_abckernels.eta, m_kernels.phi, m_kernels.pnGlobal);
   // update back
-  m_kernels.pml3D(i1, i2, m_grids.nx(), m_grids.ny(), m_grids.nz(),
-                  m_stencils.lx, m_stencils.ly, m_stencils.lz, m_grids.x1(),
-                  m_grids.x6(), m_grids.y5(), m_grids.y6(), m_grids.z3(),
-                  m_grids.z4(), m_stencils.coef0, m_grids.hdx_2(),
-                  m_grids.hdy_2(), m_grids.hdz_2(), m_stencils.coefx,
-                  m_stencils.coefy, m_stencils.coefz, m_grids.vp(),
-                  m_abckernels.eta, m_kernels.phi, m_kernels.pnGlobal);
+  m_kernels.pml3D(i1, i2, m_grids.nx(), m_grids.ny(), m_grids.nz(), m_stencils.lx, m_stencils.ly, m_stencils.lz,
+                  m_grids.x1(), m_grids.x6(), m_grids.y5(), m_grids.y6(), m_grids.z3(), m_grids.z4(), m_stencils.coef0,
+                  m_grids.hdx_2(), m_grids.hdy_2(), m_grids.hdz_2(), m_stencils.coefx, m_stencils.coefy,
+                  m_stencils.coefz, m_grids.vp(), m_abckernels.eta, m_kernels.phi, m_kernels.pnGlobal);
   // update bottom
-  m_kernels.pml3D(i1, i2, m_grids.nx(), m_grids.ny(), m_grids.nz(),
-                  m_stencils.lx, m_stencils.ly, m_stencils.lz, m_grids.x1(),
-                  m_grids.x6(), m_grids.y1(), m_grids.y6(), m_grids.z5(),
-                  m_grids.z6(), m_stencils.coef0, m_grids.hdx_2(),
-                  m_grids.hdy_2(), m_grids.hdz_2(), m_stencils.coefx,
-                  m_stencils.coefy, m_stencils.coefz, m_grids.vp(),
-                  m_abckernels.eta, m_kernels.phi, m_kernels.pnGlobal);
+  m_kernels.pml3D(i1, i2, m_grids.nx(), m_grids.ny(), m_grids.nz(), m_stencils.lx, m_stencils.ly, m_stencils.lz,
+                  m_grids.x1(), m_grids.x6(), m_grids.y1(), m_grids.y6(), m_grids.z5(), m_grids.z6(), m_stencils.coef0,
+                  m_grids.hdx_2(), m_grids.hdy_2(), m_grids.hdz_2(), m_stencils.coefx, m_stencils.coefy,
+                  m_stencils.coefz, m_grids.vp(), m_abckernels.eta, m_kernels.phi, m_kernels.pnGlobal);
   FDFENCE
 }

--- a/src/solver/fe/api/include/physics_traits.h
+++ b/src/solver/fe/api/include/physics_traits.h
@@ -3,10 +3,8 @@
 
 #include "sem_enums.h"
 
-namespace solver
-{
-namespace fe
-{
+namespace solver {
+namespace fe {
 
 /**
  * @brief Compile-time properties for each physics type.
@@ -22,8 +20,7 @@ namespace fe
  * or physics-specific trait headers for full definitions.
  */
 template <utils::enums::physicType PHYSICS>
-struct PhysicsTraits
-{
+struct PhysicsTraits {
   static constexpr const char* kName = "";
   using WavefieldType = void;
   using RhsType = void;

--- a/src/solver/fe/api/include/rhs.h
+++ b/src/solver/fe/api/include/rhs.h
@@ -1,15 +1,12 @@
 #ifndef FUNTIDES_SOLVER_FE_API_INCLUDE_RHS_H_
 #define FUNTIDES_SOLVER_FE_API_INCLUDE_RHS_H_
 #include "common_macros.h"
-namespace solver
-{
-namespace fe
-{
+namespace solver {
+namespace fe {
 /**
  * @brief Base RHS data structure.
  */
-struct Rhs
-{
+struct Rhs {
   PROXY_HOST_DEVICE
   virtual ~Rhs() = default;
 

--- a/src/solver/fe/api/include/solver.h
+++ b/src/solver/fe/api/include/solver.h
@@ -6,21 +6,17 @@
 #include "model.h"
 #include "parallel_topology.h"
 
-namespace solver
-{
-namespace fe
-{
+namespace solver {
+namespace fe {
 /**
  * @brief Base FE solver.
  */
-class Solver
-{
+class Solver {
  public:
   Solver() = default;
   virtual ~Solver() = default;
 
-  struct DataStruct
-  {
+  struct DataStruct {
     // Base structure for data passed to the solver
     PROXY_HOST_DEVICE
     virtual ~DataStruct() = default;
@@ -29,8 +25,7 @@ class Solver
   };
 
   // Pure virtual function to compute one step of the solver
-  virtual void computeOneStep(const float& dt, const int& timeSample,
-                              DataStruct& data) = 0;
+  virtual void computeOneStep(const float& dt, const int& timeSample, DataStruct& data) = 0;
 
   /**
    * @brief Initialize all finite element structures:
@@ -45,10 +40,8 @@ class Solver
    *                       for geophysics to preserve natural reflections).
    * @param taper_delta_ Attenuation parameter for sponge layers.
    */
-  virtual void computeFEInit(model::ModelApi<float, int>& mesh,
-                             const std::array<float, 3>& sponge_size,
-                             const bool surface_sponge,
-                             const float taper_delta_) = 0;
+  virtual void computeFEInit(model::ModelApi<float, int>& mesh, const std::array<float, 3>& sponge_size,
+                             const bool surface_sponge, const float taper_delta_) = 0;
 
   /**
    * @brief Initialize arrays required by the finite element solver.
@@ -99,9 +92,7 @@ class Solver
    * @param[in] fieldName Name/identifier of the field being output (as a
    *                      C-string)
    */
-  virtual void outputSolutionValues(const int& t, int& e,
-                                    const VECTOR_REAL_VIEW& field,
-                                    const char* fieldName) = 0;
+  virtual void outputSolutionValues(const int& t, int& e, const VECTOR_REAL_VIEW& field, const char* fieldName) = 0;
 
   // --- Domain Decomposition Interface ---
 
@@ -155,8 +146,7 @@ class Solver
    * via BoundarySynchronizer after calling this method and before calling
    * updateSolution.
    */
-  virtual void computeForces(const float& dt, const int& timeSample,
-                             DataStruct& data) = 0;
+  virtual void computeForces(const float& dt, const int& timeSample, DataStruct& data) = 0;
 
   /**
    * @brief Phase 2 of time step: Update solution using mass matrix and forces.
@@ -168,10 +158,8 @@ class Solver
 
   virtual void setAnisotropyType(model::AnisotropyType type) = 0;
 
-  virtual void setSLSAttenuation(
-      const VECTOR_REAL_VIEW& reference_frequencies,
-      const VECTOR_REAL_VIEW& anelasticity_coefficients =
-          VECTOR_REAL_VIEW()) = 0;
+  virtual void setSLSAttenuation(const VECTOR_REAL_VIEW& reference_frequencies,
+                                 const VECTOR_REAL_VIEW& anelasticity_coefficients = VECTOR_REAL_VIEW()) = 0;
 };
 }  // namespace fe
 }  // namespace solver

--- a/src/solver/fe/api/include/wavefield.h
+++ b/src/solver/fe/api/include/wavefield.h
@@ -1,15 +1,12 @@
 #ifndef FUNTIDES_SOLVER_FE_API_INCLUDE_WAVEFIELD_H_
 #define FUNTIDES_SOLVER_FE_API_INCLUDE_WAVEFIELD_H_
 #include "common_macros.h"
-namespace solver
-{
-namespace fe
-{
+namespace solver {
+namespace fe {
 /**
  * @brief Base Wavefield data structure.
  */
-struct Wavefield
-{
+struct Wavefield {
   PROXY_HOST_DEVICE
   virtual ~Wavefield() = default;
 

--- a/src/solver/fe/impl/acoustic/include/physics_traits_acoustic.h
+++ b/src/solver/fe/impl/acoustic/include/physics_traits_acoustic.h
@@ -5,10 +5,8 @@
 #include "rhs_acoustic.h"
 #include "wavefield_acoustic.h"
 
-namespace solver
-{
-namespace fe
-{
+namespace solver {
+namespace fe {
 
 /**
  * @brief Specialization for acoustic physics.
@@ -16,8 +14,7 @@ namespace fe
  * Acoustic wave propagation uses a single scalar pressure field.
  */
 template <>
-struct PhysicsTraits<utils::enums::physicType::kAcoustic>
-{
+struct PhysicsTraits<utils::enums::physicType::kAcoustic> {
   /// Human-readable name for logging
   static constexpr const char* kName = "Acoustic";
 

--- a/src/solver/fe/impl/acoustic/include/rhs_acoustic.h
+++ b/src/solver/fe/impl/acoustic/include/rhs_acoustic.h
@@ -4,15 +4,12 @@
 
 #include "rhs.h"
 
-namespace solver
-{
-namespace fe
-{
+namespace solver {
+namespace fe {
 /**
  * @brief Acoustic RHS data structure.
  */
-struct RhsAcoustic : public Rhs
-{
+struct RhsAcoustic : public Rhs {
   /// Number of RHS (source) components
   static constexpr int kNumRhsComponents = 1;
 
@@ -23,11 +20,8 @@ struct RhsAcoustic : public Rhs
   PROXY_HOST_DEVICE RhsAcoustic& operator=(const RhsAcoustic&) = default;
 
   PROXY_HOST_DEVICE
-  RhsAcoustic(ARRAY_REAL_VIEW term, VECTOR_INT_VIEW element,
-              ARRAY_REAL_VIEW weights)
-      : m_term(term), m_element(element), m_weights(weights)
-  {
-  }
+  RhsAcoustic(ARRAY_REAL_VIEW term, VECTOR_INT_VIEW element, ARRAY_REAL_VIEW weights)
+      : m_term(term), m_element(element), m_weights(weights) {}
 
   int getNumRhsComponents() const override final { return kNumRhsComponents; }
 
@@ -40,8 +34,7 @@ struct RhsAcoustic : public Rhs
   PROXY_HOST_DEVICE
   ARRAY_REAL_VIEW getWeights() const { return m_weights; }
 
-  void print() const override
-  {
+  void print() const override {
     std::cout << "RHS Term size:    " << m_term.extent(0) << std::endl;
     std::cout << "RHS Element size: " << m_element.extent(0) << std::endl;
     std::cout << "RHS Weights size: " << m_weights.extent(0) << std::endl;

--- a/src/solver/fe/impl/acoustic/include/wavefield_acoustic.h
+++ b/src/solver/fe/impl/acoustic/include/wavefield_acoustic.h
@@ -4,16 +4,13 @@
 
 #include "wavefield.h"
 
-namespace solver
-{
-namespace fe
-{
+namespace solver {
+namespace fe {
 /**
  * @brief Acoustic wavefield data structure.
  * Arrays are kept flat for easy cpp-python-fortran interop.
  */
-struct WavefieldAcoustic : public Wavefield
-{
+struct WavefieldAcoustic : public Wavefield {
   /// Number of solution fields (1 for pressure)
   static constexpr int kNumFields = 1;
 
@@ -24,51 +21,34 @@ struct WavefieldAcoustic : public Wavefield
   PROXY_HOST_DEVICE WavefieldAcoustic() = default;
   PROXY_HOST_DEVICE ~WavefieldAcoustic() = default;
   PROXY_HOST_DEVICE WavefieldAcoustic(const WavefieldAcoustic&) = default;
-  PROXY_HOST_DEVICE WavefieldAcoustic& operator=(const WavefieldAcoustic&) =
-      default;
+  PROXY_HOST_DEVICE WavefieldAcoustic& operator=(const WavefieldAcoustic&) = default;
 
   PROXY_HOST_DEVICE
-  WavefieldAcoustic(VECTOR_REAL_VIEW pnGlobalPrev,
-                    VECTOR_REAL_VIEW pnGlobalCurr)
-      : m_pnGlobalPrev(pnGlobalPrev), m_pnGlobalCurr(pnGlobalCurr)
-  {
-  }
+  WavefieldAcoustic(VECTOR_REAL_VIEW pnGlobalPrev, VECTOR_REAL_VIEW pnGlobalCurr)
+      : m_pnGlobalPrev(pnGlobalPrev), m_pnGlobalCurr(pnGlobalCurr) {}
 
   int getNumFields() const override final { return kNumFields; }
 
-  const char* const* getFieldNames() const override final
-  {
-    return kFieldNames;
-  }
+  const char* const* getFieldNames() const override final { return kFieldNames; }
 
   PROXY_HOST_DEVICE
-  VECTOR_REAL_VIEW getCurrentField(int i) const override
-  {
-    return m_pnGlobalCurr;
-  }
+  VECTOR_REAL_VIEW getCurrentField(int i) const override { return m_pnGlobalCurr; }
 
   PROXY_HOST_DEVICE
-  VECTOR_REAL_VIEW getPreviousField(int i) const override
-  {
-    return m_pnGlobalPrev;
-  }
+  VECTOR_REAL_VIEW getPreviousField(int i) const override { return m_pnGlobalPrev; }
 
   void swap() override { std::swap(m_pnGlobalPrev, m_pnGlobalCurr); }
 
-  void swapWithRotation(VECTOR_REAL_VIEW& prevPrevBuffer, int i) override
-  {
+  void swapWithRotation(VECTOR_REAL_VIEW& prevPrevBuffer, int i) override {
     VECTOR_REAL_VIEW tmp = prevPrevBuffer;
     prevPrevBuffer = m_pnGlobalPrev;
     m_pnGlobalPrev = m_pnGlobalCurr;
     m_pnGlobalCurr = tmp;
   }
 
-  void print() const override
-  {
-    std::cout << "Pn Global Prev size: " << m_pnGlobalPrev.extent(0)
-              << std::endl;
-    std::cout << "Pn Global Curr size: " << m_pnGlobalCurr.extent(0)
-              << std::endl;
+  void print() const override {
+    std::cout << "Pn Global Prev size: " << m_pnGlobalPrev.extent(0) << std::endl;
+    std::cout << "Pn Global Curr size: " << m_pnGlobalCurr.extent(0) << std::endl;
   }
 
   VECTOR_REAL_VIEW m_pnGlobalPrev;  ///< Pressure field at previous time step

--- a/src/solver/fe/impl/acoustoelastic/include/rhs_acoustoelastic.h
+++ b/src/solver/fe/impl/acoustoelastic/include/rhs_acoustoelastic.h
@@ -7,10 +7,8 @@
 #include "rhs_acoustic.h"
 #include "rhs_elastic.h"
 
-namespace solver
-{
-namespace fe
-{
+namespace solver {
+namespace fe {
 
 /**
  * @brief RHS data structure for the acousto-elastic coupled solver.
@@ -21,8 +19,7 @@ namespace fe
  * @ref RhsAcoustic / @ref RhsElastic member directly, so @p getTerm() is
  * provided for interface compliance only.
  */
-struct RhsAcoustoElastic : public Rhs
-{
+struct RhsAcoustoElastic : public Rhs {
   /// Number of RHS components: 1 acoustic (p) + 3 elastic (fx, fy, fz).
   static constexpr int kNumRhsComponents = 4;
 
@@ -34,22 +31,16 @@ struct RhsAcoustoElastic : public Rhs
    * @param elastic_termy  Y-component elastic source signals.
    * @param elastic_termz  Z-component elastic source signals.
    */
-  RhsAcoustoElastic(ARRAY_REAL_VIEW acoustic_term, VECTOR_INT_VIEW element,
-                    ARRAY_REAL_VIEW weights, ARRAY_REAL_VIEW elastic_termx,
-                    ARRAY_REAL_VIEW elastic_termy,
-                    ARRAY_REAL_VIEW elastic_termz)
+  RhsAcoustoElastic(ARRAY_REAL_VIEW acoustic_term, VECTOR_INT_VIEW element, ARRAY_REAL_VIEW weights,
+                    ARRAY_REAL_VIEW elastic_termx, ARRAY_REAL_VIEW elastic_termy, ARRAY_REAL_VIEW elastic_termz)
       : m_rhs_acoustic(acoustic_term, element, weights),
-        m_rhs_elastic(elastic_termx, elastic_termy, elastic_termz, element,
-                      weights)
-  {
-  }
+        m_rhs_elastic(elastic_termx, elastic_termy, elastic_termz, element, weights) {}
 
   int getNumRhsComponents() const override final { return kNumRhsComponents; }
 
   /// @brief Returns term i: 0 = acoustic, 1/2/3 = elastic x/y/z.
   PROXY_HOST_DEVICE
-  ARRAY_REAL_VIEW getTerm(int i) const override
-  {
+  ARRAY_REAL_VIEW getTerm(int i) const override {
     if (i == 0) return m_rhs_acoustic.getTerm(0);
     return m_rhs_elastic.getTerm(i - 1);
   }
@@ -60,8 +51,7 @@ struct RhsAcoustoElastic : public Rhs
   PROXY_HOST_DEVICE
   ARRAY_REAL_VIEW getWeights() const { return m_rhs_acoustic.getWeights(); }
 
-  void print() const override
-  {
+  void print() const override {
     m_rhs_acoustic.print();
     m_rhs_elastic.print();
   }

--- a/src/solver/fe/impl/acoustoelastic/include/sem_solver_acoustoelastic.h
+++ b/src/solver/fe/impl/acoustoelastic/include/sem_solver_acoustoelastic.h
@@ -13,10 +13,8 @@
 #include "solver.h"
 #include "wavefield_acoustoelastic.h"
 
-namespace solver
-{
-namespace fe
-{
+namespace solver {
+namespace fe {
 
 /// Element belongs to the acoustic (fluid) domain.
 static constexpr int kElementTypeAcoustic = 1;
@@ -29,20 +27,15 @@ static constexpr int kElementTypeElastic = 2;
  * Combines the acoustic wavefield, the elastic wavefield, and the acoustic
  * source term (source in the fluid domain only for this V1).
  */
-struct SEMsolverDataAcoustoElastic : public Solver::DataStruct
-{
+struct SEMsolverDataAcoustoElastic : public Solver::DataStruct {
   /**
    * @param wavefield Combined acousto-elastic wavefield (p + ux/uy/uz).
    * @param rhs       Acoustic source term applied to the fluid domain.
    */
-  SEMsolverDataAcoustoElastic(const WavefieldAcoustoElastic& wavefield,
-                              const RhsAcoustoElastic& rhs)
-      : m_wavefield(wavefield), m_rhs(rhs)
-  {
-  }
+  SEMsolverDataAcoustoElastic(const WavefieldAcoustoElastic& wavefield, const RhsAcoustoElastic& rhs)
+      : m_wavefield(wavefield), m_rhs(rhs) {}
 
-  void print() const override
-  {
+  void print() const override {
     m_wavefield.print();
     m_rhs.print();
   }
@@ -68,17 +61,13 @@ struct SEMsolverDataAcoustoElastic : public Solver::DataStruct
  * @tparam MESH_TYPE         Mesh implementation (ModelStruct or ModelUnstruct).
  * @tparam IS_MODEL_ON_NODES If true, material properties are stored on nodes.
  */
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-class SEMsolverAcoustoElastic : public Solver
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+class SEMsolverAcoustoElastic : public Solver {
  public:
   using AcousticSolverType =
-      SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
-                utils::enums::physicType::kAcoustic>;
+      SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, utils::enums::physicType::kAcoustic>;
   using ElasticSolverType =
-      SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
-                utils::enums::physicType::kElastic>;
+      SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, utils::enums::physicType::kElastic>;
   using DataType = SEMsolverDataAcoustoElastic;
 
   SEMsolverAcoustoElastic() = default;
@@ -89,33 +78,23 @@ class SEMsolverAcoustoElastic : public Solver
   int getNumComponents() const override { return 4; }  // p, ux, uy, uz
 
   /// @brief Returns the acoustic sub-solver mass matrix for DD synchronization.
-  VECTOR_REAL_VIEW& getMassMatrixAcoustic() override
-  {
-    return m_acoustic_solver_.getMassMatrixAcoustic();
-  }
+  VECTOR_REAL_VIEW& getMassMatrixAcoustic() override { return m_acoustic_solver_.getMassMatrixAcoustic(); }
 
   /// @brief Returns the elastic sub-solver mass matrix for DD synchronization.
-  VECTOR_REAL_VIEW& getMassMatrixElastic() override
-  {
-    return m_elastic_solver_.getMassMatrixElastic();
-  }
+  VECTOR_REAL_VIEW& getMassMatrixElastic() override { return m_elastic_solver_.getMassMatrixElastic(); }
 
-  VECTOR_REAL_VIEW& getDampingMatrix(int c) override
-  {
+  VECTOR_REAL_VIEW& getDampingMatrix(int c) override {
     if (c == 0) return m_acoustic_solver_.getDampingMatrix(0);
     return m_elastic_solver_.getDampingMatrix(c - 1);
   }
 
-  VECTOR_REAL_VIEW& getForceVector(int c) override
-  {
+  VECTOR_REAL_VIEW& getForceVector(int c) override {
     if (c == 0) return m_acoustic_solver_.getForceVector(0);
     return m_elastic_solver_.getForceVector(c - 1);
   }
 
-  void computeFEInit(model::ModelApi<float, int>& mesh,
-                     const std::array<float, 3>& sponge_size,
-                     const bool surface_sponge,
-                     const float taper_delta) override;
+  void computeFEInit(model::ModelApi<float, int>& mesh, const std::array<float, 3>& sponge_size,
+                     const bool surface_sponge, const float taper_delta) override;
 
   /**
    * @brief Perform one coupled time step (serial / non-distributed mode).
@@ -124,11 +103,9 @@ class SEMsolverAcoustoElastic : public Solver
    *   elastic forces → elastic update → acoustic forces → acoustic update,
    * with interface coupling applied between the two sub-steps.
    */
-  void computeOneStep(const float& dt, const int& timeSample,
-                      DataStruct& data) override;
+  void computeOneStep(const float& dt, const int& timeSample, DataStruct& data) override;
 
-  void computeForces(const float& dt, const int& timeSample,
-                     DataStruct& data) override;
+  void computeForces(const float& dt, const int& timeSample, DataStruct& data) override;
 
   void updateSolution(const float& dt, DataStruct& data) override;
 
@@ -139,22 +116,14 @@ class SEMsolverAcoustoElastic : public Solver
   void computeGlobalMassMatrix() override;
   void computeDampingMatrix() override;
 
-  void outputSolutionValues(const int& t, int& e, const VECTOR_REAL_VIEW& field,
-                            const char* fieldName) override;
+  void outputSolutionValues(const int& t, int& e, const VECTOR_REAL_VIEW& field, const char* fieldName) override;
 
-  void setAnisotropyType(model::AnisotropyType type) override
-  {
-    m_elastic_solver_.setAnisotropyType(type);
-  }
+  void setAnisotropyType(model::AnisotropyType type) override { m_elastic_solver_.setAnisotropyType(type); }
 
   void setSLSAttenuation(const VECTOR_REAL_VIEW& reference_frequencies,
-                         const VECTOR_REAL_VIEW& anelasticity_coefficients =
-                             VECTOR_REAL_VIEW()) override
-  {
-    m_acoustic_solver_.setSLSAttenuation(reference_frequencies,
-                                         anelasticity_coefficients);
-    m_elastic_solver_.setSLSAttenuation(reference_frequencies,
-                                        anelasticity_coefficients);
+                         const VECTOR_REAL_VIEW& anelasticity_coefficients = VECTOR_REAL_VIEW()) override {
+    m_acoustic_solver_.setSLSAttenuation(reference_frequencies, anelasticity_coefficients);
+    m_elastic_solver_.setSLSAttenuation(reference_frequencies, anelasticity_coefficients);
   }
 
   // --- Accessors for diagnostics ---

--- a/src/solver/fe/impl/acoustoelastic/include/sem_solver_acoustoelastic_impl.h
+++ b/src/solver/fe/impl/acoustoelastic/include/sem_solver_acoustoelastic_impl.h
@@ -12,53 +12,38 @@
 #include "sem_solver_acoustoelastic.h"
 #include "sem_solver_data.h"
 
-namespace solver
-{
-namespace fe
-{
+namespace solver {
+namespace fe {
 
 //============================================================================
 // computeFEInit
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-void SEMsolverAcoustoElastic<
-    ORDER, INTEGRAL_TYPE, MESH_TYPE,
-    IS_MODEL_ON_NODES>::computeFEInit(model::ModelApi<float, int>& mesh_in,
-                                      const std::array<float, 3>& sponge_size,
-                                      const bool surface_sponge,
-                                      const float taper_delta)
-{
-  if (auto* typed = dynamic_cast<MESH_TYPE*>(&mesh_in))
-  {
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::computeFEInit(
+    model::ModelApi<float, int>& mesh_in, const std::array<float, 3>& sponge_size, const bool surface_sponge,
+    const float taper_delta) {
+  if (auto* typed = dynamic_cast<MESH_TYPE*>(&mesh_in)) {
     m_mesh_ = *typed;
-  }
-  else
-  {
-    throw std::runtime_error(
-        "SEMsolverAcoustoElastic: incompatible mesh type in computeFEInit");
+  } else {
+    throw std::runtime_error("SEMsolverAcoustoElastic: incompatible mesh type in computeFEInit");
   }
 
   // Initialise sub-solvers (mass/damping matrices are overridden below).
-  m_acoustic_solver_.computeFEInit(mesh_in, sponge_size, surface_sponge,
-                                   taper_delta);
-  m_elastic_solver_.computeFEInit(mesh_in, sponge_size, surface_sponge,
-                                  taper_delta);
+  m_acoustic_solver_.computeFEInit(mesh_in, sponge_size, surface_sponge, taper_delta);
+  m_elastic_solver_.computeFEInit(mesh_in, sponge_size, surface_sponge, taper_delta);
 
   allocateFEarrays();
 
   TagElements();
-  std::cout << "SEMsolverAcoustoElastic: " << num_acoustic_elements_
-            << " acoustic elements, " << num_elastic_elements_
+  std::cout << "SEMsolverAcoustoElastic: " << num_acoustic_elements_ << " acoustic elements, " << num_elastic_elements_
             << " elastic elements." << std::endl;
 
   computeGlobalMassMatrix();
   computeDampingMatrix();
 
   TagNodes();
-  std::cout << "SEMsolverAcoustoElastic: " << num_interface_nodes_
-            << " interface nodes." << std::endl;
+  std::cout << "SEMsolverAcoustoElastic: " << num_interface_nodes_ << " interface nodes." << std::endl;
 
   ComputeInterfaceCouplingCoefficients();
 }
@@ -67,25 +52,17 @@ void SEMsolverAcoustoElastic<
 // allocateFEarrays
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
-                             IS_MODEL_ON_NODES>::allocateFEarrays()
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::allocateFEarrays() {
   int const nElem = m_mesh_.getNumberOfElements();
   int const nNode = m_mesh_.getNumberOfNodes();
 
-  m_element_type_ =
-      allocateVector<VECTOR_INT_VIEW>(nElem, "acoustoElasticElementType");
-  m_interface_node_index_ =
-      allocateVector<VECTOR_INT_VIEW>(nNode, "interfaceNodeIndex");
+  m_element_type_ = allocateVector<VECTOR_INT_VIEW>(nElem, "acoustoElasticElementType");
+  m_interface_node_index_ = allocateVector<VECTOR_INT_VIEW>(nNode, "interfaceNodeIndex");
 
-  m_coupling_coeff_x_ =
-      allocateVector<VECTOR_REAL_VIEW>(nNode, "couplingCoeffX");
-  m_coupling_coeff_y_ =
-      allocateVector<VECTOR_REAL_VIEW>(nNode, "couplingCoeffY");
-  m_coupling_coeff_z_ =
-      allocateVector<VECTOR_REAL_VIEW>(nNode, "couplingCoeffZ");
+  m_coupling_coeff_x_ = allocateVector<VECTOR_REAL_VIEW>(nNode, "couplingCoeffX");
+  m_coupling_coeff_y_ = allocateVector<VECTOR_REAL_VIEW>(nNode, "couplingCoeffY");
+  m_coupling_coeff_z_ = allocateVector<VECTOR_REAL_VIEW>(nNode, "couplingCoeffZ");
 
   auto interface_node_index = m_interface_node_index_;
   auto coupling_coeff_x = m_coupling_coeff_x_;
@@ -105,20 +82,14 @@ void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
 // initFEarrays / initSpongeValues
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
-                             IS_MODEL_ON_NODES>::initFEarrays()
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::initFEarrays() {
   // Sub-solvers handle their own sponge via computeFEInit.
   // The coupled solver's sponge taper is initialised in allocateFEarrays.
 }
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
-                             IS_MODEL_ON_NODES>::initSpongeValues()
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::initSpongeValues() {
   // Sponge taper is owned by each sub-solver; delegate reinitialisation.
   m_acoustic_solver_.initSpongeValues();
   m_elastic_solver_.initSpongeValues();
@@ -128,12 +99,8 @@ void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
 // resetGlobalVectors
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-void SEMsolverAcoustoElastic<
-    ORDER, INTEGRAL_TYPE, MESH_TYPE,
-    IS_MODEL_ON_NODES>::resetGlobalVectors(int numNodes)
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::resetGlobalVectors(int numNodes) {
   auto acoustic_w0 = m_acoustic_solver_.getForceVector(0);
   auto elastic_w0 = m_elastic_solver_.getForceVector(0);
   auto elastic_w1 = m_elastic_solver_.getForceVector(1);
@@ -152,41 +119,31 @@ void SEMsolverAcoustoElastic<
 // TagElements
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
-                             IS_MODEL_ON_NODES>::TagElements()
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::TagElements() {
   int const nElem = m_mesh_.getNumberOfElements();
   int n_acoustic = 0;
   int n_elastic = 0;
 
-  for (int e = 0; e < nElem; ++e)
-  {
+  for (int e = 0; e < nElem; ++e) {
     float vs, rho;
-    if constexpr (IS_MODEL_ON_NODES)
-    {
+    if constexpr (IS_MODEL_ON_NODES) {
       // Use interior node to avoid interface contamination (corner node may
       // carry fluid properties when >= convention is used at the boundary).
       int const mid = ORDER / 2;
       int const gIdx = m_mesh_.globalNodeIndex(e, mid, mid, mid);
       vs = m_mesh_.getModelVsOnNodes(gIdx);
       rho = m_mesh_.getModelRhoOnNodes(gIdx);
-    }
-    else
-    {
+    } else {
       vs = m_mesh_.getModelVsOnElement(e);
       rho = m_mesh_.getModelRhoOnElement(e);
     }
 
     float const mu = rho * vs * vs;
-    if (mu < kMuTolerance)
-    {
+    if (mu < kMuTolerance) {
       m_element_type_[e] = kElementTypeAcoustic;
       ++n_acoustic;
-    }
-    else
-    {
+    } else {
       m_element_type_[e] = kElementTypeElastic;
       ++n_elastic;
     }
@@ -195,14 +152,11 @@ void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
   num_acoustic_elements_ = n_acoustic;
   num_elastic_elements_ = n_elastic;
 
-  acoustic_elem_list_ = allocateVector<VECTOR_INT_VIEW>(num_acoustic_elements_,
-                                                        "acousticElemList");
-  elastic_elem_list_ =
-      allocateVector<VECTOR_INT_VIEW>(num_elastic_elements_, "elasticElemList");
+  acoustic_elem_list_ = allocateVector<VECTOR_INT_VIEW>(num_acoustic_elements_, "acousticElemList");
+  elastic_elem_list_ = allocateVector<VECTOR_INT_VIEW>(num_elastic_elements_, "elasticElemList");
   int ia = 0;
   int ie = 0;
-  for (int e = 0; e < nElem; ++e)
-  {
+  for (int e = 0; e < nElem; ++e) {
     if (m_element_type_[e] == kElementTypeAcoustic)
       acoustic_elem_list_[ia++] = e;
     else
@@ -214,19 +168,14 @@ void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
 // TagNodes
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
-                             IS_MODEL_ON_NODES>::TagNodes()
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::TagNodes() {
   int const nNode = m_mesh_.getNumberOfNodes();
   int const nElem = m_mesh_.getNumberOfElements();
   int const dim = ORDER + 1;
 
-  VECTOR_INT_VIEW acoustic_count =
-      allocateVector<VECTOR_INT_VIEW>(nNode, "acousticCount");
-  VECTOR_INT_VIEW elastic_count =
-      allocateVector<VECTOR_INT_VIEW>(nNode, "elasticCount");
+  VECTOR_INT_VIEW acoustic_count = allocateVector<VECTOR_INT_VIEW>(nNode, "acousticCount");
+  VECTOR_INT_VIEW elastic_count = allocateVector<VECTOR_INT_VIEW>(nNode, "elasticCount");
 
   Kokkos::parallel_for(
       "TagNodes_initCount", nNode, KOKKOS_LAMBDA(const int i) {
@@ -245,15 +194,11 @@ void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
         int const etype = elem_type[e];
         for (int i = 0; i < dim; ++i)
           for (int j = 0; j < dim; ++j)
-            for (int k = 0; k < dim; ++k)
-            {
+            for (int k = 0; k < dim; ++k) {
               int const gIdx = mesh_local.globalNodeIndex(e, i, j, k);
-              if (etype == kElementTypeAcoustic)
-              {
+              if (etype == kElementTypeAcoustic) {
                 ATOMICADD(acoustic_count[gIdx], 1);
-              }
-              else
-              {
+              } else {
                 ATOMICADD(elastic_count[gIdx], 1);
               }
             }
@@ -261,26 +206,20 @@ void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
   FENCE
 
   int n_interface = 0;
-  for (int n = 0; n < nNode; ++n)
-  {
+  for (int n = 0; n < nNode; ++n) {
     if (acoustic_count[n] > 0 && elastic_count[n] > 0) ++n_interface;
   }
   num_interface_nodes_ = n_interface;
   n_interface_nodes_ = n_interface;
-  m_interface_node_indices_ = allocateVector<VECTOR_INT_VIEW>(
-      n_interface_nodes_, "interfaceNodeIndices");
+  m_interface_node_indices_ = allocateVector<VECTOR_INT_VIEW>(n_interface_nodes_, "interfaceNodeIndices");
 
   int idx = 0;
-  for (int n = 0; n < nNode; ++n)
-  {
-    if (acoustic_count[n] > 0 && elastic_count[n] > 0)
-    {
+  for (int n = 0; n < nNode; ++n) {
+    if (acoustic_count[n] > 0 && elastic_count[n] > 0) {
       m_interface_node_index_[n] = idx;
       m_interface_node_indices_[idx] = n;
       ++idx;
-    }
-    else
-    {
+    } else {
       m_interface_node_index_[n] = -1;
     }
   }
@@ -291,34 +230,26 @@ void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
   // there, elastic solver updates displacement there.
   {
     int n_acou = 0, n_elas = 0;
-    for (int n = 0; n < nNode; ++n)
-    {
+    for (int n = 0; n < nNode; ++n) {
       if (acoustic_count[n] > 0) ++n_acou;
       if (elastic_count[n] > 0) ++n_elas;
     }
     num_acoustic_nodes_ = n_acou;
     num_elastic_nodes_ = n_elas;
-    acoustic_node_list_ =
-        allocateVector<VECTOR_INT_VIEW>(n_acou, "acousticNodeList");
-    elastic_node_list_ =
-        allocateVector<VECTOR_INT_VIEW>(n_elas, "elasticNodeList");
+    acoustic_node_list_ = allocateVector<VECTOR_INT_VIEW>(n_acou, "acousticNodeList");
+    elastic_node_list_ = allocateVector<VECTOR_INT_VIEW>(n_elas, "elasticNodeList");
     int ia = 0, ie = 0;
-    for (int n = 0; n < nNode; ++n)
-    {
+    for (int n = 0; n < nNode; ++n) {
       if (acoustic_count[n] > 0) acoustic_node_list_[ia++] = n;
       if (elastic_count[n] > 0) elastic_node_list_[ie++] = n;
     }
   }
 
   // Allocate compact nm1 arrays (one entry per interface node).
-  m_ux_nm1_iface_ =
-      allocateVector<VECTOR_REAL_VIEW>(n_interface_nodes_, "uxNm1Iface");
-  m_uy_nm1_iface_ =
-      allocateVector<VECTOR_REAL_VIEW>(n_interface_nodes_, "uyNm1Iface");
-  m_uz_nm1_iface_ =
-      allocateVector<VECTOR_REAL_VIEW>(n_interface_nodes_, "uzNm1Iface");
-  for (int i = 0; i < n_interface_nodes_; ++i)
-  {
+  m_ux_nm1_iface_ = allocateVector<VECTOR_REAL_VIEW>(n_interface_nodes_, "uxNm1Iface");
+  m_uy_nm1_iface_ = allocateVector<VECTOR_REAL_VIEW>(n_interface_nodes_, "uyNm1Iface");
+  m_uz_nm1_iface_ = allocateVector<VECTOR_REAL_VIEW>(n_interface_nodes_, "uzNm1Iface");
+  for (int i = 0; i < n_interface_nodes_; ++i) {
     m_ux_nm1_iface_[i] = 0.0f;
     m_uy_nm1_iface_[i] = 0.0f;
     m_uz_nm1_iface_[i] = 0.0f;
@@ -327,21 +258,16 @@ void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
   // Build dual-property interface arrays for IS_MODEL_ON_NODES: solid and
   // fluid properties stored separately so the elastic stiffness and mass
   // kernels use the correct material side.
-  if constexpr (IS_MODEL_ON_NODES)
-  {
+  if constexpr (IS_MODEL_ON_NODES) {
     // Map each interface node to one adjacent elastic element.
-    m_interface_adj_elastic_elem_ = allocateVector<VECTOR_INT_VIEW>(
-        n_interface_nodes_, "interfaceAdjElasticElem");
-    for (int i = 0; i < n_interface_nodes_; ++i)
-      m_interface_adj_elastic_elem_[i] = -1;
+    m_interface_adj_elastic_elem_ = allocateVector<VECTOR_INT_VIEW>(n_interface_nodes_, "interfaceAdjElasticElem");
+    for (int i = 0; i < n_interface_nodes_; ++i) m_interface_adj_elastic_elem_[i] = -1;
 
-    for (int ei = 0; ei < num_elastic_elements_; ++ei)
-    {
+    for (int ei = 0; ei < num_elastic_elements_; ++ei) {
       int const e = elastic_elem_list_[ei];
       for (int ii = 0; ii < dim; ++ii)
         for (int jj = 0; jj < dim; ++jj)
-          for (int kk = 0; kk < dim; ++kk)
-          {
+          for (int kk = 0; kk < dim; ++kk) {
             int const gn = m_mesh_.globalNodeIndex(e, ii, jj, kk);
             int const iface_idx = m_interface_node_index_[gn];
             if (iface_idx >= 0 && m_interface_adj_elastic_elem_[iface_idx] < 0)
@@ -350,19 +276,13 @@ void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
     }
 
     // Allocate compact solid/fluid property arrays.
-    m_vp_solid_iface_ =
-        allocateVector<VECTOR_REAL_VIEW>(n_interface_nodes_, "vpSolidIface");
-    m_vs_solid_iface_ =
-        allocateVector<VECTOR_REAL_VIEW>(n_interface_nodes_, "vsSolidIface");
-    m_rho_solid_iface_ =
-        allocateVector<VECTOR_REAL_VIEW>(n_interface_nodes_, "rhoSolidIface");
-    m_vp_fluid_iface_ =
-        allocateVector<VECTOR_REAL_VIEW>(n_interface_nodes_, "vpFluidIface");
-    m_rho_fluid_iface_ =
-        allocateVector<VECTOR_REAL_VIEW>(n_interface_nodes_, "rhoFluidIface");
+    m_vp_solid_iface_ = allocateVector<VECTOR_REAL_VIEW>(n_interface_nodes_, "vpSolidIface");
+    m_vs_solid_iface_ = allocateVector<VECTOR_REAL_VIEW>(n_interface_nodes_, "vsSolidIface");
+    m_rho_solid_iface_ = allocateVector<VECTOR_REAL_VIEW>(n_interface_nodes_, "rhoSolidIface");
+    m_vp_fluid_iface_ = allocateVector<VECTOR_REAL_VIEW>(n_interface_nodes_, "vpFluidIface");
+    m_rho_fluid_iface_ = allocateVector<VECTOR_REAL_VIEW>(n_interface_nodes_, "rhoFluidIface");
 
-    for (int i = 0; i < n_interface_nodes_; ++i)
-    {
+    for (int i = 0; i < n_interface_nodes_; ++i) {
       int const j = m_interface_node_indices_[i];
 
       // Fluid side: current values in the mesh (assigned by the builder with
@@ -374,15 +294,12 @@ void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
       // element to avoid picking up fluid-contaminated corner properties.
       int const e_adj = m_interface_adj_elastic_elem_[i];
       bool found = false;
-      if (e_adj >= 0)
-      {
+      if (e_adj >= 0) {
         for (int ii = 0; ii < dim && !found; ++ii)
           for (int jj = 0; jj < dim && !found; ++jj)
-            for (int kk = 0; kk < dim && !found; ++kk)
-            {
+            for (int kk = 0; kk < dim && !found; ++kk) {
               int const g = m_mesh_.globalNodeIndex(e_adj, ii, jj, kk);
-              if (m_interface_node_index_[g] < 0)
-              {
+              if (m_interface_node_index_[g] < 0) {
                 m_vp_solid_iface_[i] = m_mesh_.getModelVpOnNodes(g);
                 m_vs_solid_iface_[i] = m_mesh_.getModelVsOnNodes(g);
                 m_rho_solid_iface_[i] = m_mesh_.getModelRhoOnNodes(g);
@@ -390,8 +307,7 @@ void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
               }
             }
       }
-      if (!found)
-      {
+      if (!found) {
         // Fallback: no non-interface node found (degenerate case).
         m_vp_solid_iface_[i] = m_vp_fluid_iface_[i];
         m_vs_solid_iface_[i] = 0.0f;
@@ -403,13 +319,11 @@ void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
     // before TagNodes and integrated rho_fluid over elastic elements.  In SEM
     // the lumped mass M_e[j] = rho[j] * J * w_j, so the correction is exact.
     auto elastic_mass = m_elastic_solver_.getMassMatrixElastic();
-    for (int i = 0; i < n_interface_nodes_; ++i)
-    {
+    for (int i = 0; i < n_interface_nodes_; ++i) {
       int const j = m_interface_node_indices_[i];
       float const rho_fluid = m_rho_fluid_iface_[i];
       float const rho_solid = m_rho_solid_iface_[i];
-      if (rho_fluid > 0.0f && rho_solid != rho_fluid)
-        elastic_mass[j] *= rho_solid / rho_fluid;
+      if (rho_fluid > 0.0f && rho_solid != rho_fluid) elastic_mass[j] *= rho_solid / rho_fluid;
     }
     FENCE
   }
@@ -419,51 +333,38 @@ void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
 // ComputeInterfaceCouplingCoefficients
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-void SEMsolverAcoustoElastic<
-    ORDER, INTEGRAL_TYPE, MESH_TYPE,
-    IS_MODEL_ON_NODES>::ComputeInterfaceCouplingCoefficients()
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
+                             IS_MODEL_ON_NODES>::ComputeInterfaceCouplingCoefficients() {
   constexpr int numNodesPerFace = (ORDER + 1) * (ORDER + 1);
 
   int const nElem = m_mesh_.getNumberOfElements();
 
-  for (int elementNumber = 0; elementNumber < nElem; ++elementNumber)
-  {
+  for (int elementNumber = 0; elementNumber < nElem; ++elementNumber) {
     if (m_element_type_[elementNumber] != kElementTypeAcoustic) continue;
 
-    for (int fi = 0; fi < 6; ++fi)
-    {
-      int const f = m_mesh_.getGlobalFace(elementNumber,
-                                          static_cast<model::CubicFace>(fi));
+    for (int fi = 0; fi < 6; ++fi) {
+      int const f = m_mesh_.getGlobalFace(elementNumber, static_cast<model::CubicFace>(fi));
 
       // All nodes must be interface nodes (excludes lateral corner faces).
       int iface_count = 0;
-      for (int q = 0; q < numNodesPerFace; ++q)
-      {
-        if (m_interface_node_index_[m_mesh_.getGlobalNodeFromFace(f, q)] >= 0)
-          ++iface_count;
+      for (int q = 0; q < numNodesPerFace; ++q) {
+        if (m_interface_node_index_[m_mesh_.getGlobalNodeFromFace(f, q)] >= 0) ++iface_count;
       }
       if (iface_count < numNodesPerFace) continue;
 
       float normal[3];
-      m_mesh_.faceNormal(elementNumber, static_cast<model::CubicFace>(fi),
-                         normal);
+      m_mesh_.faceNormal(elementNumber, static_cast<model::CubicFace>(fi), normal);
 
       float coords[4][3];
-      for (int j = 0; j < 4; ++j)
-      {
-        int const gn = m_mesh_.getGlobalNodeFromFace(
-            f, INTEGRAL_TYPE::meshIndexToLinearIndex2D(j));
+      for (int j = 0; j < 4; ++j) {
+        int const gn = m_mesh_.getGlobalNodeFromFace(f, INTEGRAL_TYPE::meshIndexToLinearIndex2D(j));
         for (int d = 0; d < 3; ++d) coords[j][d] = m_mesh_.nodeCoord(gn, d);
       }
 
-      for (int q = 0; q < numNodesPerFace; ++q)
-      {
+      for (int q = 0; q < numNodesPerFace; ++q) {
         int const gn = m_mesh_.getGlobalNodeFromFace(f, q);
-        float const aux =
-            static_cast<float>(INTEGRAL_TYPE::computeDampingTerm(q, coords));
+        float const aux = static_cast<float>(INTEGRAL_TYPE::computeDampingTerm(q, coords));
         m_coupling_coeff_x_[gn] += aux * normal[0];
         m_coupling_coeff_y_[gn] += aux * normal[1];
         m_coupling_coeff_z_[gn] += aux * normal[2];
@@ -477,11 +378,8 @@ void SEMsolverAcoustoElastic<
 // computeGlobalMassMatrix  (domain-masked override)
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
-                             IS_MODEL_ON_NODES>::computeGlobalMassMatrix()
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::computeGlobalMassMatrix() {
   int const nNode = m_mesh_.getNumberOfNodes();
 
   auto acoustic_mass = m_acoustic_solver_.getMassMatrixAcoustic();
@@ -493,11 +391,9 @@ void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
       });
   FENCE
 
-  m_acoustic_solver_.computeGlobalMassMatrixMasked(m_element_type_,
-                                                   kElementTypeAcoustic);
+  m_acoustic_solver_.computeGlobalMassMatrixMasked(m_element_type_, kElementTypeAcoustic);
   FENCE
-  m_elastic_solver_.computeGlobalMassMatrixMasked(m_element_type_,
-                                                  kElementTypeElastic);
+  m_elastic_solver_.computeGlobalMassMatrixMasked(m_element_type_, kElementTypeElastic);
   FENCE
 }
 
@@ -505,11 +401,8 @@ void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
 // computeDampingMatrix  (domain-masked override)
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
-                             IS_MODEL_ON_NODES>::computeDampingMatrix()
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::computeDampingMatrix() {
   int const nNode = m_mesh_.getNumberOfNodes();
 
   auto acoustic_d0 = m_acoustic_solver_.getDampingMatrix(0);
@@ -525,10 +418,8 @@ void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
       });
   FENCE
 
-  m_acoustic_solver_.computeDampingMatrixMasked(m_element_type_,
-                                                kElementTypeAcoustic);
-  m_elastic_solver_.computeDampingMatrixMasked(m_element_type_,
-                                               kElementTypeElastic);
+  m_acoustic_solver_.computeDampingMatrixMasked(m_element_type_, kElementTypeAcoustic);
+  m_elastic_solver_.computeDampingMatrixMasked(m_element_type_, kElementTypeElastic);
   FENCE
 }
 
@@ -536,20 +427,16 @@ void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
 // computeForces  (both domains, no coupling — for potential DD use)
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
-                             IS_MODEL_ON_NODES>::computeForces(const float& dt,
-                                                               const int&
-                                                                   timeSample,
-                                                               DataStruct& data)
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::computeForces(const float& dt,
+                                                                                                const int& timeSample,
+                                                                                                DataStruct& data) {
   auto& myData = dynamic_cast<DataType&>(data);
 
-  SEMsolverData<utils::enums::physicType::kAcoustic> acoustic_data(
-      myData.m_wavefield.m_acoustic, myData.m_rhs.m_rhs_acoustic);
-  SEMsolverData<utils::enums::physicType::kElastic> elastic_data(
-      myData.m_wavefield.m_elastic, myData.m_rhs.m_rhs_elastic);
+  SEMsolverData<utils::enums::physicType::kAcoustic> acoustic_data(myData.m_wavefield.m_acoustic,
+                                                                   myData.m_rhs.m_rhs_acoustic);
+  SEMsolverData<utils::enums::physicType::kElastic> elastic_data(myData.m_wavefield.m_elastic,
+                                                                 myData.m_rhs.m_rhs_elastic);
 
   resetGlobalVectors(m_mesh_.getNumberOfNodes());
   FENCE
@@ -559,28 +446,20 @@ void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
   m_elastic_solver_.applyRHSTerm(timeSample, dt, elastic_data);
   FENCE
 
-  m_acoustic_solver_.computeElementContributionsFromList(
-      acoustic_data, acoustic_elem_list_, num_acoustic_elements_);
+  m_acoustic_solver_.computeElementContributionsFromList(acoustic_data, acoustic_elem_list_, num_acoustic_elements_);
   FENCE
-  if constexpr (IS_MODEL_ON_NODES)
-  {
-    for (int i = 0; i < n_interface_nodes_; ++i)
-    {
+  if constexpr (IS_MODEL_ON_NODES) {
+    for (int i = 0; i < n_interface_nodes_; ++i) {
       int const j = m_interface_node_indices_[i];
-      m_mesh_.setModelNodeProps(j, m_vp_solid_iface_[i], m_vs_solid_iface_[i],
-                                m_rho_solid_iface_[i]);
+      m_mesh_.setModelNodeProps(j, m_vp_solid_iface_[i], m_vs_solid_iface_[i], m_rho_solid_iface_[i]);
     }
   }
-  m_elastic_solver_.computeElementContributionsFromList(
-      elastic_data, elastic_elem_list_, num_elastic_elements_);
+  m_elastic_solver_.computeElementContributionsFromList(elastic_data, elastic_elem_list_, num_elastic_elements_);
   FENCE
-  if constexpr (IS_MODEL_ON_NODES)
-  {
-    for (int i = 0; i < n_interface_nodes_; ++i)
-    {
+  if constexpr (IS_MODEL_ON_NODES) {
+    for (int i = 0; i < n_interface_nodes_; ++i) {
       int const j = m_interface_node_indices_[i];
-      m_mesh_.setModelNodeProps(j, m_vp_fluid_iface_[i], 0.0f,
-                                m_rho_fluid_iface_[i]);
+      m_mesh_.setModelNodeProps(j, m_vp_fluid_iface_[i], 0.0f, m_rho_fluid_iface_[i]);
     }
   }
 }
@@ -589,25 +468,19 @@ void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
 // updateSolution  (both domains simultaneously — delegates to sub-solvers)
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
-                             IS_MODEL_ON_NODES>::updateSolution(const float& dt,
-                                                                DataStruct&
-                                                                    data)
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::updateSolution(const float& dt,
+                                                                                                 DataStruct& data) {
   auto& myData = dynamic_cast<DataType&>(data);
 
-  SEMsolverData<utils::enums::physicType::kElastic> elastic_data(
-      myData.m_wavefield.m_elastic, myData.m_rhs.m_rhs_elastic);
-  m_elastic_solver_.updateFieldsFromList(dt, elastic_data, elastic_node_list_,
-                                         num_elastic_nodes_);
+  SEMsolverData<utils::enums::physicType::kElastic> elastic_data(myData.m_wavefield.m_elastic,
+                                                                 myData.m_rhs.m_rhs_elastic);
+  m_elastic_solver_.updateFieldsFromList(dt, elastic_data, elastic_node_list_, num_elastic_nodes_);
   FENCE
 
-  SEMsolverData<utils::enums::physicType::kAcoustic> acoustic_data(
-      myData.m_wavefield.m_acoustic, myData.m_rhs.m_rhs_acoustic);
-  m_acoustic_solver_.updateFieldsFromList(
-      dt, acoustic_data, acoustic_node_list_, num_acoustic_nodes_);
+  SEMsolverData<utils::enums::physicType::kAcoustic> acoustic_data(myData.m_wavefield.m_acoustic,
+                                                                   myData.m_rhs.m_rhs_acoustic);
+  m_acoustic_solver_.updateFieldsFromList(dt, acoustic_data, acoustic_node_list_, num_acoustic_nodes_);
   FENCE
 }
 
@@ -615,13 +488,9 @@ void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE,
 // ApplyCouplingAcousticToElastic
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-void SEMsolverAcoustoElastic<
-    ORDER, INTEGRAL_TYPE, MESH_TYPE,
-    IS_MODEL_ON_NODES>::ApplyCouplingAcousticToElastic(float dt,
-                                                       const DataType& data)
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::ApplyCouplingAcousticToElastic(
+    float dt, const DataType& data) {
   float const dt2 = dt * dt;
   auto p_curr = data.m_wavefield.m_acoustic.getCurrentField(0);    // p^n
   auto u_prev_x = data.m_wavefield.m_elastic.getPreviousField(0);  // u_x^{n+1}
@@ -635,11 +504,9 @@ void SEMsolverAcoustoElastic<
   int const n_iface = n_interface_nodes_;
 
   Kokkos::parallel_for(
-      "ApplyCouplingAcousticToElastic_Loop", n_iface,
-      KOKKOS_LAMBDA(const int i) {
+      "ApplyCouplingAcousticToElastic_Loop", n_iface, KOKKOS_LAMBDA(const int i) {
         int const j = iface_list[i];
-        if (M_e[j] > 0.0f)
-        {
+        if (M_e[j] > 0.0f) {
           float const aux = -p_curr[j] / M_e[j];
           u_prev_x[j] += dt2 * cx[j] * aux;
           u_prev_y[j] += dt2 * cy[j] * aux;
@@ -652,12 +519,9 @@ void SEMsolverAcoustoElastic<
 // ApplyCouplingElasticToAcoustic
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-void SEMsolverAcoustoElastic<
-    ORDER, INTEGRAL_TYPE, MESH_TYPE,
-    IS_MODEL_ON_NODES>::ApplyCouplingElasticToAcoustic(const DataType& data)
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::ApplyCouplingElasticToAcoustic(
+    const DataType& data) {
   auto p_prev = data.m_wavefield.m_acoustic.getPreviousField(0);
   auto u_np1_x = data.m_wavefield.m_elastic.getPreviousField(0);
   auto u_np1_y = data.m_wavefield.m_elastic.getPreviousField(1);
@@ -676,11 +540,9 @@ void SEMsolverAcoustoElastic<
   int const n_iface = n_interface_nodes_;
 
   Kokkos::parallel_for(
-      "ApplyCouplingElasticToAcoustic_Loop", n_iface,
-      KOKKOS_LAMBDA(const int i) {
+      "ApplyCouplingElasticToAcoustic_Loop", n_iface, KOKKOS_LAMBDA(const int i) {
         int const j = iface_list[i];
-        if (M_f[j] > 0.0f)
-        {
+        if (M_f[j] > 0.0f) {
           float const fd_x = u_np1_x[j] - 2.0f * u_n_x[j] + u_nm1_x[i];
           float const fd_y = u_np1_y[j] - 2.0f * u_n_y[j] + u_nm1_y[i];
           float const fd_z = u_np1_z[j] - 2.0f * u_n_z[j] + u_nm1_z[i];
@@ -693,21 +555,18 @@ void SEMsolverAcoustoElastic<
 // computeOneStep  (staggered elasto-acoustic coupling scheme)
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-void SEMsolverAcoustoElastic<
-    ORDER, INTEGRAL_TYPE, MESH_TYPE,
-    IS_MODEL_ON_NODES>::computeOneStep(const float& dt, const int& timeSample,
-                                       DataStruct& data)
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::computeOneStep(const float& dt,
+                                                                                                 const int& timeSample,
+                                                                                                 DataStruct& data) {
   auto& myData = dynamic_cast<DataType&>(data);
   int const nNode = m_mesh_.getNumberOfNodes();
 
   // Sub-solver data views are constructed once and reused throughout the step.
-  SEMsolverData<utils::enums::physicType::kElastic> elastic_data(
-      myData.m_wavefield.m_elastic, myData.m_rhs.m_rhs_elastic);
-  SEMsolverData<utils::enums::physicType::kAcoustic> acoustic_data(
-      myData.m_wavefield.m_acoustic, myData.m_rhs.m_rhs_acoustic);
+  SEMsolverData<utils::enums::physicType::kElastic> elastic_data(myData.m_wavefield.m_elastic,
+                                                                 myData.m_rhs.m_rhs_elastic);
+  SEMsolverData<utils::enums::physicType::kAcoustic> acoustic_data(myData.m_wavefield.m_acoustic,
+                                                                   myData.m_rhs.m_rhs_acoustic);
 
   // =========================================================================
   // ELASTIC STEP
@@ -724,26 +583,19 @@ void SEMsolverAcoustoElastic<
   // 2. Compute elastic stiffness (list: elastic elements only).
   // When IS_MODEL_ON_NODES, temporarily override interface node properties
   // to solid values so the elastic kernel uses the correct λ/μ/ρ.
-  if constexpr (IS_MODEL_ON_NODES)
-  {
-    for (int i = 0; i < n_interface_nodes_; ++i)
-    {
+  if constexpr (IS_MODEL_ON_NODES) {
+    for (int i = 0; i < n_interface_nodes_; ++i) {
       int const j = m_interface_node_indices_[i];
-      m_mesh_.setModelNodeProps(j, m_vp_solid_iface_[i], m_vs_solid_iface_[i],
-                                m_rho_solid_iface_[i]);
+      m_mesh_.setModelNodeProps(j, m_vp_solid_iface_[i], m_vs_solid_iface_[i], m_rho_solid_iface_[i]);
     }
   }
-  m_elastic_solver_.computeElementContributionsFromList(
-      elastic_data, elastic_elem_list_, num_elastic_elements_);
+  m_elastic_solver_.computeElementContributionsFromList(elastic_data, elastic_elem_list_, num_elastic_elements_);
   FENCE
   // Restore fluid properties at interface nodes for subsequent acoustic step.
-  if constexpr (IS_MODEL_ON_NODES)
-  {
-    for (int i = 0; i < n_interface_nodes_; ++i)
-    {
+  if constexpr (IS_MODEL_ON_NODES) {
+    for (int i = 0; i < n_interface_nodes_; ++i) {
       int const j = m_interface_node_indices_[i];
-      m_mesh_.setModelNodeProps(j, m_vp_fluid_iface_[i], 0.0f,
-                                m_rho_fluid_iface_[i]);
+      m_mesh_.setModelNodeProps(j, m_vp_fluid_iface_[i], 0.0f, m_rho_fluid_iface_[i]);
     }
   }
 
@@ -771,8 +623,7 @@ void SEMsolverAcoustoElastic<
   }
 
   // 3. Elastic Verlet: u^{n+1} written into elastic_data.getPreviousField().
-  m_elastic_solver_.updateFieldsFromList(dt, elastic_data, elastic_node_list_,
-                                         num_elastic_nodes_);
+  m_elastic_solver_.updateFieldsFromList(dt, elastic_data, elastic_node_list_, num_elastic_nodes_);
   FENCE
 
   // 4. A→E coupling (GEOS post-Verlet): u^{n+1} += dt²·c·(-p^n)/M_e.
@@ -792,13 +643,11 @@ void SEMsolverAcoustoElastic<
   FENCE
 
   // 7. Compute acoustic stiffness (list: acoustic elements only).
-  m_acoustic_solver_.computeElementContributionsFromList(
-      acoustic_data, acoustic_elem_list_, num_acoustic_elements_);
+  m_acoustic_solver_.computeElementContributionsFromList(acoustic_data, acoustic_elem_list_, num_acoustic_elements_);
   FENCE
 
   // 8. Acoustic Verlet: p^{n+1} written into acoustic_data.getPreviousField().
-  m_acoustic_solver_.updateFieldsFromList(
-      dt, acoustic_data, acoustic_node_list_, num_acoustic_nodes_);
+  m_acoustic_solver_.updateFieldsFromList(dt, acoustic_data, acoustic_node_list_, num_acoustic_nodes_);
   FENCE
 
   // 9. E→A coupling post-Verlet.
@@ -810,14 +659,9 @@ void SEMsolverAcoustoElastic<
 // outputSolutionValues
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
-void SEMsolverAcoustoElastic<
-    ORDER, INTEGRAL_TYPE, MESH_TYPE,
-    IS_MODEL_ON_NODES>::outputSolutionValues(const int& t, int& e,
-                                             const VECTOR_REAL_VIEW& field,
-                                             const char* fieldName)
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
+void SEMsolverAcoustoElastic<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES>::outputSolutionValues(
+    const int& t, int& e, const VECTOR_REAL_VIEW& field, const char* fieldName) {
   m_acoustic_solver_.outputSolutionValues(t, e, field, fieldName);
 }
 

--- a/src/solver/fe/impl/acoustoelastic/include/wavefield_acoustoelastic.h
+++ b/src/solver/fe/impl/acoustoelastic/include/wavefield_acoustoelastic.h
@@ -7,10 +7,8 @@
 #include "wavefield_acoustic.h"
 #include "wavefield_elastic.h"
 
-namespace solver
-{
-namespace fe
-{
+namespace solver {
+namespace fe {
 
 /**
  * @brief Combined wavefield for the acousto-elastic coupled solver.
@@ -19,31 +17,23 @@ namespace fe
  * components at two consecutive time levels (previous and current).
  * This struct is passed to SEMsolverAcoustoElastic at each time step.
  */
-struct WavefieldAcoustoElastic : public Wavefield
-{
+struct WavefieldAcoustoElastic : public Wavefield {
   /// Total number of solution fields: 1 acoustic (p) + 3 elastic (ux, uy, uz)
   static constexpr int kNumFields = 4;
 
   /// Field names in order: p, ux, uy, uz
   static constexpr const char* kFieldNames[4] = {"pressure", "ux", "uy", "uz"};
 
-  WavefieldAcoustoElastic(
-      VECTOR_REAL_VIEW pnGlobalPrev, VECTOR_REAL_VIEW pnGlobalCurr,
-      VECTOR_REAL_VIEW uxnGlobalPrev, VECTOR_REAL_VIEW uxnGlobalCurr,
-      VECTOR_REAL_VIEW uynGlobalPrev, VECTOR_REAL_VIEW uynGlobalCurr,
-      VECTOR_REAL_VIEW uznGlobalPrev, VECTOR_REAL_VIEW uznGlobalCurr)
+  WavefieldAcoustoElastic(VECTOR_REAL_VIEW pnGlobalPrev, VECTOR_REAL_VIEW pnGlobalCurr, VECTOR_REAL_VIEW uxnGlobalPrev,
+                          VECTOR_REAL_VIEW uxnGlobalCurr, VECTOR_REAL_VIEW uynGlobalPrev,
+                          VECTOR_REAL_VIEW uynGlobalCurr, VECTOR_REAL_VIEW uznGlobalPrev,
+                          VECTOR_REAL_VIEW uznGlobalCurr)
       : m_acoustic(pnGlobalPrev, pnGlobalCurr),
-        m_elastic(uxnGlobalPrev, uxnGlobalCurr, uynGlobalPrev, uynGlobalCurr,
-                  uznGlobalPrev, uznGlobalCurr)
-  {
-  }
+        m_elastic(uxnGlobalPrev, uxnGlobalCurr, uynGlobalPrev, uynGlobalCurr, uznGlobalPrev, uznGlobalCurr) {}
 
   int getNumFields() const override final { return kNumFields; }
 
-  const char* const* getFieldNames() const override final
-  {
-    return kFieldNames;
-  }
+  const char* const* getFieldNames() const override final { return kFieldNames; }
 
   /**
    * @brief Get the current field by index.
@@ -51,8 +41,7 @@ struct WavefieldAcoustoElastic : public Wavefield
    * Index mapping: 0=p, 1=ux, 2=uy, 3=uz.
    */
   PROXY_HOST_DEVICE
-  VECTOR_REAL_VIEW getCurrentField(int i) const override
-  {
+  VECTOR_REAL_VIEW getCurrentField(int i) const override {
     if (i == 0) return m_acoustic.getCurrentField(0);
     return m_elastic.getCurrentField(i - 1);
   }
@@ -63,30 +52,25 @@ struct WavefieldAcoustoElastic : public Wavefield
    * Index mapping: 0=p, 1=ux, 2=uy, 3=uz.
    */
   PROXY_HOST_DEVICE
-  VECTOR_REAL_VIEW getPreviousField(int i) const override
-  {
+  VECTOR_REAL_VIEW getPreviousField(int i) const override {
     if (i == 0) return m_acoustic.getPreviousField(0);
     return m_elastic.getPreviousField(i - 1);
   }
 
-  void swap() override
-  {
+  void swap() override {
     m_acoustic.swap();
     m_elastic.swap();
   }
 
-  void swapWithRotation(VECTOR_REAL_VIEW& prevPrevBuffer, int i) override
-  {
-    if (i == 0)
-    {
+  void swapWithRotation(VECTOR_REAL_VIEW& prevPrevBuffer, int i) override {
+    if (i == 0) {
       m_acoustic.swapWithRotation(prevPrevBuffer, 0);
       return;
     }
     m_elastic.swapWithRotation(prevPrevBuffer, i - 1);
   }
 
-  void print() const override
-  {
+  void print() const override {
     m_acoustic.print();
     m_elastic.print();
   }

--- a/src/solver/fe/impl/common/include/boundary_synchronizer.h
+++ b/src/solver/fe/impl/common/include/boundary_synchronizer.h
@@ -10,10 +10,8 @@
 
 using namespace utils;
 
-namespace solver
-{
-namespace fe
-{
+namespace solver {
+namespace fe {
 // @brief Handles data exchange at partition boundaries.
 //
 // Manages synchronization of boundary node values across distributed ranks.
@@ -35,8 +33,7 @@ namespace fe
 // For single-rank execution, synchronization is a no-op (no neighbors exist).
 // For distributed execution, must be called after computeForces() and before
 // updateSolution() to ensure boundary values are complete.
-class BoundarySynchronizer
-{
+class BoundarySynchronizer {
  public:
   // @brief Backend interface for communication.
   //
@@ -45,8 +42,7 @@ class BoundarySynchronizer
   // - DebugBackend: logs all exchanges for diagnostics
   // - MPIBackend: real MPI communication (future)
   // - GPUBackend: GPU direct peer-to-peer (future)
-  struct Backend
-  {
+  struct Backend {
     virtual ~Backend() = default;
 
     // @brief Exchange boundary data with neighboring ranks.
@@ -72,11 +68,8 @@ class BoundarySynchronizer
   // @param[in] backend Communication strategy (caller manages lifetime)
   //
   // @throws std::invalid_argument if backend is null
-  explicit BoundarySynchronizer(std::unique_ptr<Backend> backend)
-      : m_backend(std::move(backend))
-  {
-    if (!m_backend)
-    {
+  explicit BoundarySynchronizer(std::unique_ptr<Backend> backend) : m_backend(std::move(backend)) {
+    if (!m_backend) {
       throw std::invalid_argument("Backend cannot be null");
     }
   }
@@ -112,16 +105,13 @@ class BoundarySynchronizer
   // - Mass matrix: once after computeFEInit()
   // - Force vectors: every time step after computeForces()
   template <typename ViewType>
-  void synchronize(ViewType& field, const ParallelTopology& topo)
-  {
-    if (!topo.isDistributed())
-    {
+  void synchronize(ViewType& field, const ParallelTopology& topo) {
+    if (!topo.isDistributed()) {
       // Single rank: no synchronization needed
       return;
     }
 
-    try
-    {
+    try {
       // Pack boundary values
       auto sendBufs = pack(field, topo);
 
@@ -131,11 +121,8 @@ class BoundarySynchronizer
 
       // Accumulate (sum) received values
       accumulate(field, recvBufs, topo);
-    }
-    catch (const std::exception& e)
-    {
-      throw std::runtime_error(
-          std::string("Boundary synchronization failed: ") + e.what());
+    } catch (const std::exception& e) {
+      throw std::runtime_error(std::string("Boundary synchronization failed: ") + e.what());
     }
   }
 
@@ -151,18 +138,14 @@ class BoundarySynchronizer
   // @return Map from neighbor rank to vector of extracted values
   //         (in same order as topo.sharedNodes[rank])
   template <typename ViewType>
-  static std::map<int, std::vector<float>> pack(const ViewType& field,
-                                                const ParallelTopology& topo)
-  {
+  static std::map<int, std::vector<float>> pack(const ViewType& field, const ParallelTopology& topo) {
     std::map<int, std::vector<float>> buffers;
 
-    for (const auto& [neighborRank, nodeIndices] : topo.sharedNodes)
-    {
+    for (const auto& [neighborRank, nodeIndices] : topo.sharedNodes) {
       auto& buf = buffers[neighborRank];
       buf.reserve(nodeIndices.size());
 
-      for (int nodeIdx : nodeIndices)
-      {
+      for (int nodeIdx : nodeIndices) {
         buf.push_back(static_cast<float>(field(nodeIdx)));
       }
     }
@@ -192,23 +175,17 @@ class BoundarySynchronizer
   // 2. Verify buffer size matches node count
   // 3. Sum received values into field at boundary nodes
   template <typename ViewType>
-  static void accumulate(ViewType& field,
-                         const std::map<int, std::vector<float>>& recvBufs,
-                         const ParallelTopology& topo)
-  {
-    for (const auto& [neighborRank, nodeIndices] : topo.sharedNodes)
-    {
+  static void accumulate(ViewType& field, const std::map<int, std::vector<float>>& recvBufs,
+                         const ParallelTopology& topo) {
+    for (const auto& [neighborRank, nodeIndices] : topo.sharedNodes) {
       auto it = recvBufs.find(neighborRank);
 
-      if (it == recvBufs.end())
-      {
+      if (it == recvBufs.end()) {
         // In distributed mode, missing data is an error
         // In serial mode (no actual neighbors), it's OK to skip
-        if (topo.isDistributed())
-        {
-          throw std::runtime_error(
-              "Expected data from rank " + std::to_string(neighborRank) +
-              " but received nothing. Exchange failed or topology mismatch.");
+        if (topo.isDistributed()) {
+          throw std::runtime_error("Expected data from rank " + std::to_string(neighborRank) +
+                                   " but received nothing. Exchange failed or topology mismatch.");
         }
         continue;
       }
@@ -216,17 +193,13 @@ class BoundarySynchronizer
       const auto& buf = it->second;
 
       // Validate buffer size matches node count
-      if (buf.size() != nodeIndices.size())
-      {
-        throw std::length_error("Buffer size mismatch from rank " +
-                                std::to_string(neighborRank) + ": expected " +
-                                std::to_string(nodeIndices.size()) +
-                                " values, got " + std::to_string(buf.size()));
+      if (buf.size() != nodeIndices.size()) {
+        throw std::length_error("Buffer size mismatch from rank " + std::to_string(neighborRank) + ": expected " +
+                                std::to_string(nodeIndices.size()) + " values, got " + std::to_string(buf.size()));
       }
 
       // Accumulate (sum) received values
-      for (size_t i = 0; i < nodeIndices.size(); ++i)
-      {
+      for (size_t i = 0; i < nodeIndices.size(); ++i) {
         int nodeIdx = nodeIndices[i];
         field(nodeIdx) += buf[i];
       }
@@ -238,15 +211,13 @@ class BoundarySynchronizer
 //
 // Used when running on a single rank or in serial testing mode.
 // Simply clears receive buffers to prevent spurious data accumulation.
-class SerialBackend : public BoundarySynchronizer::Backend
-{
+class SerialBackend : public BoundarySynchronizer::Backend {
  public:
   // @brief Exchange (no-op for serial execution).
   //
   // Clears recvBuffers since there are no neighbors in serial mode.
   void exchange(const std::map<int, std::vector<float>>& sendBuffers,
-                std::map<int, std::vector<float>>& recvBuffers) override
-  {
+                std::map<int, std::vector<float>>& recvBuffers) override {
     // Single rank: clear recv buffers (no data from neighbors)
     recvBuffers.clear();
   }
@@ -264,8 +235,7 @@ class SerialBackend : public BoundarySynchronizer::Backend
 //   → Send M values to rank X
 //   ← Recv M values from rank X (zeroed for debug)
 // ```
-class DebugBackend : public BoundarySynchronizer::Backend
-{
+class DebugBackend : public BoundarySynchronizer::Backend {
  private:
   int m_rank;  //< Current rank (for logging)
 
@@ -279,24 +249,19 @@ class DebugBackend : public BoundarySynchronizer::Backend
   // Logs all send/receive operations and populates recvBuffers with zeros.
   // Useful for verifying synchronization is called at correct times.
   void exchange(const std::map<int, std::vector<float>>& sendBuffers,
-                std::map<int, std::vector<float>>& recvBuffers) override
-  {
+                std::map<int, std::vector<float>>& recvBuffers) override {
     std::cout << "[Rank " << m_rank << "] Boundary Synchronization:\n";
 
-    for (const auto& [neighbor, data] : sendBuffers)
-    {
-      std::cout << "  → Send " << data.size() << " values to rank " << neighbor
-                << "\n";
+    for (const auto& [neighbor, data] : sendBuffers) {
+      std::cout << "  → Send " << data.size() << " values to rank " << neighbor << "\n";
     }
 
     // In debug mode, populate recv with zeros (safe default)
     // In real MPI, this would receive actual data from neighbors
     recvBuffers.clear();
-    for (const auto& [neighbor, data] : sendBuffers)
-    {
+    for (const auto& [neighbor, data] : sendBuffers) {
       recvBuffers[neighbor].resize(data.size(), 0.0f);
-      std::cout << "  ← Recv " << data.size() << " values from rank "
-                << neighbor << " (zeroed for debug)\n";
+      std::cout << "  ← Recv " << data.size() << " values from rank " << neighbor << " (zeroed for debug)\n";
     }
   }
 };

--- a/src/solver/fe/impl/common/include/model_discretization_interface.h
+++ b/src/solver/fe/impl/common/include/model_discretization_interface.h
@@ -4,37 +4,26 @@
 
 #include "Qk_Hexahedron_Lagrange_GaussLobatto.h"
 
-namespace solver
-{
-namespace fe
-{
+namespace solver {
+namespace fe {
 /// @brief Namespace for model-discretization interface utilities
-namespace model_discretization_interface
-{
+namespace model_discretization_interface {
 
 /**
  * @brief Enumeration of the different types of transform data structures
  */
-enum class transform_types
-{
+enum class transform_types {
   linear_transform,  /// simple linear transform struct used in makutu kernel
   invalid_transform  /// invalid transform type
 };
 
-namespace detail
-{
+namespace detail {
 // Helper to detect if a type has a `data` member of type float[8][3]
 template <typename T, typename = void>
-struct is_makutu_transform : std::false_type
-{
-};
+struct is_makutu_transform : std::false_type {};
 
 template <typename T>
-struct is_makutu_transform<
-    T, std::enable_if_t<std::is_same_v<decltype(T::data), float[8][3]>>>
-    : std::true_type
-{
-};
+struct is_makutu_transform<T, std::enable_if_t<std::is_same_v<decltype(T::data), float[8][3]>>> : std::true_type {};
 }  // namespace detail
 
 /**
@@ -43,17 +32,14 @@ struct is_makutu_transform<
  * @tparam TRANSFORM_TYPE The transform data structure type.
  */
 template <typename T, typename = void>
-struct transform_type_selector
-{
+struct transform_type_selector {
   /// define the transform type as invalid by default
   static constexpr transform_types type = transform_types::invalid_transform;
 };
 
 // Specialization for makutu TransformType (detected by float data[8][3] member)
 template <typename T>
-struct transform_type_selector<
-    T, std::enable_if_t<detail::is_makutu_transform<T>::value>>
-{
+struct transform_type_selector<T, std::enable_if_t<detail::is_makutu_transform<T>::value>> {
   static constexpr transform_types type = transform_types::linear_transform;
 };
 
@@ -62,27 +48,18 @@ struct transform_type_selector<
  *        provided transform data structure.
  */
 template <typename MESH_TYPE, typename TRANSFORM_TYPE>
-static constexpr PROXY_HOST_DEVICE void gatherTransformData(
-    const int& elementNumber, const MESH_TYPE& mesh,
-    TRANSFORM_TYPE& transformData)
-{
+static constexpr PROXY_HOST_DEVICE void gatherTransformData(const int& elementNumber, const MESH_TYPE& mesh,
+                                                            TRANSFORM_TYPE& transformData) {
   using TT = std::remove_cv_t<TRANSFORM_TYPE>;
 
-  if constexpr (transform_type_selector<TT>::type ==
-                transform_types::linear_transform)
-  {
-    typename MESH_TYPE::IndexType elementIndex =
-        mesh.elementIndex(elementNumber);
+  if constexpr (transform_type_selector<TT>::type == transform_types::linear_transform) {
+    typename MESH_TYPE::IndexType elementIndex = mesh.elementIndex(elementNumber);
 
     int I = 0;
-    for (int k = 0; k < 2; ++k)
-    {
-      for (int j = 0; j < 2; ++j)
-      {
-        for (int i = 0; i < 2; ++i)
-        {
-          typename MESH_TYPE::IndexType const vertexIndex =
-              mesh.globalVertexIndex(elementIndex, i, j, k);
+    for (int k = 0; k < 2; ++k) {
+      for (int j = 0; j < 2; ++j) {
+        for (int i = 0; i < 2; ++i) {
+          typename MESH_TYPE::IndexType const vertexIndex = mesh.globalVertexIndex(elementIndex, i, j, k);
           mesh.vertexCoords(vertexIndex, transformData.data[I]);
           ++I;
         }

--- a/src/solver/fe/impl/common/include/mpi_backend.h
+++ b/src/solver/fe/impl/common/include/mpi_backend.h
@@ -9,24 +9,20 @@
 
 #include "boundary_synchronizer.h"
 
-namespace solver
-{
-namespace fe
-{
+namespace solver {
+namespace fe {
 
 /**
  * @brief MPI implementation for boundary synchronization.
  * Uses Non-blocking communication (Isend/Irecv) to exchange ghost layers.
  */
-class MPIBackend : public BoundarySynchronizer::Backend
-{
+class MPIBackend : public BoundarySynchronizer::Backend {
  public:
   MPIBackend() = default;
   ~MPIBackend() = default;
 
   void exchange(const std::map<int, std::vector<float>>& sendBuffers,
-                std::map<int, std::vector<float>>& recvBuffers) override
-  {
+                std::map<int, std::vector<float>>& recvBuffers) override {
     recvBuffers.clear();
     std::vector<MPI_Request> requests;
     // Reserve space for 2 requests per neighbor (send + recv)
@@ -35,39 +31,32 @@ class MPIBackend : public BoundarySynchronizer::Backend
     // Post Non-Blocking Receives
     // /!\ We assume we receive the same amount we send (symmetric mesh
     // partition)
-    for (const auto& [neighborRank, sendData] : sendBuffers)
-    {
+    for (const auto& [neighborRank, sendData] : sendBuffers) {
       // Allocate receive buffer
       recvBuffers[neighborRank].resize(sendData.size());
 
       MPI_Request req;
       int tag = 0;  // Simple tag
-      MPI_Irecv(recvBuffers[neighborRank].data(),
-                static_cast<int>(sendData.size()), MPI_FLOAT, neighborRank, tag,
+      MPI_Irecv(recvBuffers[neighborRank].data(), static_cast<int>(sendData.size()), MPI_FLOAT, neighborRank, tag,
                 MPI_COMM_WORLD, &req);
       requests.push_back(req);
     }
 
     // Post Non-Blocking Sends
-    for (const auto& [neighborRank, sendData] : sendBuffers)
-    {
+    for (const auto& [neighborRank, sendData] : sendBuffers) {
       MPI_Request req;
       int tag = 0;
       // const_cast is safe here because MPI_Isend treats buffer as const
-      MPI_Isend(const_cast<float*>(sendData.data()),
-                static_cast<int>(sendData.size()), MPI_FLOAT, neighborRank, tag,
+      MPI_Isend(const_cast<float*>(sendData.data()), static_cast<int>(sendData.size()), MPI_FLOAT, neighborRank, tag,
                 MPI_COMM_WORLD, &req);
       requests.push_back(req);
     }
 
     // Wait for all communications to finish
-    if (!requests.empty())
-    {
+    if (!requests.empty()) {
       std::vector<MPI_Status> statuses(requests.size());
-      int err = MPI_Waitall(static_cast<int>(requests.size()), requests.data(),
-                            statuses.data());
-      if (err != MPI_SUCCESS)
-      {
+      int err = MPI_Waitall(static_cast<int>(requests.size()), requests.data(), statuses.data());
+      if (err != MPI_SUCCESS) {
         throw std::runtime_error("MPI_Waitall failed during boundary exchange");
       }
     }

--- a/src/solver/fe/impl/common/include/sem_solver.h
+++ b/src/solver/fe/impl/common/include/sem_solver.h
@@ -17,15 +17,12 @@
 #include "sem_solver_data.h"
 #include "solver.h"
 
-namespace solver
-{
-namespace fe
-{
+namespace solver {
+namespace fe {
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES, utils::enums::physicType PHYSICS>
-class SEMsolver : public Solver
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES,
+          utils::enums::physicType PHYSICS>
+class SEMsolver : public Solver {
  public:
   using Traits = PhysicsTraits<PHYSICS>;
   using DataType = SEMsolverData<PHYSICS>;
@@ -40,47 +37,29 @@ class SEMsolver : public Solver
 
   int getNumComponents() const override { return kNumFields; }
 
-  VECTOR_REAL_VIEW& getMassMatrixAcoustic() override
-  {
-    return massMatrixGlobal_;
-  }
-  VECTOR_REAL_VIEW& getMassMatrixElastic() override
-  {
-    return massMatrixGlobal_;
-  }
+  VECTOR_REAL_VIEW& getMassMatrixAcoustic() override { return massMatrixGlobal_; }
+  VECTOR_REAL_VIEW& getMassMatrixElastic() override { return massMatrixGlobal_; }
 
-  VECTOR_REAL_VIEW& getDampingMatrix(int c) override
-  {
-    return dampingMatrixGlobal_[c];
-  }
+  VECTOR_REAL_VIEW& getDampingMatrix(int c) override { return dampingMatrixGlobal_[c]; }
 
-  VECTOR_REAL_VIEW& getForceVector(int c) override
-  {
-    return workVectorsGlobal_[c];
-  }
+  VECTOR_REAL_VIEW& getForceVector(int c) override { return workVectorsGlobal_[c]; }
 
   // -------------------------------------
 
-  void computeFEInit(model::ModelApi<float, int>& mesh,
-                     const std::array<float, 3>& sponge_size,
-                     const bool surface_sponge,
-                     const float taper_delta) override;
+  void computeFEInit(model::ModelApi<float, int>& mesh, const std::array<float, 3>& sponge_size,
+                     const bool surface_sponge, const float taper_delta) override;
 
   // Split-phase methods for DD
-  void computeForces(const float& dt, const int& timeSample,
-                     DataStruct& data) override;
+  void computeForces(const float& dt, const int& timeSample, DataStruct& data) override;
   void updateSolution(const float& dt, DataStruct& data) override;
 
   /**
    * @brief Legacy/Serial wrapper.
    * @throws std::runtime_error if called in distributed mode.
    */
-  void computeOneStep(const float& dt, const int& timeSample,
-                      DataStruct& data) override
-  {
+  void computeOneStep(const float& dt, const int& timeSample, DataStruct& data) override {
     auto& myData = dynamic_cast<DataType&>(data);
-    if (myData.isDistributed)
-    {
+    if (myData.isDistributed) {
       throw std::runtime_error(
           "computeOneStep called in distributed mode. Use computeForces() -> "
           "synchronize() -> updateSolution().");
@@ -107,8 +86,7 @@ class SEMsolver : public Solver
    * @param elem_mask   Per-element integer tag array (size = nElements).
    * @param active_value Only elements with this tag value are accumulated.
    */
-  void computeGlobalMassMatrixMasked(const VECTOR_INT_VIEW& elem_mask,
-                                     int active_value);
+  void computeGlobalMassMatrixMasked(const VECTOR_INT_VIEW& elem_mask, int active_value);
 
   /**
    * @brief Assemble damping matrix restricted to elements matching a mask.
@@ -121,11 +99,9 @@ class SEMsolver : public Solver
    * @param elem_mask   Per-element integer tag array (size = nElements).
    * @param active_value Only elements with this tag value are accumulated.
    */
-  void computeDampingMatrixMasked(const VECTOR_INT_VIEW& elem_mask,
-                                  int active_value);
+  void computeDampingMatrixMasked(const VECTOR_INT_VIEW& elem_mask, int active_value);
 
-  void outputSolutionValues(const int& t, int& e, const VECTOR_REAL_VIEW& field,
-                            const char* fieldName) override;
+  void outputSolutionValues(const int& t, int& e, const VECTOR_REAL_VIEW& field, const char* fieldName) override;
 
   /**
    * @brief Apply external forcing to the global fields.
@@ -156,9 +132,7 @@ class SEMsolver : public Solver
    * @param elem_mask    Per-element integer tag array (size = nElements).
    * @param active_value Only elements with this tag value are accumulated.
    */
-  void computeElementContributionsMasked(const DataType& data,
-                                         const VECTOR_INT_VIEW& elem_mask,
-                                         int active_value);
+  void computeElementContributionsMasked(const DataType& data, const VECTOR_INT_VIEW& elem_mask, int active_value);
 
   /**
    * @brief Assemble stiffness into workVectorsGlobal_ for a compact list of
@@ -167,9 +141,7 @@ class SEMsolver : public Solver
    * @param elem_list Compact array of element indices to process.
    * @param n_elems   Number of entries in @p elem_list.
    */
-  void computeElementContributionsFromList(const DataType& data,
-                                           const VECTOR_INT_VIEW& elem_list,
-                                           int n_elems);
+  void computeElementContributionsFromList(const DataType& data, const VECTOR_INT_VIEW& elem_list, int n_elems);
 
   /**
    * @brief Update the global solution fields at interior nodes.
@@ -186,8 +158,7 @@ class SEMsolver : public Solver
    * @param node_list Compact array of node indices to update.
    * @param n_nodes   Number of entries in @p node_list.
    */
-  void updateFieldsFromList(float dt, const DataType& data,
-                            const VECTOR_INT_VIEW& node_list, int n_nodes);
+  void updateFieldsFromList(float dt, const DataType& data, const VECTOR_INT_VIEW& node_list, int n_nodes);
 
   /**
    * @brief Read-only access to the f-th work (force) vector.
@@ -199,10 +170,7 @@ class SEMsolver : public Solver
    * @param f Component index (0 <= f < kNumFields).
    * @return  Const reference to the view.
    */
-  const VECTOR_REAL_VIEW& getForceVector(int f) const
-  {
-    return workVectorsGlobal_[f];
-  }
+  const VECTOR_REAL_VIEW& getForceVector(int f) const { return workVectorsGlobal_[f]; }
 
   void computeElementContributions_Acoustic(const DataType& data);
   void computeElementContributions_Iso(const DataType& data);
@@ -228,13 +196,9 @@ class SEMsolver : public Solver
    * @param theta Dip angle (radians).
    * @param C Output 6x6 elasticity matrix.
    */
-  template <
-      physicType P = PHYSICS,
-      typename = std::enable_if_t<P == utils::enums::physicType::kElastic>>
-  static PROXY_HOST_DEVICE void computeCMatrix(float vp, float vs, float rho,
-                                               float delta, float epsilon,
-                                               float gamma, float phi,
-                                               float theta, float (&C)[6][6]);
+  template <physicType P = PHYSICS, typename = std::enable_if_t<P == utils::enums::physicType::kElastic>>
+  static PROXY_HOST_DEVICE void computeCMatrix(float vp, float vs, float rho, float delta, float epsilon, float gamma,
+                                               float phi, float theta, float (&C)[6][6]);
 
   /**
    * @brief Set the anisotropy type for the solver.
@@ -242,45 +206,33 @@ class SEMsolver : public Solver
   void setAnisotropyType(model::AnisotropyType type) { anisotropyType_ = type; }
 
   void setSLSAttenuation(const VECTOR_REAL_VIEW& reference_frequencies,
-                         const VECTOR_REAL_VIEW& anelasticity_coefficients =
-                             VECTOR_REAL_VIEW()) override
-  {
+                         const VECTOR_REAL_VIEW& anelasticity_coefficients = VECTOR_REAL_VIEW()) override {
     attenuationEnabled_ = reference_frequencies.extent(0) > 0;
     nSls_ = static_cast<int>(reference_frequencies.extent(0));
-    if (!attenuationEnabled_)
-    {
+    if (!attenuationEnabled_) {
       nSls_ = 0;
       slsReferenceAngularFrequencies_ = VECTOR_REAL_VIEW();
       slsAnelasticityCoefficients_ = VECTOR_REAL_VIEW();
       return;
     }
 
-    slsReferenceAngularFrequencies_ = allocateVector<VECTOR_REAL_VIEW>(
-        nSls_, "slsReferenceAngularFrequencies");
-    for (int i = 0; i < nSls_; ++i)
-    {
+    slsReferenceAngularFrequencies_ = allocateVector<VECTOR_REAL_VIEW>(nSls_, "slsReferenceAngularFrequencies");
+    for (int i = 0; i < nSls_; ++i) {
       slsReferenceAngularFrequencies_[i] = reference_frequencies[i];
     }
 
-    slsAnelasticityCoefficients_ =
-        allocateVector<VECTOR_REAL_VIEW>(nSls_, "slsAnelasticityCoefficients");
-    if (anelasticity_coefficients.extent(0) == 0)
-    {
-      for (int i = 0; i < nSls_; ++i)
-      {
+    slsAnelasticityCoefficients_ = allocateVector<VECTOR_REAL_VIEW>(nSls_, "slsAnelasticityCoefficients");
+    if (anelasticity_coefficients.extent(0) == 0) {
+      for (int i = 0; i < nSls_; ++i) {
         slsAnelasticityCoefficients_[i] = -1.0f;
       }
-    }
-    else
-    {
-      if (static_cast<int>(anelasticity_coefficients.extent(0)) != nSls_)
-      {
+    } else {
+      if (static_cast<int>(anelasticity_coefficients.extent(0)) != nSls_) {
         throw std::runtime_error(
             "SLS anelasticity coefficients must match reference frequencies "
             "size");
       }
-      for (int i = 0; i < nSls_; ++i)
-      {
+      for (int i = 0; i < nSls_; ++i) {
         slsAnelasticityCoefficients_[i] = anelasticity_coefficients[i];
       }
     }
@@ -289,8 +241,7 @@ class SEMsolver : public Solver
  private:
   MESH_TYPE m_mesh;
 
-  static constexpr int kPointsPerElement =
-      (ORDER + 1) * (ORDER + 1) * (ORDER + 1);
+  static constexpr int kPointsPerElement = (ORDER + 1) * (ORDER + 1) * (ORDER + 1);
 
   float sponge_size_[3];
   bool surface_sponge_;
@@ -328,17 +279,13 @@ class SEMsolver : public Solver
 };
 
 // Backward Compatibility Aliases
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
 using SEMsolverAcoustic =
-    SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
-              utils::enums::physicType::kAcoustic>;
+    SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, utils::enums::physicType::kAcoustic>;
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES>
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES>
 using SEMsolverElastic =
-    SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
-              utils::enums::physicType::kElastic>;
+    SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, utils::enums::physicType::kElastic>;
 
 }  // namespace fe
 }  // namespace solver

--- a/src/solver/fe/impl/common/include/sem_solver_data.h
+++ b/src/solver/fe/impl/common/include/sem_solver_data.h
@@ -6,10 +6,8 @@
 #include "physics_traits_elastic.h"
 #include "solver.h"
 
-namespace solver
-{
-namespace fe
-{
+namespace solver {
+namespace fe {
 
 using physicType = utils::enums::physicType;
 
@@ -27,8 +25,7 @@ using physicType = utils::enums::physicType;
  * @tparam PHYSICS The physics type (kAcoustic or kElastic)
  */
 template <physicType PHYSICS>
-struct SEMsolverData : public Solver::DataStruct
-{
+struct SEMsolverData : public Solver::DataStruct {
   using Traits = PhysicsTraits<PHYSICS>;
   static constexpr int kNumFields = Traits::WavefieldType::kNumFields;
   static constexpr int kNumRhs = Traits::RhsType::kNumRhsComponents;
@@ -40,23 +37,15 @@ struct SEMsolverData : public Solver::DataStruct
   /**
    * @brief Constructor for acoustic physics (single field).
    */
-  template <physicType P = PHYSICS,
-            typename = std::enable_if_t<P == physicType::kAcoustic>>
-  SEMsolverData(const WavefieldAcoustic& wavefield, const RhsAcoustic& rhs)
-      : m_wavefield(wavefield), m_rhs(rhs)
-  {
-  }
+  template <physicType P = PHYSICS, typename = std::enable_if_t<P == physicType::kAcoustic>>
+  SEMsolverData(const WavefieldAcoustic& wavefield, const RhsAcoustic& rhs) : m_wavefield(wavefield), m_rhs(rhs) {}
 
   /**
    * @brief Constructor for elastic physics (three fields).
    */
-  template <physicType P = PHYSICS,
-            typename = std::enable_if_t<P == physicType::kElastic>>
-  SEMsolverData(const WavefieldElastic& wavefield, const RhsElastic& rhs,
-                const bool isDistributed = false)
-      : m_wavefield(wavefield), m_rhs(rhs), isDistributed(isDistributed)
-  {
-  }
+  template <physicType P = PHYSICS, typename = std::enable_if_t<P == physicType::kElastic>>
+  SEMsolverData(const WavefieldElastic& wavefield, const RhsElastic& rhs, const bool isDistributed = false)
+      : m_wavefield(wavefield), m_rhs(rhs), isDistributed(isDistributed) {}
 
   PROXY_HOST_DEVICE
   ARRAY_REAL_VIEW getRhsTerm(int i) const { return m_rhs.getTerm(i); }
@@ -68,32 +57,21 @@ struct SEMsolverData : public Solver::DataStruct
   ARRAY_REAL_VIEW getRhsWeights() const { return m_rhs.getWeights(); }
 
   PROXY_HOST_DEVICE
-  VECTOR_REAL_VIEW getCurrentField(int i) const
-  {
-    return m_wavefield.getCurrentField(i);
-  }
+  VECTOR_REAL_VIEW getCurrentField(int i) const { return m_wavefield.getCurrentField(i); }
 
   PROXY_HOST_DEVICE
-  VECTOR_REAL_VIEW getPreviousField(int i) const
-  {
-    return m_wavefield.getPreviousField(i);
-  }
+  VECTOR_REAL_VIEW getPreviousField(int i) const { return m_wavefield.getPreviousField(i); }
 
   void swapWavefields() { m_wavefield.swap(); }
 
-  void print() const override
-  {
+  void print() const override {
     std::cout << "SEMsolverData<" << Traits::kName << ">" << std::endl;
-    for (int f = 0; f < kNumFields; ++f)
-    {
-      std::cout << "Field[" << f << "] ("
-                << Traits::WavefieldType::kFieldNames[f]
+    for (int f = 0; f < kNumFields; ++f) {
+      std::cout << "Field[" << f << "] (" << Traits::WavefieldType::kFieldNames[f]
                 << ") size: " << getCurrentField(f).extent(0) << std::endl;
     }
-    for (int r = 0; r < kNumRhs; ++r)
-    {
-      std::cout << "RHS[" << r << "] size: " << getRhsTerm(r).extent(0)
-                << std::endl;
+    for (int r = 0; r < kNumRhs; ++r) {
+      std::cout << "RHS[" << r << "] size: " << getRhsTerm(r).extent(0) << std::endl;
     }
     std::cout << "RHS Element size: " << getRhsElement().extent(0) << std::endl;
     std::cout << "RHS Weights size: " << getRhsWeights().extent(0) << std::endl;
@@ -102,7 +80,7 @@ struct SEMsolverData : public Solver::DataStruct
   bool isDistributed{false};
   WavefieldType m_wavefield;  ///< Wavefield stored by value for GPU
                               ///< (lightweight view handles)
-  RhsType m_rhs;  ///< RHS stored by value for GPU (lightweight view handles)
+  RhsType m_rhs;              ///< RHS stored by value for GPU (lightweight view handles)
 };
 
 //============================================================================

--- a/src/solver/fe/impl/common/include/sem_solver_impl.h
+++ b/src/solver/fe/impl/common/include/sem_solver_impl.h
@@ -9,29 +9,21 @@
 #include "model_discretization_interface.h"
 #include "sem_solver.h"
 
-namespace solver
-{
-namespace fe
-{
+namespace solver {
+namespace fe {
 
 //============================================================================
 // computeFEInit - Initialize finite element structures
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES, utils::enums::physicType PHYSICS>
-void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
-               PHYSICS>::computeFEInit(model::ModelApi<float, int>& mesh_in,
-                                       const std::array<float, 3>& sponge_size,
-                                       const bool surface_sponge,
-                                       const float taper_delta)
-{
-  if (auto* typed_mesh = dynamic_cast<MESH_TYPE*>(&mesh_in))
-  {
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES,
+          utils::enums::physicType PHYSICS>
+void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::computeFEInit(
+    model::ModelApi<float, int>& mesh_in, const std::array<float, 3>& sponge_size, const bool surface_sponge,
+    const float taper_delta) {
+  if (auto* typed_mesh = dynamic_cast<MESH_TYPE*>(&mesh_in)) {
     m_mesh = *typed_mesh;
-  }
-  else
-  {
+  } else {
     throw std::runtime_error("Incompatible mesh type in solver");
   }
 
@@ -49,40 +41,25 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
   // Compute Local Damping Matrix
   computeDampingMatrix();
 
-  if (attenuationEnabled_ && nSls_ > 0)
-  {
+  if (attenuationEnabled_ && nSls_ > 0) {
     float minQVal = std::numeric_limits<float>::max();
-    for (int e = 0; e < m_mesh.getNumberOfElements(); ++e)
-    {
-      if constexpr (PHYSICS == utils::enums::physicType::kAcoustic)
-      {
-        float q =
-            IS_MODEL_ON_NODES
-                ? m_mesh.getModelQpOnNodes(m_mesh.globalNodeIndex(e, 0, 0, 0))
-                : m_mesh.getModelQpOnElement(e);
+    for (int e = 0; e < m_mesh.getNumberOfElements(); ++e) {
+      if constexpr (PHYSICS == utils::enums::physicType::kAcoustic) {
+        float q = IS_MODEL_ON_NODES ? m_mesh.getModelQpOnNodes(m_mesh.globalNodeIndex(e, 0, 0, 0))
+                                    : m_mesh.getModelQpOnElement(e);
         minQVal = std::min(minQVal, q);
-      }
-      else
-      {
-        float qp =
-            IS_MODEL_ON_NODES
-                ? m_mesh.getModelQpOnNodes(m_mesh.globalNodeIndex(e, 0, 0, 0))
-                : m_mesh.getModelQpOnElement(e);
-        float qs =
-            IS_MODEL_ON_NODES
-                ? m_mesh.getModelQsOnNodes(m_mesh.globalNodeIndex(e, 0, 0, 0))
-                : m_mesh.getModelQsOnElement(e);
+      } else {
+        float qp = IS_MODEL_ON_NODES ? m_mesh.getModelQpOnNodes(m_mesh.globalNodeIndex(e, 0, 0, 0))
+                                     : m_mesh.getModelQpOnElement(e);
+        float qs = IS_MODEL_ON_NODES ? m_mesh.getModelQsOnNodes(m_mesh.globalNodeIndex(e, 0, 0, 0))
+                                     : m_mesh.getModelQsOnElement(e);
         minQVal = std::min(minQVal, std::min(qp, qs));
       }
     }
 
-    for (int l = 0; l < nSls_; ++l)
-    {
-      if (slsAnelasticityCoefficients_.extent(0) > 0 &&
-          slsAnelasticityCoefficients_[l] < 0.0f)
-      {
-        slsAnelasticityCoefficients_[l] =
-            2.0f * minQVal / (std::max(1.0001f, minQVal) - 1.0f);
+    for (int l = 0; l < nSls_; ++l) {
+      if (slsAnelasticityCoefficients_.extent(0) > 0 && slsAnelasticityCoefficients_[l] < 0.0f) {
+        slsAnelasticityCoefficients_[l] = 2.0f * minQVal / (std::max(1.0001f, minQVal) - 1.0f);
       }
     }
   }
@@ -92,12 +69,11 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
 // Compute Forces (Phase 1)
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES, utils::enums::physicType PHYSICS>
-void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
-               PHYSICS>::computeForces(const float& dt, const int& timeSample,
-                                       Solver::DataStruct& data)
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES,
+          utils::enums::physicType PHYSICS>
+void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::computeForces(const float& dt,
+                                                                                           const int& timeSample,
+                                                                                           Solver::DataStruct& data) {
   auto& myData = dynamic_cast<DataType&>(data);
 
   resetGlobalVectors(m_mesh.getNumberOfNodes());
@@ -106,8 +82,7 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
   FENCE
   computeElementContributions(myData);
   FENCE
-  if (attenuationEnabled_ && nSls_ > 0)
-  {
+  if (attenuationEnabled_ && nSls_ > 0) {
     computeAttenuationContributions(myData);
     FENCE
   }
@@ -117,12 +92,10 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
 // Update Solution (Phase 2)
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES, utils::enums::physicType PHYSICS>
-void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
-               PHYSICS>::updateSolution(const float& dt,
-                                        Solver::DataStruct& data)
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES,
+          utils::enums::physicType PHYSICS>
+void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::updateSolution(const float& dt,
+                                                                                            Solver::DataStruct& data) {
   auto& myData = dynamic_cast<DataType&>(data);
   updateFields(dt, myData);
   FENCE
@@ -132,36 +105,25 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
 // resetGlobalVectors
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES, physicType PHYSICS>
-void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
-               PHYSICS>::resetGlobalVectors(int numNodes)
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES, physicType PHYSICS>
+void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::resetGlobalVectors(int numNodes) {
   bool const has_attenuation = (attenuationEnabled_ && nSls_ > 0);
-  std::array<std::remove_reference_t<decltype(workVectorsGlobal_[0])>,
-             kNumFields>
-      local_workVectorsGlobal;
-  std::array<
-      std::remove_reference_t<decltype(attenuationWorkVectorsGlobal_[0])>,
-      kNumFields>
+  std::array<std::remove_reference_t<decltype(workVectorsGlobal_[0])>, kNumFields> local_workVectorsGlobal;
+  std::array<std::remove_reference_t<decltype(attenuationWorkVectorsGlobal_[0])>, kNumFields>
       local_attenuationWorkVectorsGlobal;
 
-  for (int f = 0; f < kNumFields; ++f)
-  {
+  for (int f = 0; f < kNumFields; ++f) {
     local_workVectorsGlobal[f] = workVectorsGlobal_[f];
-    if (has_attenuation)
-    {
+    if (has_attenuation) {
       local_attenuationWorkVectorsGlobal[f] = attenuationWorkVectorsGlobal_[f];
     }
   }
 
   Kokkos::parallel_for(
       "Solver Reset GVector", numNodes, KOKKOS_LAMBDA(const int i) {
-        for (int f = 0; f < kNumFields; ++f)
-        {
+        for (int f = 0; f < kNumFields; ++f) {
           local_workVectorsGlobal[f][i] = 0;
-          if (has_attenuation)
-          {
+          if (has_attenuation) {
             local_attenuationWorkVectorsGlobal[f][i] = 0;
           }
         }
@@ -172,40 +134,27 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
 // applyRHSTerm
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES, physicType PHYSICS>
-void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
-               PHYSICS>::applyRHSTerm(int timeSample, float dt,
-                                      const DataType& data)
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES, physicType PHYSICS>
+void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::applyRHSTerm(int timeSample, float dt,
+                                                                                          const DataType& data) {
   int nb_rhs_element = data.getRhsElement().extent(0);
   auto mesh_local = m_mesh;  // Capture mesh for lambda
 
-  std::array<std::remove_reference_t<decltype(workVectorsGlobal_[0])>,
-             kNumFields>
-      local_workVectorsGlobal;
-  for (int f = 0; f < kNumFields; ++f)
-  {
+  std::array<std::remove_reference_t<decltype(workVectorsGlobal_[0])>, kNumFields> local_workVectorsGlobal;
+  for (int f = 0; f < kNumFields; ++f) {
     local_workVectorsGlobal[f] = workVectorsGlobal_[f];
   }
 
   Kokkos::parallel_for(
       "Solver Apply RHSTerm", nb_rhs_element, KOKKOS_LAMBDA(const int i) {
-        for (int z = 0; z < ORDER + 1; z++)
-        {
-          for (int y = 0; y < ORDER + 1; y++)
-          {
-            for (int x = 0; x < ORDER + 1; x++)
-            {
-              int localNodeId =
-                  x + y * (ORDER + 1) + z * (ORDER + 1) * (ORDER + 1);
-              int nodeRHS =
-                  mesh_local.globalNodeIndex(data.getRhsElement()[i], x, y, z);
+        for (int z = 0; z < ORDER + 1; z++) {
+          for (int y = 0; y < ORDER + 1; y++) {
+            for (int x = 0; x < ORDER + 1; x++) {
+              int localNodeId = x + y * (ORDER + 1) + z * (ORDER + 1) * (ORDER + 1);
+              int nodeRHS = mesh_local.globalNodeIndex(data.getRhsElement()[i], x, y, z);
 
-              for (int f = 0; f < kNumRhs; ++f)
-              {
-                float source = data.getRhsTerm(f)(i, timeSample) *
-                               data.getRhsWeights()(i, localNodeId);
+              for (int f = 0; f < kNumRhs; ++f) {
+                float source = data.getRhsTerm(f)(i, timeSample) * data.getRhsWeights()(i, localNodeId);
                 local_workVectorsGlobal[f](nodeRHS) -= source;
               }
             }
@@ -218,27 +167,19 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
 // computeElementContributions - DISPATCH
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES, physicType PHYSICS>
-void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
-               PHYSICS>::computeElementContributions(const DataType& data)
-{
-  if constexpr (PHYSICS == utils::enums::physicType::kElastic)
-  {
-    if (anisotropyType_ == model::AnisotropyType::kIso)
-    {
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES, physicType PHYSICS>
+void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::computeElementContributions(
+    const DataType& data) {
+  if constexpr (PHYSICS == utils::enums::physicType::kElastic) {
+    if (anisotropyType_ == model::AnisotropyType::kIso) {
       computeElementContributions_Iso(data);
-    }
-    else if (anisotropyType_ == model::AnisotropyType::kVTI)
-    {
+    } else if (anisotropyType_ == model::AnisotropyType::kVTI) {
       computeElementContributions_Vti(data);
-    }
-    else  // kTTI
+    } else  // kTTI
     {
       computeElementContributions_Tti(data);
     }
-  }
-  else  // Acoustic - DISPATCH
+  } else  // Acoustic - DISPATCH
   {
     computeElementContributions_Acoustic(data);
   }
@@ -248,46 +189,34 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
 // computeElementContributions_Acoustic - ACOUSTIC
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES, physicType PHYSICS>
-void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::
-    computeElementContributions_Acoustic(const DataType& data)
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES, physicType PHYSICS>
+void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::computeElementContributions_Acoustic(
+    const DataType& data) {
   auto mesh_local = m_mesh;
   bool const list_on = m_list_mode_;
   auto list_local = m_elem_list_;
-  int const n_iter =
-      list_on ? m_n_elem_list_ : mesh_local.getNumberOfElements();
+  int const n_iter = list_on ? m_n_elem_list_ : mesh_local.getNumberOfElements();
 
-  std::array<std::remove_reference_t<decltype(workVectorsGlobal_[0])>,
-             kNumFields>
-      local_workVectorsGlobal;
-  for (int f = 0; f < kNumFields; ++f)
-  {
+  std::array<std::remove_reference_t<decltype(workVectorsGlobal_[0])>, kNumFields> local_workVectorsGlobal;
+  for (int f = 0; f < kNumFields; ++f) {
     local_workVectorsGlobal[f] = workVectorsGlobal_[f];
   }
 
   Kokkos::parallel_for(
-      "Solver Element Contribution Acoustic", Kokkos::RangePolicy(0, n_iter),
-      KOKKOS_LAMBDA(const int _loop_idx) {
+      "Solver Element Contribution Acoustic", Kokkos::RangePolicy(0, n_iter), KOKKOS_LAMBDA(const int _loop_idx) {
         int const elementNumber = list_on ? list_local[_loop_idx] : _loop_idx;
 
         int const dim = mesh_local.getOrder() + 1;
         float localFields[kNumFields][kPointsPerElement] = {{0}};
         float localWork[kNumFields][kPointsPerElement] = {{0}};
 
-        for (int i = 0; i < dim; ++i)
-        {
-          for (int j = 0; j < dim; ++j)
-          {
-            for (int k = 0; k < dim; ++k)
-            {
-              int const globalIdx =
-                  mesh_local.globalNodeIndex(elementNumber, i, j, k);
+        for (int i = 0; i < dim; ++i) {
+          for (int j = 0; j < dim; ++j) {
+            for (int k = 0; k < dim; ++k) {
+              int const globalIdx = mesh_local.globalNodeIndex(elementNumber, i, j, k);
               int const localIdx = i + j * dim + k * dim * dim;
 
-              for (int f = 0; f < kNumFields; ++f)
-              {
+              for (int f = 0; f < kNumFields; ++f) {
                 localFields[f][localIdx] = data.getCurrentField(f)(globalIdx);
               }
             }
@@ -295,44 +224,31 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::
         }
 
         typename INTEGRAL_TYPE::TransformType transformData;
-        model_discretization_interface::gatherTransformData(
-            elementNumber, mesh_local, transformData);
+        model_discretization_interface::gatherTransformData(elementNumber, mesh_local, transformData);
 
         real_t inv_density = 0.0f;
-        if constexpr (!IS_MODEL_ON_NODES)
-        {
+        if constexpr (!IS_MODEL_ON_NODES) {
           inv_density = 1.0f / mesh_local.getModelRhoOnElement(elementNumber);
         }
 
         INTEGRAL_TYPE::computeStiffnessTermSumFact(
-            transformData, localFields[0], localWork[0],
-            [&](const int qa, const int qb, const int qc) -> real_t {
-              if constexpr (IS_MODEL_ON_NODES)
-              {
-                int const gIndex =
-                    mesh_local.globalNodeIndex(elementNumber, qa, qb, qc);
+            transformData, localFields[0], localWork[0], [&](const int qa, const int qb, const int qc) -> real_t {
+              if constexpr (IS_MODEL_ON_NODES) {
+                int const gIndex = mesh_local.globalNodeIndex(elementNumber, qa, qb, qc);
                 return 1.0f / mesh_local.getModelRhoOnNodes(gIndex);
-              }
-              else
-              {
+              } else {
                 return inv_density;
               }
             });
 
-        for (int i = 0; i < dim; ++i)
-        {
-          for (int j = 0; j < dim; ++j)
-          {
-            for (int k = 0; k < dim; ++k)
-            {
-              int const globalIdx =
-                  mesh_local.globalNodeIndex(elementNumber, i, j, k);
+        for (int i = 0; i < dim; ++i) {
+          for (int j = 0; j < dim; ++j) {
+            for (int k = 0; k < dim; ++k) {
+              int const globalIdx = mesh_local.globalNodeIndex(elementNumber, i, j, k);
               int const localIdx = i + j * dim + k * dim * dim;
 
-              for (int f = 0; f < kNumFields; ++f)
-              {
-                ATOMICADD(local_workVectorsGlobal[f][globalIdx],
-                          localWork[f][localIdx]);
+              for (int f = 0; f < kNumFields; ++f) {
+                ATOMICADD(local_workVectorsGlobal[f][globalIdx], localWork[f][localIdx]);
               }
             }
           }
@@ -344,11 +260,9 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::
 // computeAttenuationContributions - Assemble attenuation stiffness terms
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES, physicType PHYSICS>
-void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
-               PHYSICS>::computeAttenuationContributions(const DataType& data)
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES, physicType PHYSICS>
+void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::computeAttenuationContributions(
+    const DataType& data) {
   if (!attenuationEnabled_ || nSls_ <= 0) return;
 
   if constexpr (PHYSICS == utils::enums::physicType::kAcoustic)
@@ -357,21 +271,16 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
     computeAttenuationContributionsElastic(data);
 }
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES, physicType PHYSICS>
-void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::
-    computeAttenuationContributionsAcoustic(const DataType& data)
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES, physicType PHYSICS>
+void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::computeAttenuationContributionsAcoustic(
+    const DataType& data) {
   auto mesh_local = m_mesh;
-  Kokkos::Array<VECTOR_REAL_VIEW, kNumFields>
-      local_attenuationWorkVectorsGlobal;
-  for (int f = 0; f < kNumFields; ++f)
-    local_attenuationWorkVectorsGlobal[f] = attenuationWorkVectorsGlobal_[f];
+  Kokkos::Array<VECTOR_REAL_VIEW, kNumFields> local_attenuationWorkVectorsGlobal;
+  for (int f = 0; f < kNumFields; ++f) local_attenuationWorkVectorsGlobal[f] = attenuationWorkVectorsGlobal_[f];
 
   Kokkos::parallel_for(
       "Solver Attenuation Contributions Acoustic",
-      Kokkos::RangePolicy<
-          Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(
+      Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(
           0, mesh_local.getNumberOfElements()),
       KOKKOS_LAMBDA(const int elementNumber) {
         int const dim = mesh_local.getOrder() + 1;
@@ -380,36 +289,27 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::
 
         for (int i = 0; i < dim; ++i)
           for (int j = 0; j < dim; ++j)
-            for (int k = 0; k < dim; ++k)
-            {
-              int const globalIdx =
-                  mesh_local.globalNodeIndex(elementNumber, i, j, k);
+            for (int k = 0; k < dim; ++k) {
+              int const globalIdx = mesh_local.globalNodeIndex(elementNumber, i, j, k);
               int const localIdx = i + j * dim + k * dim * dim;
-              for (int f = 0; f < kNumFields; ++f)
-                localFields[f][localIdx] = data.getCurrentField(f)(globalIdx);
+              for (int f = 0; f < kNumFields; ++f) localFields[f][localIdx] = data.getCurrentField(f)(globalIdx);
             }
 
         typename INTEGRAL_TYPE::TransformType transformData;
-        model_discretization_interface::gatherTransformData(
-            elementNumber, mesh_local, transformData);
+        model_discretization_interface::gatherTransformData(elementNumber, mesh_local, transformData);
 
         real_t inv_density_q = 0.0f;
-        if constexpr (!IS_MODEL_ON_NODES)
-        {
+        if constexpr (!IS_MODEL_ON_NODES) {
           inv_density_q =
-              1.0f / (mesh_local.getModelRhoOnElement(elementNumber) *
-                      mesh_local.getModelQpOnElement(elementNumber));
+              1.0f / (mesh_local.getModelRhoOnElement(elementNumber) * mesh_local.getModelQpOnElement(elementNumber));
         }
 
         INTEGRAL_TYPE::computeStiffnessTerm(
             transformData,
             [&](const int qa, const int qb, const int qc) {
-              if constexpr (IS_MODEL_ON_NODES)
-              {
-                int const gIndex =
-                    mesh_local.globalNodeIndex(elementNumber, qa, qb, qc);
-                inv_density_q = 1.0f / (mesh_local.getModelRhoOnNodes(gIndex) *
-                                        mesh_local.getModelQpOnNodes(gIndex));
+              if constexpr (IS_MODEL_ON_NODES) {
+                int const gIndex = mesh_local.globalNodeIndex(elementNumber, qa, qb, qc);
+                inv_density_q = 1.0f / (mesh_local.getModelRhoOnNodes(gIndex) * mesh_local.getModelQpOnNodes(gIndex));
               }
             },
             [&](const int i, const int j, const real_t val) {
@@ -418,36 +318,28 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::
 
         for (int i = 0; i < dim; ++i)
           for (int j = 0; j < dim; ++j)
-            for (int k = 0; k < dim; ++k)
-            {
-              int const globalIdx =
-                  mesh_local.globalNodeIndex(elementNumber, i, j, k);
+            for (int k = 0; k < dim; ++k) {
+              int const globalIdx = mesh_local.globalNodeIndex(elementNumber, i, j, k);
               int const localIdx = i + j * dim + k * dim * dim;
               for (int f = 0; f < kNumFields; ++f)
-                ATOMICADD(local_attenuationWorkVectorsGlobal[f][globalIdx],
-                          localWorkA[f][localIdx]);
+                ATOMICADD(local_attenuationWorkVectorsGlobal[f][globalIdx], localWorkA[f][localIdx]);
             }
       });
 }
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES, physicType PHYSICS>
-void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::
-    computeAttenuationContributionsElastic(const DataType& data)
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES, physicType PHYSICS>
+void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::computeAttenuationContributionsElastic(
+    const DataType& data) {
   if (anisotropyType_ != model::AnisotropyType::kIso) return;
 
   auto mesh_local = m_mesh;
 
-  Kokkos::Array<VECTOR_REAL_VIEW, kNumFields>
-      local_attenuationWorkVectorsGlobal;
-  for (int f = 0; f < kNumFields; ++f)
-    local_attenuationWorkVectorsGlobal[f] = attenuationWorkVectorsGlobal_[f];
+  Kokkos::Array<VECTOR_REAL_VIEW, kNumFields> local_attenuationWorkVectorsGlobal;
+  for (int f = 0; f < kNumFields; ++f) local_attenuationWorkVectorsGlobal[f] = attenuationWorkVectorsGlobal_[f];
 
   Kokkos::parallel_for(
       "Solver Attenuation Contributions Elastic",
-      Kokkos::RangePolicy<
-          Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(
+      Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(
           0, mesh_local.getNumberOfElements()),
       KOKKOS_LAMBDA(const int elementNumber) {
         int const dim = mesh_local.getOrder() + 1;
@@ -456,21 +348,16 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::
 
         for (int i = 0; i < dim; ++i)
           for (int j = 0; j < dim; ++j)
-            for (int k = 0; k < dim; ++k)
-            {
-              int const globalIdx =
-                  mesh_local.globalNodeIndex(elementNumber, i, j, k);
+            for (int k = 0; k < dim; ++k) {
+              int const globalIdx = mesh_local.globalNodeIndex(elementNumber, i, j, k);
               int const localIdx = i + j * dim + k * dim * dim;
-              for (int f = 0; f < kNumFields; ++f)
-                localFields[f][localIdx] = data.getCurrentField(f)(globalIdx);
+              for (int f = 0; f < kNumFields; ++f) localFields[f][localIdx] = data.getCurrentField(f)(globalIdx);
             }
 
         typename INTEGRAL_TYPE::TransformType transformData;
-        model_discretization_interface::gatherTransformData(
-            elementNumber, mesh_local, transformData);
+        model_discretization_interface::gatherTransformData(elementNumber, mesh_local, transformData);
 
-        struct CJPacked
-        {
+        struct CJPacked {
           float a0, a1, a2, a3;
           float b0, b1;
         };
@@ -480,18 +367,14 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::
             transformData,
             [&](int qa, int qb, int qc, float const(&J)[3][3]) {
               float vp, vs, rho, qp, qs;
-              if constexpr (IS_MODEL_ON_NODES)
-              {
-                int const gIndex =
-                    mesh_local.globalNodeIndex(elementNumber, qa, qb, qc);
+              if constexpr (IS_MODEL_ON_NODES) {
+                int const gIndex = mesh_local.globalNodeIndex(elementNumber, qa, qb, qc);
                 vp = mesh_local.getModelVpOnNodes(gIndex);
                 vs = mesh_local.getModelVsOnNodes(gIndex);
                 rho = mesh_local.getModelRhoOnNodes(gIndex);
                 qp = mesh_local.getModelQpOnNodes(gIndex);
                 qs = mesh_local.getModelQsOnNodes(gIndex);
-              }
-              else
-              {
+              } else {
                 vp = mesh_local.getModelVpOnElement(elementNumber);
                 vs = mesh_local.getModelVsOnElement(elementNumber);
                 rho = mesh_local.getModelRhoOnElement(elementNumber);
@@ -506,19 +389,14 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::
               lambda = lambdap2mua - 2.0f * mu;
               float lambda_plus_2mu = lambda + 2.0f * mu;
 
-              for (int p = 0; p < 3; ++p)
-              {
+              for (int p = 0; p < 3; ++p) {
                 float const Jp0 = J[p][0], Jp1 = J[p][1], Jp2 = J[p][2];
-                for (int r = 0; r < 3; ++r)
-                {
+                for (int r = 0; r < 3; ++r) {
                   float const Jr0 = J[r][0], Jr1 = J[r][1], Jr2 = J[r][2];
                   int const idx = p * 3 + r;
-                  CJflat[idx].a0 = lambda_plus_2mu * Jp0 * Jr0 +
-                                   mu * (Jp1 * Jr1 + Jp2 * Jr2);
-                  CJflat[idx].a1 = mu * Jp0 * Jr0 +
-                                   lambda_plus_2mu * Jp1 * Jr1 + mu * Jp2 * Jr2;
-                  CJflat[idx].a2 = mu * (Jp0 * Jr0 + Jp1 * Jr1) +
-                                   lambda_plus_2mu * Jp2 * Jr2;
+                  CJflat[idx].a0 = lambda_plus_2mu * Jp0 * Jr0 + mu * (Jp1 * Jr1 + Jp2 * Jr2);
+                  CJflat[idx].a1 = mu * Jp0 * Jr0 + lambda_plus_2mu * Jp1 * Jr1 + mu * Jp2 * Jr2;
+                  CJflat[idx].a2 = mu * (Jp0 * Jr0 + Jp1 * Jr1) + lambda_plus_2mu * Jp2 * Jr2;
                   CJflat[idx].a3 = lambda * Jp0 * Jr1 + mu * Jp1 * Jr0;
                   CJflat[idx].b0 = lambda * Jp0 * Jr2 + mu * Jp2 * Jr0;
                   CJflat[idx].b1 = lambda * Jp1 * Jr2 + mu * Jp2 * Jr1;
@@ -530,27 +408,18 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::
               float const uxj = localFields[0][j];
               float const uyj = localFields[1][j];
               float const uzj = localFields[2][j];
-              localWorkA[0][i] +=
-                  val * (CJflat[idx].a0 * uxj + CJflat[idx].a3 * uyj +
-                         CJflat[idx].b0 * uzj);
-              localWorkA[1][i] +=
-                  val * (CJflat[idx].a3 * uxj + CJflat[idx].a1 * uyj +
-                         CJflat[idx].b1 * uzj);
-              localWorkA[2][i] +=
-                  val * (CJflat[idx].b0 * uxj + CJflat[idx].b1 * uyj +
-                         CJflat[idx].a2 * uzj);
+              localWorkA[0][i] += val * (CJflat[idx].a0 * uxj + CJflat[idx].a3 * uyj + CJflat[idx].b0 * uzj);
+              localWorkA[1][i] += val * (CJflat[idx].a3 * uxj + CJflat[idx].a1 * uyj + CJflat[idx].b1 * uzj);
+              localWorkA[2][i] += val * (CJflat[idx].b0 * uxj + CJflat[idx].b1 * uyj + CJflat[idx].a2 * uzj);
             });
 
         for (int i = 0; i < dim; ++i)
           for (int j = 0; j < dim; ++j)
-            for (int k = 0; k < dim; ++k)
-            {
-              int const globalIdx =
-                  mesh_local.globalNodeIndex(elementNumber, i, j, k);
+            for (int k = 0; k < dim; ++k) {
+              int const globalIdx = mesh_local.globalNodeIndex(elementNumber, i, j, k);
               int const localIdx = i + j * dim + k * dim * dim;
               for (int f = 0; f < kNumFields; ++f)
-                ATOMICADD(local_attenuationWorkVectorsGlobal[f][globalIdx],
-                          localWorkA[f][localIdx]);
+                ATOMICADD(local_attenuationWorkVectorsGlobal[f][globalIdx], localWorkA[f][localIdx]);
             }
       });
 }
@@ -559,30 +428,22 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::
 // computeElementContributions_Iso - ISOTROPIC OPTIMIZED
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES, physicType PHYSICS>
-void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
-               PHYSICS>::computeElementContributions_Iso(const DataType& data)
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES, physicType PHYSICS>
+void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::computeElementContributions_Iso(
+    const DataType& data) {
   auto mesh_local = m_mesh;
   bool const list_on = m_list_mode_;
   auto list_local = m_elem_list_;
-  int const n_iter =
-      list_on ? m_n_elem_list_ : mesh_local.getNumberOfElements();
+  int const n_iter = list_on ? m_n_elem_list_ : mesh_local.getNumberOfElements();
 
-  std::array<std::remove_reference_t<decltype(workVectorsGlobal_[0])>,
-             kNumFields>
-      local_workVectorsGlobal;
-  for (int f = 0; f < kNumFields; ++f)
-  {
+  std::array<std::remove_reference_t<decltype(workVectorsGlobal_[0])>, kNumFields> local_workVectorsGlobal;
+  for (int f = 0; f < kNumFields; ++f) {
     local_workVectorsGlobal[f] = workVectorsGlobal_[f];
   }
 
   Kokkos::parallel_for(
       "Solver Element Contribution Iso",
-      Kokkos::RangePolicy<
-          Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(
-          0, n_iter),
+      Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(0, n_iter),
       KOKKOS_LAMBDA(const int _loop_idx) {
         // avoid extended __host__ __device__ lambda cannot first-capture
         // variable in constexpr-if context
@@ -594,33 +455,25 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
         float localFields[kNumFields][kPointsPerElement] = {{0}};
         float localWork[kNumFields][kPointsPerElement] = {{0}};
 
-        for (int i = 0; i < dim; ++i)
-        {
-          for (int j = 0; j < dim; ++j)
-          {
-            for (int k = 0; k < dim; ++k)
-            {
-              int const globalIdx =
-                  mesh_local.globalNodeIndex(elementNumber, i, j, k);
+        for (int i = 0; i < dim; ++i) {
+          for (int j = 0; j < dim; ++j) {
+            for (int k = 0; k < dim; ++k) {
+              int const globalIdx = mesh_local.globalNodeIndex(elementNumber, i, j, k);
               int const localIdx = i + j * dim + k * dim * dim;
 
-              for (int f = 0; f < kNumFields; ++f)
-              {
+              for (int f = 0; f < kNumFields; ++f) {
                 localFields[f][localIdx] = data.getCurrentField(f)(globalIdx);
               }
             }
           }
         }
 
-        if constexpr (PHYSICS == utils::enums::physicType::kElastic)
-        {
+        if constexpr (PHYSICS == utils::enums::physicType::kElastic) {
           typename INTEGRAL_TYPE::TransformType transformData;
-          model_discretization_interface::gatherTransformData(
-              elementNumber, mesh_local, transformData);
+          model_discretization_interface::gatherTransformData(elementNumber, mesh_local, transformData);
 
           float mu_e = 0.0f, lambda_e = 0.0f, lam2mu_e = 0.0f;
-          if constexpr (!IS_MODEL_ON_NODES)
-          {
+          if constexpr (!IS_MODEL_ON_NODES) {
             float const vp_e = mesh_local.getModelVpOnElement(elementNumber);
             float const vs_e = mesh_local.getModelVsOnElement(elementNumber);
             float const rho_e = mesh_local.getModelRhoOnElement(elementNumber);
@@ -631,46 +484,37 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
 
           INTEGRAL_TYPE::computeElasticStiffnessSumFact(
               transformData, localFields, localWork,
-              [&](int qa, int qb, int qc, float const(&J_inv)[3][3],
-                  float const(&grad_u_ref)[3][3], float(&flux)[3][3]) {
+              [&](int qa, int qb, int qc, float const(&J_inv)[3][3], float const(&grad_u_ref)[3][3],
+                  float(&flux)[3][3]) {
                 float mu, lambda, lam2mu;
-                if constexpr (IS_MODEL_ON_NODES)
-                {
-                  int const gIndex =
-                      mesh_local.globalNodeIndex(elementNumber, qa, qb, qc);
+                if constexpr (IS_MODEL_ON_NODES) {
+                  int const gIndex = mesh_local.globalNodeIndex(elementNumber, qa, qb, qc);
                   float const vp = mesh_local.getModelVpOnNodes(gIndex);
                   float const vs = mesh_local.getModelVsOnNodes(gIndex);
                   float const rho = mesh_local.getModelRhoOnNodes(gIndex);
                   mu = rho * vs * vs;
                   lambda = rho * (vp * vp - 2.0f * vs * vs);
                   lam2mu = lambda + 2.0f * mu;
-                }
-                else
-                {
+                } else {
                   mu = mu_e;
                   lambda = lambda_e;
                   lam2mu = lam2mu_e;
                 }
 
-                for (int p = 0; p < 3; ++p)
-                {
+                for (int p = 0; p < 3; ++p) {
                   float const Jp0 = J_inv[p][0];
                   float const Jp1 = J_inv[p][1];
                   float const Jp2 = J_inv[p][2];
                   flux[p][0] = 0.0f;
                   flux[p][1] = 0.0f;
                   flux[p][2] = 0.0f;
-                  for (int r = 0; r < 3; ++r)
-                  {
+                  for (int r = 0; r < 3; ++r) {
                     float const Jr0 = J_inv[r][0];
                     float const Jr1 = J_inv[r][1];
                     float const Jr2 = J_inv[r][2];
-                    float const v0 =
-                        lam2mu * Jp0 * Jr0 + mu * (Jp1 * Jr1 + Jp2 * Jr2);
-                    float const v1 =
-                        mu * Jp0 * Jr0 + lam2mu * Jp1 * Jr1 + mu * Jp2 * Jr2;
-                    float const v2 =
-                        mu * (Jp0 * Jr0 + Jp1 * Jr1) + lam2mu * Jp2 * Jr2;
+                    float const v0 = lam2mu * Jp0 * Jr0 + mu * (Jp1 * Jr1 + Jp2 * Jr2);
+                    float const v1 = mu * Jp0 * Jr0 + lam2mu * Jp1 * Jr1 + mu * Jp2 * Jr2;
+                    float const v2 = mu * (Jp0 * Jr0 + Jp1 * Jr1) + lam2mu * Jp2 * Jr2;
                     float const v3 = lambda * Jp0 * Jr1 + mu * Jp1 * Jr0;
                     float const v4 = lambda * Jp0 * Jr2 + mu * Jp2 * Jr0;
                     float const v5 = lambda * Jp1 * Jr2 + mu * Jp2 * Jr1;
@@ -684,20 +528,14 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
                 }
               });
 
-          for (int i = 0; i < dim; ++i)
-          {
-            for (int j = 0; j < dim; ++j)
-            {
-              for (int k = 0; k < dim; ++k)
-              {
-                int const globalIdx =
-                    mesh_local.globalNodeIndex(elementNumber, i, j, k);
+          for (int i = 0; i < dim; ++i) {
+            for (int j = 0; j < dim; ++j) {
+              for (int k = 0; k < dim; ++k) {
+                int const globalIdx = mesh_local.globalNodeIndex(elementNumber, i, j, k);
                 int const localIdx = i + j * dim + k * dim * dim;
 
-                for (int f = 0; f < kNumFields; ++f)
-                {
-                  ATOMICADD(local_workVectorsGlobal[f][globalIdx],
-                            localWork[f][localIdx]);
+                for (int f = 0; f < kNumFields; ++f) {
+                  ATOMICADD(local_workVectorsGlobal[f][globalIdx], localWork[f][localIdx]);
                 }
               }
             }
@@ -710,30 +548,22 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
 // computeElementContributions_VTI - VTI
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES, physicType PHYSICS>
-void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
-               PHYSICS>::computeElementContributions_Vti(const DataType& data)
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES, physicType PHYSICS>
+void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::computeElementContributions_Vti(
+    const DataType& data) {
   auto mesh_local = m_mesh;
   bool const list_on = m_list_mode_;
   auto list_local = m_elem_list_;
-  int const n_iter =
-      list_on ? m_n_elem_list_ : mesh_local.getNumberOfElements();
+  int const n_iter = list_on ? m_n_elem_list_ : mesh_local.getNumberOfElements();
 
-  std::array<std::remove_reference_t<decltype(workVectorsGlobal_[0])>,
-             kNumFields>
-      local_workVectorsGlobal;
-  for (int f = 0; f < kNumFields; ++f)
-  {
+  std::array<std::remove_reference_t<decltype(workVectorsGlobal_[0])>, kNumFields> local_workVectorsGlobal;
+  for (int f = 0; f < kNumFields; ++f) {
     local_workVectorsGlobal[f] = workVectorsGlobal_[f];
   }
 
   Kokkos::parallel_for(
       "Solver Element Contribution Vti",
-      Kokkos::RangePolicy<
-          Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(
-          0, n_iter),
+      Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(0, n_iter),
       KOKKOS_LAMBDA(const int _loop_idx) {
         // avoid extended __host__ __device__ lambda cannot first-capture
         // variable in constexpr-if context
@@ -744,43 +574,31 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
         float localFields[kNumFields][kPointsPerElement] = {{0}};
         float localWork[kNumFields][kPointsPerElement] = {{0}};
 
-        for (int i = 0; i < dim; ++i)
-        {
-          for (int j = 0; j < dim; ++j)
-          {
-            for (int k = 0; k < dim; ++k)
-            {
-              int const globalIdx =
-                  mesh_local.globalNodeIndex(elementNumber, i, j, k);
+        for (int i = 0; i < dim; ++i) {
+          for (int j = 0; j < dim; ++j) {
+            for (int k = 0; k < dim; ++k) {
+              int const globalIdx = mesh_local.globalNodeIndex(elementNumber, i, j, k);
               int const localIdx = i + j * dim + k * dim * dim;
 
-              for (int f = 0; f < kNumFields; ++f)
-              {
+              for (int f = 0; f < kNumFields; ++f) {
                 localFields[f][localIdx] = data.getCurrentField(f)(globalIdx);
               }
             }
           }
         }
 
-        if constexpr (PHYSICS == utils::enums::physicType::kElastic)
-        {
+        if constexpr (PHYSICS == utils::enums::physicType::kElastic) {
           typename INTEGRAL_TYPE::TransformType transformData;
-          model_discretization_interface::gatherTransformData(
-              elementNumber, mesh_local, transformData);
+          model_discretization_interface::gatherTransformData(elementNumber, mesh_local, transformData);
 
-          float c11_e = 0, c12_e = 0, c13_e = 0, c33_e = 0, c44_e = 0,
-                c66_e = 0;
-          if constexpr (!IS_MODEL_ON_NODES)
-          {
+          float c11_e = 0, c12_e = 0, c13_e = 0, c33_e = 0, c44_e = 0, c66_e = 0;
+          if constexpr (!IS_MODEL_ON_NODES) {
             float const vp_e = mesh_local.getModelVpOnElement(elementNumber);
             float const vs_e = mesh_local.getModelVsOnElement(elementNumber);
             float const rho_e = mesh_local.getModelRhoOnElement(elementNumber);
-            float const delta_e =
-                mesh_local.getModelDeltaOnElement(elementNumber);
-            float const epsilon_e =
-                mesh_local.getModelEpsilonOnElement(elementNumber);
-            float const gamma_e =
-                mesh_local.getModelGammaOnElement(elementNumber);
+            float const delta_e = mesh_local.getModelDeltaOnElement(elementNumber);
+            float const epsilon_e = mesh_local.getModelEpsilonOnElement(elementNumber);
+            float const gamma_e = mesh_local.getModelGammaOnElement(elementNumber);
             float const rho_vp2 = rho_e * vp_e * vp_e;
             float const rho_vs2 = rho_e * vs_e * vs_e;
             c33_e = rho_vp2;
@@ -788,27 +606,22 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
             c11_e = rho_vp2 * (1.0f + 2.0f * epsilon_e);
             c66_e = rho_vs2 * (1.0f + 2.0f * gamma_e);
             float const vp2_vs2 = vp_e * vp_e - vs_e * vs_e;
-            c13_e = rho_e * sqrtf(vp2_vs2 * vp2_vs2 +
-                                  2.0f * rho_vp2 * delta_e * vp2_vs2) -
-                    rho_vs2;
+            c13_e = rho_e * sqrtf(vp2_vs2 * vp2_vs2 + 2.0f * rho_vp2 * delta_e * vp2_vs2) - rho_vs2;
             c12_e = c11_e - 2.0f * c66_e;
           }
 
           INTEGRAL_TYPE::computeElasticStiffnessSumFact(
               transformData, localFields, localWork,
-              [&](int qa, int qb, int qc, float const(&J_inv)[3][3],
-                  float const(&grad_u_ref)[3][3], float(&flux)[3][3]) {
+              [&](int qa, int qb, int qc, float const(&J_inv)[3][3], float const(&grad_u_ref)[3][3],
+                  float(&flux)[3][3]) {
                 float c11, c12, c13, c33, c44, c66;
-                if constexpr (IS_MODEL_ON_NODES)
-                {
-                  int const gIndex =
-                      mesh_local.globalNodeIndex(elementNumber, qa, qb, qc);
+                if constexpr (IS_MODEL_ON_NODES) {
+                  int const gIndex = mesh_local.globalNodeIndex(elementNumber, qa, qb, qc);
                   float const vp = mesh_local.getModelVpOnNodes(gIndex);
                   float const vs = mesh_local.getModelVsOnNodes(gIndex);
                   float const rho = mesh_local.getModelRhoOnNodes(gIndex);
                   float const delta = mesh_local.getModelDeltaOnNodes(gIndex);
-                  float const epsilon =
-                      mesh_local.getModelEpsilonOnNodes(gIndex);
+                  float const epsilon = mesh_local.getModelEpsilonOnNodes(gIndex);
                   float const gamma = mesh_local.getModelGammaOnNodes(gIndex);
                   float const rho_vp2 = rho * vp * vp;
                   float const rho_vs2 = rho * vs * vs;
@@ -817,13 +630,9 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
                   c11 = rho_vp2 * (1.0f + 2.0f * epsilon);
                   c66 = rho_vs2 * (1.0f + 2.0f * gamma);
                   float const vp2_vs2 = vp * vp - vs * vs;
-                  c13 = rho * sqrtf(vp2_vs2 * vp2_vs2 +
-                                    2.0f * rho_vp2 * delta * vp2_vs2) -
-                        rho_vs2;
+                  c13 = rho * sqrtf(vp2_vs2 * vp2_vs2 + 2.0f * rho_vp2 * delta * vp2_vs2) - rho_vs2;
                   c12 = c11 - 2.0f * c66;
-                }
-                else
-                {
+                } else {
                   c11 = c11_e;
                   c12 = c12_e;
                   c13 = c13_e;
@@ -832,25 +641,20 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
                   c66 = c66_e;
                 }
 
-                for (int p = 0; p < 3; ++p)
-                {
+                for (int p = 0; p < 3; ++p) {
                   float const Jp0 = J_inv[p][0];
                   float const Jp1 = J_inv[p][1];
                   float const Jp2 = J_inv[p][2];
                   flux[p][0] = 0.0f;
                   flux[p][1] = 0.0f;
                   flux[p][2] = 0.0f;
-                  for (int r = 0; r < 3; ++r)
-                  {
+                  for (int r = 0; r < 3; ++r) {
                     float const Jr0 = J_inv[r][0];
                     float const Jr1 = J_inv[r][1];
                     float const Jr2 = J_inv[r][2];
-                    float const p0r0 = Jp0 * Jr0, p0r1 = Jp0 * Jr1,
-                                p0r2 = Jp0 * Jr2;
-                    float const p1r0 = Jp1 * Jr0, p1r1 = Jp1 * Jr1,
-                                p1r2 = Jp1 * Jr2;
-                    float const p2r0 = Jp2 * Jr0, p2r1 = Jp2 * Jr1,
-                                p2r2 = Jp2 * Jr2;
+                    float const p0r0 = Jp0 * Jr0, p0r1 = Jp0 * Jr1, p0r2 = Jp0 * Jr2;
+                    float const p1r0 = Jp1 * Jr0, p1r1 = Jp1 * Jr1, p1r2 = Jp1 * Jr2;
+                    float const p2r0 = Jp2 * Jr0, p2r1 = Jp2 * Jr1, p2r2 = Jp2 * Jr2;
                     float const v0 = c11 * p0r0 + c66 * p1r1 + c44 * p2r2;
                     float const v1 = c66 * p0r0 + c11 * p1r1 + c44 * p2r2;
                     float const v2 = c44 * p0r0 + c44 * p1r1 + c33 * p2r2;
@@ -867,20 +671,14 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
                 }
               });
 
-          for (int i = 0; i < dim; ++i)
-          {
-            for (int j = 0; j < dim; ++j)
-            {
-              for (int k = 0; k < dim; ++k)
-              {
-                int const globalIdx =
-                    mesh_local.globalNodeIndex(elementNumber, i, j, k);
+          for (int i = 0; i < dim; ++i) {
+            for (int j = 0; j < dim; ++j) {
+              for (int k = 0; k < dim; ++k) {
+                int const globalIdx = mesh_local.globalNodeIndex(elementNumber, i, j, k);
                 int const localIdx = i + j * dim + k * dim * dim;
 
-                for (int f = 0; f < kNumFields; ++f)
-                {
-                  ATOMICADD(local_workVectorsGlobal[f][globalIdx],
-                            localWork[f][localIdx]);
+                for (int f = 0; f < kNumFields; ++f) {
+                  ATOMICADD(local_workVectorsGlobal[f][globalIdx], localWork[f][localIdx]);
                 }
               }
             }
@@ -893,35 +691,24 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
 // computeElementContributions_TTI - TTI
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES, physicType PHYSICS>
-void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
-               PHYSICS>::computeElementContributions_Tti(const DataType& data)
-{
-  if constexpr (PHYSICS != utils::enums::physicType::kElastic)
-  {
-  }
-  else
-  {
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES, physicType PHYSICS>
+void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::computeElementContributions_Tti(
+    const DataType& data) {
+  if constexpr (PHYSICS != utils::enums::physicType::kElastic) {
+  } else {
     auto mesh_local = m_mesh;
     bool const list_on = m_list_mode_;
     auto list_local = m_elem_list_;
-    int const n_iter =
-        list_on ? m_n_elem_list_ : mesh_local.getNumberOfElements();
+    int const n_iter = list_on ? m_n_elem_list_ : mesh_local.getNumberOfElements();
 
-    std::array<std::remove_reference_t<decltype(workVectorsGlobal_[0])>,
-               kNumFields>
-        local_workVectorsGlobal;
-    for (int f = 0; f < kNumFields; ++f)
-    {
+    std::array<std::remove_reference_t<decltype(workVectorsGlobal_[0])>, kNumFields> local_workVectorsGlobal;
+    for (int f = 0; f < kNumFields; ++f) {
       local_workVectorsGlobal[f] = workVectorsGlobal_[f];
     }
 
     Kokkos::parallel_for(
         "Solver Element Contribution Tti",
-        Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock,
-                                                 LaunchMinBlocksPerSM>>(0,
-                                                                        n_iter),
+        Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(0, n_iter),
         KOKKOS_LAMBDA(const int _loop_idx) {
           int const elementNumber = list_on ? list_local[_loop_idx] : _loop_idx;
 
@@ -929,18 +716,13 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
           float localFields[kNumFields][kPointsPerElement] = {{0}};
           float localWork[kNumFields][kPointsPerElement] = {{0}};
 
-          for (int i = 0; i < dim; ++i)
-          {
-            for (int j = 0; j < dim; ++j)
-            {
-              for (int k = 0; k < dim; ++k)
-              {
-                int const globalIdx =
-                    mesh_local.globalNodeIndex(elementNumber, i, j, k);
+          for (int i = 0; i < dim; ++i) {
+            for (int j = 0; j < dim; ++j) {
+              for (int k = 0; k < dim; ++k) {
+                int const globalIdx = mesh_local.globalNodeIndex(elementNumber, i, j, k);
                 int const localIdx = i + j * dim + k * dim * dim;
 
-                for (int f = 0; f < kNumFields; ++f)
-                {
+                for (int f = 0; f < kNumFields; ++f) {
                   localFields[f][localIdx] = data.getCurrentField(f)(globalIdx);
                 }
               }
@@ -948,86 +730,64 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
           }
 
           typename INTEGRAL_TYPE::TransformType transformData;
-          model_discretization_interface::gatherTransformData(
-              elementNumber, mesh_local, transformData);
+          model_discretization_interface::gatherTransformData(elementNumber, mesh_local, transformData);
 
           float CTTI[6][6] = {};
-          if constexpr (!IS_MODEL_ON_NODES)
-          {
+          if constexpr (!IS_MODEL_ON_NODES) {
             mesh_local.getCTensorOnElement(elementNumber, CTTI);
           }
 
           INTEGRAL_TYPE::computeElasticStiffnessSumFact(
               transformData, localFields, localWork,
-              [&](int qa, int qb, int qc, float const(&J_inv)[3][3],
-                  float const(&grad_u_ref)[3][3], float(&flux)[3][3]) {
-                if constexpr (IS_MODEL_ON_NODES)
-                {
-                  int const gIndex =
-                      mesh_local.globalNodeIndex(elementNumber, qa, qb, qc);
+              [&](int qa, int qb, int qc, float const(&J_inv)[3][3], float const(&grad_u_ref)[3][3],
+                  float(&flux)[3][3]) {
+                if constexpr (IS_MODEL_ON_NODES) {
+                  int const gIndex = mesh_local.globalNodeIndex(elementNumber, qa, qb, qc);
                   float const vp = mesh_local.getModelVpOnNodes(gIndex);
                   float const vs = mesh_local.getModelVsOnNodes(gIndex);
                   float const rho = mesh_local.getModelRhoOnNodes(gIndex);
                   float const delta = mesh_local.getModelDeltaOnNodes(gIndex);
-                  float const epsilon =
-                      mesh_local.getModelEpsilonOnNodes(gIndex);
+                  float const epsilon = mesh_local.getModelEpsilonOnNodes(gIndex);
                   float const gamma = mesh_local.getModelGammaOnNodes(gIndex);
                   float const phi = mesh_local.getModelPhiOnNodes(gIndex);
                   float const theta = mesh_local.getModelThetaOnNodes(gIndex);
-                  computeCMatrix(vp, vs, rho, delta, epsilon, gamma, phi, theta,
-                                 CTTI);
+                  computeCMatrix(vp, vs, rho, delta, epsilon, gamma, phi, theta, CTTI);
                 }
 
-                float const C00 = CTTI[0][0], C01 = CTTI[0][1],
-                            C02 = CTTI[0][2];
-                float const C03 = CTTI[0][3], C04 = CTTI[0][4],
-                            C05 = CTTI[0][5];
-                float const C11 = CTTI[1][1], C12 = CTTI[1][2],
-                            C13 = CTTI[1][3];
+                float const C00 = CTTI[0][0], C01 = CTTI[0][1], C02 = CTTI[0][2];
+                float const C03 = CTTI[0][3], C04 = CTTI[0][4], C05 = CTTI[0][5];
+                float const C11 = CTTI[1][1], C12 = CTTI[1][2], C13 = CTTI[1][3];
                 float const C14 = CTTI[1][4], C15 = CTTI[1][5];
-                float const C22 = CTTI[2][2], C23 = CTTI[2][3],
-                            C24 = CTTI[2][4], C25 = CTTI[2][5];
-                float const C33 = CTTI[3][3], C34 = CTTI[3][4],
-                            C35 = CTTI[3][5];
+                float const C22 = CTTI[2][2], C23 = CTTI[2][3], C24 = CTTI[2][4], C25 = CTTI[2][5];
+                float const C33 = CTTI[3][3], C34 = CTTI[3][4], C35 = CTTI[3][5];
                 float const C44 = CTTI[4][4], C45 = CTTI[4][5];
                 float const C55 = CTTI[5][5];
 
-                for (int p = 0; p < 3; ++p)
-                {
+                for (int p = 0; p < 3; ++p) {
                   float const Jp0 = J_inv[p][0];
                   float const Jp1 = J_inv[p][1];
                   float const Jp2 = J_inv[p][2];
                   flux[p][0] = 0.0f;
                   flux[p][1] = 0.0f;
                   flux[p][2] = 0.0f;
-                  for (int r = 0; r < 3; ++r)
-                  {
+                  for (int r = 0; r < 3; ++r) {
                     float const Jr0 = J_inv[r][0];
                     float const Jr1 = J_inv[r][1];
                     float const Jr2 = J_inv[r][2];
-                    float const p0r0 = Jp0 * Jr0, p0r1 = Jp0 * Jr1,
-                                p0r2 = Jp0 * Jr2;
-                    float const p1r0 = Jp1 * Jr0, p1r1 = Jp1 * Jr1,
-                                p1r2 = Jp1 * Jr2;
-                    float const p2r0 = Jp2 * Jr0, p2r1 = Jp2 * Jr1,
-                                p2r2 = Jp2 * Jr2;
-                    float const v0 = C00 * p0r0 + C05 * p0r1 + C04 * p0r2 +
-                                     C05 * p1r0 + C55 * p1r1 + C45 * p1r2 +
+                    float const p0r0 = Jp0 * Jr0, p0r1 = Jp0 * Jr1, p0r2 = Jp0 * Jr2;
+                    float const p1r0 = Jp1 * Jr0, p1r1 = Jp1 * Jr1, p1r2 = Jp1 * Jr2;
+                    float const p2r0 = Jp2 * Jr0, p2r1 = Jp2 * Jr1, p2r2 = Jp2 * Jr2;
+                    float const v0 = C00 * p0r0 + C05 * p0r1 + C04 * p0r2 + C05 * p1r0 + C55 * p1r1 + C45 * p1r2 +
                                      C04 * p2r0 + C45 * p2r1 + C44 * p2r2;
-                    float const v1 = C55 * p0r0 + C15 * p0r1 + C35 * p0r2 +
-                                     C15 * p1r0 + C11 * p1r1 + C13 * p1r2 +
+                    float const v1 = C55 * p0r0 + C15 * p0r1 + C35 * p0r2 + C15 * p1r0 + C11 * p1r1 + C13 * p1r2 +
                                      C35 * p2r0 + C13 * p2r1 + C33 * p2r2;
-                    float const v2 = C44 * p0r0 + C34 * p0r1 + C24 * p0r2 +
-                                     C34 * p1r0 + C33 * p1r1 + C23 * p1r2 +
+                    float const v2 = C44 * p0r0 + C34 * p0r1 + C24 * p0r2 + C34 * p1r0 + C33 * p1r1 + C23 * p1r2 +
                                      C24 * p2r0 + C23 * p2r1 + C22 * p2r2;
-                    float const v3 = C05 * p0r0 + C01 * p0r1 + C03 * p0r2 +
-                                     C55 * p1r0 + C15 * p1r1 + C35 * p1r2 +
+                    float const v3 = C05 * p0r0 + C01 * p0r1 + C03 * p0r2 + C55 * p1r0 + C15 * p1r1 + C35 * p1r2 +
                                      C45 * p2r0 + C14 * p2r1 + C34 * p2r2;
-                    float const v4 = C04 * p0r0 + C03 * p0r1 + C02 * p0r2 +
-                                     C45 * p1r0 + C35 * p1r1 + C25 * p1r2 +
+                    float const v4 = C04 * p0r0 + C03 * p0r1 + C02 * p0r2 + C45 * p1r0 + C35 * p1r1 + C25 * p1r2 +
                                      C44 * p2r0 + C34 * p2r1 + C24 * p2r2;
-                    float const v5 = C45 * p0r0 + C35 * p0r1 + C25 * p0r2 +
-                                     C14 * p1r0 + C13 * p1r1 + C12 * p1r2 +
+                    float const v5 = C45 * p0r0 + C35 * p0r1 + C25 * p0r2 + C14 * p1r0 + C13 * p1r1 + C12 * p1r2 +
                                      C34 * p2r0 + C33 * p2r1 + C23 * p2r2;
                     float const g0 = grad_u_ref[r][0];
                     float const g1 = grad_u_ref[r][1];
@@ -1039,20 +799,14 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
                 }
               });
 
-          for (int i = 0; i < dim; ++i)
-          {
-            for (int j = 0; j < dim; ++j)
-            {
-              for (int k = 0; k < dim; ++k)
-              {
-                int const globalIdx =
-                    mesh_local.globalNodeIndex(elementNumber, i, j, k);
+          for (int i = 0; i < dim; ++i) {
+            for (int j = 0; j < dim; ++j) {
+              for (int k = 0; k < dim; ++k) {
+                int const globalIdx = mesh_local.globalNodeIndex(elementNumber, i, j, k);
                 int const localIdx = i + j * dim + k * dim * dim;
 
-                for (int f = 0; f < kNumFields; ++f)
-                {
-                  ATOMICADD(local_workVectorsGlobal[f][globalIdx],
-                            localWork[f][localIdx]);
+                for (int f = 0; f < kNumFields; ++f) {
+                  ATOMICADD(local_workVectorsGlobal[f][globalIdx], localWork[f][localIdx]);
                 }
               }
             }
@@ -1064,11 +818,9 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
 //============================================================================
 // updateFields - Time integration update
 //============================================================================
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES, physicType PHYSICS>
-void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
-               PHYSICS>::updateFields(float dt, const DataType& data)
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES, physicType PHYSICS>
+void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::updateFields(float dt,
+                                                                                          const DataType& data) {
   // Extract scalar constants to local variables
   float const dt_local = dt;
   float const dt2_local = dt * dt;
@@ -1083,34 +835,19 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
   auto sls_w = slsReferenceAngularFrequencies_;
   auto sls_beta = slsAnelasticityCoefficients_;
 
-  std::array<std::remove_reference_t<decltype(data.getCurrentField(0))>,
-             kNumFields>
-      current_field;
-  std::array<std::remove_reference_t<decltype(data.getPreviousField(0))>,
-             kNumFields>
-      prev_field;
-  std::array<std::remove_reference_t<decltype(dampingMatrixGlobal_[0])>,
-             kNumFields>
-      damping_matrix;
-  std::array<std::remove_reference_t<decltype(workVectorsGlobal_[0])>,
-             kNumFields>
-      work_vector;
-  std::array<
-      std::remove_reference_t<decltype(attenuationWorkVectorsGlobal_[0])>,
-      kNumFields>
-      atten_work_vec;
-  std::array<std::remove_reference_t<decltype(attenuationMemoryVariables_[0])>,
-             kNumFields>
-      atten_mem_vars;
+  std::array<std::remove_reference_t<decltype(data.getCurrentField(0))>, kNumFields> current_field;
+  std::array<std::remove_reference_t<decltype(data.getPreviousField(0))>, kNumFields> prev_field;
+  std::array<std::remove_reference_t<decltype(dampingMatrixGlobal_[0])>, kNumFields> damping_matrix;
+  std::array<std::remove_reference_t<decltype(workVectorsGlobal_[0])>, kNumFields> work_vector;
+  std::array<std::remove_reference_t<decltype(attenuationWorkVectorsGlobal_[0])>, kNumFields> atten_work_vec;
+  std::array<std::remove_reference_t<decltype(attenuationMemoryVariables_[0])>, kNumFields> atten_mem_vars;
 
-  for (int f = 0; f < kNumFields; ++f)
-  {
+  for (int f = 0; f < kNumFields; ++f) {
     current_field[f] = data.getCurrentField(f);
     prev_field[f] = data.getPreviousField(f);
     damping_matrix[f] = dampingMatrixGlobal_[f];
     work_vector[f] = workVectorsGlobal_[f];
-    if (has_attenuation)
-    {
+    if (has_attenuation) {
       atten_work_vec[f] = attenuationWorkVectorsGlobal_[f];
       atten_mem_vars[f] = attenuationMemoryVariables_[f];
     }
@@ -1119,93 +856,66 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
   bool const list_on = m_node_list_mode_;
   auto list_local = m_node_list_;
 
-  if constexpr (PHYSICS == utils::enums::physicType::kAcoustic)
-  {
+  if constexpr (PHYSICS == utils::enums::physicType::kAcoustic) {
     int const n_iter = list_on ? m_n_node_list_ : mesh_local.getNumberOfNodes();
     Kokkos::parallel_for(
-        "Solver Update Field Acoustic", n_iter,
-        KOKKOS_LAMBDA(const int _node_idx) {
+        "Solver Update Field Acoustic", n_iter, KOKKOS_LAMBDA(const int _node_idx) {
           if (_node_idx >= n_iter) return;
           int const I = list_on ? list_local[_node_idx] : _node_idx;
           if (mass_matrix[I] <= 0.0f) return;
 
-          if (mesh_local.isFreeSurface(I))
-          {
+          if (mesh_local.isFreeSurface(I)) {
             current_field[0](I) = 0.0f;
             prev_field[0](I) = 0.0f;
-          }
-          else
-          {
-            float next_val =
-                (2.0f * mass_matrix(I) * current_field[0](I) -
-                 (mass_matrix(I) - 0.5f * dt_local * damping_matrix[0](I)) *
-                     prev_field[0](I) -
-                 dt2_local * work_vector[0](I));
+          } else {
+            float next_val = (2.0f * mass_matrix(I) * current_field[0](I) -
+                              (mass_matrix(I) - 0.5f * dt_local * damping_matrix[0](I)) * prev_field[0](I) -
+                              dt2_local * work_vector[0](I));
 
-            if (has_attenuation)
-            {
-              for (int l = 0; l < n_sls; ++l)
-              {
+            if (has_attenuation) {
+              for (int l = 0; l < n_sls; ++l) {
                 float const w = sls_w[l];
-                float const gamma =
-                    (2.0f - w * dt_local) / (2.0f + w * dt_local);
-                float const beta =
-                    sls_beta[l] * w * 2.0f * dt_local / (2.0f + w * dt_local);
+                float const gamma = (2.0f - w * dt_local) / (2.0f + w * dt_local);
+                float const beta = sls_beta[l] * w * 2.0f * dt_local / (2.0f + w * dt_local);
                 float const gamma_p = 0.5f + 0.5f * gamma;
                 float const beta_p = 0.5f * beta;
 
-                next_val += dt2_local * (gamma_p * atten_mem_vars[0](I, l) +
-                                         beta_p * atten_work_vec[0](I));
+                next_val += dt2_local * (gamma_p * atten_mem_vars[0](I, l) + beta_p * atten_work_vec[0](I));
 
-                atten_mem_vars[0](I, l) = gamma * atten_mem_vars[0](I, l) +
-                                          beta * atten_work_vec[0](I);
+                atten_mem_vars[0](I, l) = gamma * atten_mem_vars[0](I, l) + beta * atten_work_vec[0](I);
               }
             }
 
-            prev_field[0](I) =
-                next_val /
-                (mass_matrix(I) + 0.5f * dt_local * damping_matrix[0](I));
+            prev_field[0](I) = next_val / (mass_matrix(I) + 0.5f * dt_local * damping_matrix[0](I));
             prev_field[0](I) *= taper_coeff(I);
             current_field[0](I) *= taper_coeff(I);
           }
         });
-  }
-  else  // ELASTIC
+  } else  // ELASTIC
   {
-    int const n_iter_el =
-        list_on ? m_n_node_list_ : mesh_local.getNumberOfNodes();
+    int const n_iter_el = list_on ? m_n_node_list_ : mesh_local.getNumberOfNodes();
 
     Kokkos::parallel_for(
-        "Solver Update Field Elastic", n_iter_el,
-        KOKKOS_LAMBDA(const int _node_idx) {
+        "Solver Update Field Elastic", n_iter_el, KOKKOS_LAMBDA(const int _node_idx) {
           if (_node_idx >= n_iter_el) return;
           int const I = list_on ? list_local[_node_idx] : _node_idx;
           if (mass_matrix[I] <= 0.0f) return;
-          if (mesh_local.isFreeSurface(I))
-          {
-            for (int f = 0; f < kNumFields; ++f)
-            {
-              float next_val = (2.0f * mass_matrix(I) * current_field[f](I) -
-                                mass_matrix(I) * prev_field[f](I) -
+          if (mesh_local.isFreeSurface(I)) {
+            for (int f = 0; f < kNumFields; ++f) {
+              float next_val = (2.0f * mass_matrix(I) * current_field[f](I) - mass_matrix(I) * prev_field[f](I) -
                                 dt2_local * work_vector[f](I));
 
-              if (has_attenuation)
-              {
-                for (int l = 0; l < n_sls; ++l)
-                {
+              if (has_attenuation) {
+                for (int l = 0; l < n_sls; ++l) {
                   float const w = sls_w[l];
-                  float const gamma =
-                      (2.0f - w * dt_local) / (2.0f + w * dt_local);
-                  float const beta =
-                      sls_beta[l] * w * 2.0f * dt_local / (2.0f + w * dt_local);
+                  float const gamma = (2.0f - w * dt_local) / (2.0f + w * dt_local);
+                  float const beta = sls_beta[l] * w * 2.0f * dt_local / (2.0f + w * dt_local);
                   float const gamma_p = 0.5f + 0.5f * gamma;
                   float const beta_p = 0.5f * beta;
 
-                  next_val += dt2_local * (gamma_p * atten_mem_vars[f](I, l) +
-                                           beta_p * atten_work_vec[f](I));
+                  next_val += dt2_local * (gamma_p * atten_mem_vars[f](I, l) + beta_p * atten_work_vec[f](I));
 
-                  atten_mem_vars[f](I, l) = gamma * atten_mem_vars[f](I, l) +
-                                            beta * atten_work_vec[f](I);
+                  atten_mem_vars[f](I, l) = gamma * atten_mem_vars[f](I, l) + beta * atten_work_vec[f](I);
                 }
               }
 
@@ -1213,40 +923,27 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
               prev_field[f](I) *= taper_coeff(I);
               current_field[f](I) *= taper_coeff(I);
             }
-          }
-          else
-          {
-            for (int f = 0; f < kNumFields; ++f)
-            {
-              float next_val =
-                  (2.0f * mass_matrix(I) * current_field[f](I) -
-                   (mass_matrix(I) - 0.5f * dt_local * damping_matrix[f](I)) *
-                       prev_field[f](I) -
-                   dt2_local * work_vector[f](I));
+          } else {
+            for (int f = 0; f < kNumFields; ++f) {
+              float next_val = (2.0f * mass_matrix(I) * current_field[f](I) -
+                                (mass_matrix(I) - 0.5f * dt_local * damping_matrix[f](I)) * prev_field[f](I) -
+                                dt2_local * work_vector[f](I));
 
-              if (has_attenuation)
-              {
-                for (int l = 0; l < n_sls; ++l)
-                {
+              if (has_attenuation) {
+                for (int l = 0; l < n_sls; ++l) {
                   float const w = sls_w[l];
-                  float const gamma =
-                      (2.0f - w * dt_local) / (2.0f + w * dt_local);
-                  float const beta =
-                      sls_beta[l] * w * 2.0f * dt_local / (2.0f + w * dt_local);
+                  float const gamma = (2.0f - w * dt_local) / (2.0f + w * dt_local);
+                  float const beta = sls_beta[l] * w * 2.0f * dt_local / (2.0f + w * dt_local);
                   float const gamma_p = 0.5f + 0.5f * gamma;
                   float const beta_p = 0.5f * beta;
 
-                  next_val += dt2_local * (gamma_p * atten_mem_vars[f](I, l) +
-                                           beta_p * atten_work_vec[f](I));
+                  next_val += dt2_local * (gamma_p * atten_mem_vars[f](I, l) + beta_p * atten_work_vec[f](I));
 
-                  atten_mem_vars[f](I, l) = gamma * atten_mem_vars[f](I, l) +
-                                            beta * atten_work_vec[f](I);
+                  atten_mem_vars[f](I, l) = gamma * atten_mem_vars[f](I, l) + beta * atten_work_vec[f](I);
                 }
               }
 
-              prev_field[f](I) =
-                  next_val /
-                  (mass_matrix(I) + 0.5f * dt_local * damping_matrix[f](I));
+              prev_field[f](I) = next_val / (mass_matrix(I) + 0.5f * dt_local * damping_matrix[f](I));
               prev_field[f](I) *= taper_coeff(I);
               current_field[f](I) *= taper_coeff(I);
             }
@@ -1259,64 +956,47 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
 // computeGlobalMassMatrix - Assemble mass matrix
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES, physicType PHYSICS>
-void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
-               PHYSICS>::computeGlobalMassMatrix()
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES, physicType PHYSICS>
+void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::computeGlobalMassMatrix() {
   auto mesh_local = m_mesh;
   auto local_massMatrixGlobal = massMatrixGlobal_;
 
   Kokkos::parallel_for(
       "Solver Compute GMatrix",
-      Kokkos::RangePolicy<
-          Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(
+      Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(
           0, mesh_local.getNumberOfElements()),
       KOKKOS_LAMBDA(const int elementNumber) {
         float massMatrixLocal[kPointsPerElement] = {0};
         int const dim = mesh_local.getOrder() + 1;
 
         typename INTEGRAL_TYPE::TransformType transformData;
-        model_discretization_interface::gatherTransformData(
-            elementNumber, mesh_local, transformData);
+        model_discretization_interface::gatherTransformData(elementNumber, mesh_local, transformData);
 
-        INTEGRAL_TYPE::computeMassTerm(
-            transformData,
-            [&](const int j, const real_t val) { massMatrixLocal[j] += val; });
+        INTEGRAL_TYPE::computeMassTerm(transformData,
+                                       [&](const int j, const real_t val) { massMatrixLocal[j] += val; });
 
         real_t model_factor = 0.0f;
-        if constexpr (!IS_MODEL_ON_NODES)
-        {
-          if constexpr (PHYSICS == utils::enums::physicType::kAcoustic)
-          {
+        if constexpr (!IS_MODEL_ON_NODES) {
+          if constexpr (PHYSICS == utils::enums::physicType::kAcoustic) {
             model_factor =
-                1.0f / (mesh_local.getModelVpOnElement(elementNumber) *
-                        mesh_local.getModelVpOnElement(elementNumber) *
+                1.0f / (mesh_local.getModelVpOnElement(elementNumber) * mesh_local.getModelVpOnElement(elementNumber) *
                         mesh_local.getModelRhoOnElement(elementNumber));
-          }
-          else
-          {
+          } else {
             model_factor = mesh_local.getModelRhoOnElement(elementNumber);
           }
         }
 
-        for (int i = 0; i < mesh_local.getNumberOfPointsPerElement(); ++i)
-        {
+        for (int i = 0; i < mesh_local.getNumberOfPointsPerElement(); ++i) {
           int x = i % dim;
           int z = (i / dim) % dim;
           int y = i / (dim * dim);
           int const gIndex = mesh_local.globalNodeIndex(elementNumber, x, y, z);
 
-          if constexpr (IS_MODEL_ON_NODES)
-          {
-            if constexpr (PHYSICS == utils::enums::physicType::kAcoustic)
-            {
-              model_factor = 1.0f / (mesh_local.getModelVpOnNodes(gIndex) *
-                                     mesh_local.getModelVpOnNodes(gIndex) *
+          if constexpr (IS_MODEL_ON_NODES) {
+            if constexpr (PHYSICS == utils::enums::physicType::kAcoustic) {
+              model_factor = 1.0f / (mesh_local.getModelVpOnNodes(gIndex) * mesh_local.getModelVpOnNodes(gIndex) *
                                      mesh_local.getModelRhoOnNodes(gIndex));
-            }
-            else
-            {
+            } else {
               model_factor = mesh_local.getModelRhoOnNodes(gIndex);
             }
           }
@@ -1331,142 +1011,105 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
 // computeGlobalDampingMatrix - Assemble damping matrix
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES, physicType PHYSICS>
-void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
-               PHYSICS>::computeDampingMatrix()
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES, physicType PHYSICS>
+void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::computeDampingMatrix() {
   auto mesh_local = m_mesh;
 
-  std::array<std::remove_reference_t<decltype(dampingMatrixGlobal_[0])>,
-             kNumFields>
-      local_dampingMatrixGlobal;
-  for (int f = 0; f < kNumFields; ++f)
-  {
+  std::array<std::remove_reference_t<decltype(dampingMatrixGlobal_[0])>, kNumFields> local_dampingMatrixGlobal;
+  for (int f = 0; f < kNumFields; ++f) {
     local_dampingMatrixGlobal[f] = dampingMatrixGlobal_[f];
   }
 
   Kokkos::parallel_for(
       "Solver Compute Damping Matrix",
-      Kokkos::RangePolicy<
-          Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(
+      Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>(
           0, mesh_local.getNumberOfElements()),
       KOKKOS_LAMBDA(const int elementNumber) {
         (void)local_dampingMatrixGlobal;
-        for (int i = 0; i < 6; ++i)
-        {
+        for (int i = 0; i < 6; ++i) {
           // Get global face ID for this element face
-          int f = mesh_local.getGlobalFace(elementNumber,
-                                           static_cast<model::CubicFace>(i));
+          int f = mesh_local.getGlobalFace(elementNumber, static_cast<model::CubicFace>(i));
 
           // Skip internal faces (only process boundary faces)
           if (!mesh_local.isBoundaryFace(f)) continue;
 
           // Get corner coordinates of the face for integration
           float coords[4][3];
-          for (int j = 0; j < 4; ++j)
-          {
-            int const globalNodeIndex = mesh_local.getGlobalNodeFromFace(
-                f, INTEGRAL_TYPE::meshIndexToLinearIndex2D(j));
-            for (int d = 0; d < 3; ++d)
-            {
+          for (int j = 0; j < 4; ++j) {
+            int const globalNodeIndex = mesh_local.getGlobalNodeFromFace(f, INTEGRAL_TYPE::meshIndexToLinearIndex2D(j));
+            for (int d = 0; d < 3; ++d) {
               coords[j][d] = mesh_local.nodeCoord(globalNodeIndex, d);
             }
           }
 
-          if constexpr (PHYSICS == utils::enums::physicType::kAcoustic)
-          {
+          if constexpr (PHYSICS == utils::enums::physicType::kAcoustic) {
             // Acoustic damping
             real_t model_rho = 0.0f;
             real_t model_vp = 0.0f;
             real_t alpha = 0.0f;
 
-            if constexpr (!IS_MODEL_ON_NODES)
-            {
+            if constexpr (!IS_MODEL_ON_NODES) {
               model_rho = mesh_local.getModelRhoOnElement(elementNumber);
               model_vp = mesh_local.getModelVpOnElement(elementNumber);
               alpha = 1.0 / (model_rho * model_vp);
             }
 
             constexpr int numNodesPerFace = (ORDER + 1) * (ORDER + 1);
-            for (int q = 0; q < numNodesPerFace; ++q)
-            {
-              int const globalNodeIndex =
-                  mesh_local.getGlobalNodeFromFace(f, q);
+            for (int q = 0; q < numNodesPerFace; ++q) {
+              int const globalNodeIndex = mesh_local.getGlobalNodeFromFace(f, q);
 
               // Skip free surface nodes (no damping on free surface)
-              if (mesh_local.isFreeSurface(globalNodeIndex))
-              {
+              if (mesh_local.isFreeSurface(globalNodeIndex)) {
                 continue;
               }
 
-              if constexpr (IS_MODEL_ON_NODES)
-              {
+              if constexpr (IS_MODEL_ON_NODES) {
                 model_rho = mesh_local.getModelRhoOnNodes(globalNodeIndex);
                 model_vp = mesh_local.getModelVpOnNodes(globalNodeIndex);
                 alpha = 1.0 / (model_rho * model_vp);
               }
 
-              real_t localIncrement =
-                  alpha * INTEGRAL_TYPE::computeDampingTerm(q, coords);
-              ATOMICADD(local_dampingMatrixGlobal[0][globalNodeIndex],
-                        localIncrement);
+              real_t localIncrement = alpha * INTEGRAL_TYPE::computeDampingTerm(q, coords);
+              ATOMICADD(local_dampingMatrixGlobal[0][globalNodeIndex], localIncrement);
             }
-          }
-          else  // Elastic
+          } else  // Elastic
           {
             // Elastic damping
             float normal[3];
-            mesh_local.faceNormal(elementNumber,
-                                  static_cast<model::CubicFace>(i), normal);
+            mesh_local.faceNormal(elementNumber, static_cast<model::CubicFace>(i), normal);
             real_t nx = normal[0], ny = normal[1], nz = normal[2];
 
             real_t density, velocityVp, velocityVs;
 
-            if constexpr (!IS_MODEL_ON_NODES)
-            {
+            if constexpr (!IS_MODEL_ON_NODES) {
               density = mesh_local.getModelRhoOnElement(elementNumber);
               velocityVp = mesh_local.getModelVpOnElement(elementNumber);
               velocityVs = mesh_local.getModelVsOnElement(elementNumber);
             }
 
             constexpr int numNodesPerFace = (ORDER + 1) * (ORDER + 1);
-            for (int q = 0; q < numNodesPerFace; ++q)
-            {
-              int const globalNodeIndex =
-                  mesh_local.getGlobalNodeFromFace(f, q);
+            for (int q = 0; q < numNodesPerFace; ++q) {
+              int const globalNodeIndex = mesh_local.getGlobalNodeFromFace(f, q);
 
               // Skip free surface nodes (no damping on free surface)
-              if (mesh_local.isFreeSurface(globalNodeIndex))
-              {
+              if (mesh_local.isFreeSurface(globalNodeIndex)) {
                 continue;
               }
 
-              if constexpr (IS_MODEL_ON_NODES)
-              {
+              if constexpr (IS_MODEL_ON_NODES) {
                 density = mesh_local.getModelRhoOnNodes(globalNodeIndex);
                 velocityVp = mesh_local.getModelVpOnNodes(globalNodeIndex);
                 velocityVs = mesh_local.getModelVsOnNodes(globalNodeIndex);
               }
 
-              real_t aux =
-                  density * INTEGRAL_TYPE::computeDampingTerm(q, coords);
-              real_t localIncrementx =
-                  aux * (velocityVp * fabs(nx) +
-                         velocityVs * sqrt(ny * ny + nz * nz));
-              real_t localIncrementy =
-                  aux * (velocityVp * fabs(ny) +
-                         velocityVs * sqrt(nx * nx + nz * nz));
-              real_t localIncrementz =
-                  aux * (velocityVp * fabs(nz) +
-                         velocityVs * sqrt(nx * nx + ny * ny));
+              real_t aux = density * INTEGRAL_TYPE::computeDampingTerm(q, coords);
+              real_t localIncrementx = aux * (velocityVp * fabs(nx) + velocityVs * sqrt(ny * ny + nz * nz));
+              real_t localIncrementy = aux * (velocityVp * fabs(ny) + velocityVs * sqrt(nx * nx + nz * nz));
+              real_t localIncrementz = aux * (velocityVp * fabs(nz) + velocityVs * sqrt(nx * nx + ny * ny));
 
-              ATOMICADD(local_dampingMatrixGlobal[0][globalNodeIndex],
-                        localIncrementx);
-              ATOMICADD(local_dampingMatrixGlobal[1][globalNodeIndex],
-                        localIncrementy);
-              ATOMICADD(local_dampingMatrixGlobal[2][globalNodeIndex],
-                        localIncrementz);
+              ATOMICADD(local_dampingMatrixGlobal[0][globalNodeIndex], localIncrementx);
+              ATOMICADD(local_dampingMatrixGlobal[1][globalNodeIndex], localIncrementy);
+              ATOMICADD(local_dampingMatrixGlobal[2][globalNodeIndex], localIncrementz);
             }
           }
         }
@@ -1477,70 +1120,47 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
 // allocateFEarrays - Allocate memory for FE arrays
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES, physicType PHYSICS>
-void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
-               PHYSICS>::allocateFEarrays()
-{
-  massMatrixGlobal_ = allocateVector<VECTOR_REAL_VIEW>(
-      m_mesh.getNumberOfNodes(), "massMatrixGlobal");
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES, physicType PHYSICS>
+void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::allocateFEarrays() {
+  massMatrixGlobal_ = allocateVector<VECTOR_REAL_VIEW>(m_mesh.getNumberOfNodes(), "massMatrixGlobal");
 
-  static constexpr const char* dampingNames[3] = {"dampingX", "dampingY",
-                                                  "dampingZ"};
-  for (int f = 0; f < kNumFields; ++f)
-  {
-    dampingMatrixGlobal_[f] = allocateVector<VECTOR_REAL_VIEW>(
-        m_mesh.getNumberOfNodes(), dampingNames[f]);
+  static constexpr const char* dampingNames[3] = {"dampingX", "dampingY", "dampingZ"};
+  for (int f = 0; f < kNumFields; ++f) {
+    dampingMatrixGlobal_[f] = allocateVector<VECTOR_REAL_VIEW>(m_mesh.getNumberOfNodes(), dampingNames[f]);
   }
 
   // Allocate work vectors for each field
-  static constexpr const char* workVectorNames[3] = {"workVec0", "workVec1",
-                                                     "workVec2"};
-  for (int f = 0; f < kNumFields; ++f)
-  {
-    workVectorsGlobal_[f] = allocateVector<VECTOR_REAL_VIEW>(
-        m_mesh.getNumberOfNodes(), workVectorNames[f]);
+  static constexpr const char* workVectorNames[3] = {"workVec0", "workVec1", "workVec2"};
+  for (int f = 0; f < kNumFields; ++f) {
+    workVectorsGlobal_[f] = allocateVector<VECTOR_REAL_VIEW>(m_mesh.getNumberOfNodes(), workVectorNames[f]);
   }
 
-  if (attenuationEnabled_ && nSls_ > 0)
-  {
-    static constexpr const char* attWorkNames[3] = {
-        "attWorkVec0", "attWorkVec1", "attWorkVec2"};
-    static constexpr const char* attMemNames[3] = {"attMemory0", "attMemory1",
-                                                   "attMemory2"};
-    for (int f = 0; f < kNumFields; ++f)
-    {
-      attenuationWorkVectorsGlobal_[f] = allocateVector<VECTOR_REAL_VIEW>(
-          m_mesh.getNumberOfNodes(), attWorkNames[f]);
-      attenuationMemoryVariables_[f] = allocateArray2D<ARRAY_REAL_VIEW>(
-          m_mesh.getNumberOfNodes(), nSls_, attMemNames[f]);
+  if (attenuationEnabled_ && nSls_ > 0) {
+    static constexpr const char* attWorkNames[3] = {"attWorkVec0", "attWorkVec1", "attWorkVec2"};
+    static constexpr const char* attMemNames[3] = {"attMemory0", "attMemory1", "attMemory2"};
+    for (int f = 0; f < kNumFields; ++f) {
+      attenuationWorkVectorsGlobal_[f] = allocateVector<VECTOR_REAL_VIEW>(m_mesh.getNumberOfNodes(), attWorkNames[f]);
+      attenuationMemoryVariables_[f] =
+          allocateArray2D<ARRAY_REAL_VIEW>(m_mesh.getNumberOfNodes(), nSls_, attMemNames[f]);
     }
   }
 
-  spongeTaperCoeff_ = allocateVector<VECTOR_REAL_VIEW>(
-      m_mesh.getNumberOfNodes(), "spongeTaperCoeff");
+  spongeTaperCoeff_ = allocateVector<VECTOR_REAL_VIEW>(m_mesh.getNumberOfNodes(), "spongeTaperCoeff");
 }
 
 //============================================================================
 // initFEarrays - Initialize FE arrays
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES, physicType PHYSICS>
-void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
-               PHYSICS>::initFEarrays()
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES, physicType PHYSICS>
+void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::initFEarrays() {
   initSpongeValues();
 
-  if (attenuationEnabled_ && nSls_ > 0)
-  {
-    for (int n = 0; n < m_mesh.getNumberOfNodes(); ++n)
-    {
-      for (int f = 0; f < kNumFields; ++f)
-      {
+  if (attenuationEnabled_ && nSls_ > 0) {
+    for (int n = 0; n < m_mesh.getNumberOfNodes(); ++n) {
+      for (int f = 0; f < kNumFields; ++f) {
         attenuationWorkVectorsGlobal_[f](n) = 0.0f;
-        for (int l = 0; l < nSls_; ++l)
-        {
+        for (int l = 0; l < nSls_; ++l) {
           attenuationMemoryVariables_[f](n, l) = 0.0f;
         }
       }
@@ -1553,54 +1173,41 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
 // initSpongeValues - Initialize absorbing boundary coefficients
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES, physicType PHYSICS>
-void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
-               PHYSICS>::initSpongeValues()
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES, physicType PHYSICS>
+void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::initSpongeValues() {
   const double sigma_max = 0.15;
 
-  for (int n = 0; n < m_mesh.getNumberOfNodes(); n++)
-  {
+  for (int n = 0; n < m_mesh.getNumberOfNodes(); n++) {
     const double x = m_mesh.nodeCoord(n, 0);
     const double y = m_mesh.nodeCoord(n, 1);
     const double z = m_mesh.nodeCoord(n, 2);
 
-    const double distToFrontierX = (surface_sponge_)
-                                       ? m_mesh.domainSize(0) - x
-                                       : min(m_mesh.domainSize(0) - x, x);
+    const double distToFrontierX = (surface_sponge_) ? m_mesh.domainSize(0) - x : min(m_mesh.domainSize(0) - x, x);
     const double distToFrontierY = min(m_mesh.domainSize(1) - y, y);
     const double distToFrontierZ = min(m_mesh.domainSize(2) - z, z);
 
-    double minDistToFrontier = max(
-        m_mesh.domainSize(0), max(m_mesh.domainSize(1), m_mesh.domainSize(2)));
+    double minDistToFrontier = max(m_mesh.domainSize(0), max(m_mesh.domainSize(1), m_mesh.domainSize(2)));
 
     bool is_sponge = false;
-    if (distToFrontierX < sponge_size_[0])
-    {
+    if (distToFrontierX < sponge_size_[0]) {
       is_sponge = true;
       minDistToFrontier = min(minDistToFrontier, distToFrontierX);
     }
-    if (distToFrontierY < sponge_size_[1])
-    {
+    if (distToFrontierY < sponge_size_[1]) {
       is_sponge = true;
       minDistToFrontier = min(minDistToFrontier, distToFrontierY);
     }
-    if (distToFrontierZ < sponge_size_[2])
-    {
+    if (distToFrontierZ < sponge_size_[2]) {
       is_sponge = true;
       minDistToFrontier = min(minDistToFrontier, distToFrontierZ);
     }
 
-    if (is_sponge)
-    {
+    if (is_sponge) {
       double d = minDistToFrontier;
       double delta = taper_delta_;
       double sigma = sigma_max * std::exp(-((d / delta) * (d / delta)));
       spongeTaperCoeff_(n) = 1.0 / (1.0 + sigma);
-    }
-    else
-    {
+    } else {
       spongeTaperCoeff_(n) = 1.0;
     }
   }
@@ -1612,34 +1219,22 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
 // outputSolutionValues - Output field values for diagnostics
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES, physicType PHYSICS>
-void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
-               PHYSICS>::outputSolutionValues(const int& t, int& e,
-                                              const VECTOR_REAL_VIEW&
-                                                  fieldGlobal,
-                                              const char* fieldName)
-{
-  cout << "TimeStep=" << t << ";  " << fieldName << " @ elementSource location "
-       << e << " after computeOneStep = "
-       << fieldGlobal(m_mesh.globalNodeIndex(e, 0, 0, 0)) << endl;
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES, physicType PHYSICS>
+void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::outputSolutionValues(
+    const int& t, int& e, const VECTOR_REAL_VIEW& fieldGlobal, const char* fieldName) {
+  cout << "TimeStep=" << t << ";  " << fieldName << " @ elementSource location " << e
+       << " after computeOneStep = " << fieldGlobal(m_mesh.globalNodeIndex(e, 0, 0, 0)) << endl;
 }
 
 //============================================================================
 // computeCMatrix - Compute TTI elasticity tensor (for nodes only)
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES, physicType PHYSICS>
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES, physicType PHYSICS>
 template <physicType P, typename>
-PROXY_HOST_DEVICE void
-SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
-          PHYSICS>::computeCMatrix(float const vp, float const vs,
-                                   float const rho, float const delta,
-                                   float const epsilon, float const gamma,
-                                   float const phi, float const theta,
-                                   float (&CTTI)[6][6])
-{
+PROXY_HOST_DEVICE void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::computeCMatrix(
+    float const vp, float const vs, float const rho, float const delta, float const epsilon, float const gamma,
+    float const phi, float const theta, float (&CTTI)[6][6]) {
   const float rho_vp2 = rho * vp * vp;
   const float rho_vs2 = rho * vs * vs;
   const float two_eps = 2.0f * epsilon;
@@ -1738,13 +1333,10 @@ SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
   float temp[6][6];
 
   // M * CVTI
-  for (int i = 0; i < 6; i++)
-  {
-    for (int j = 0; j < 6; j++)
-    {
+  for (int i = 0; i < 6; i++) {
+    for (int j = 0; j < 6; j++) {
       float sum = 0.0f;
-      for (int k = 0; k < 6; k++)
-      {
+      for (int k = 0; k < 6; k++) {
         sum += M[i][k] * CVTI[k][j];
       }
       temp[i][j] = sum;
@@ -1752,13 +1344,10 @@ SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
   }
 
   // temp * M^T
-  for (int i = 0; i < 6; i++)
-  {
-    for (int j = i; j < 6; j++)
-    {
+  for (int i = 0; i < 6; i++) {
+    for (int j = i; j < 6; j++) {
       float sum = 0.0f;
-      for (int k = 0; k < 6; k++)
-      {
+      for (int k = 0; k < 6; k++) {
         sum += temp[i][k] * M[j][k];
       }
       CTTI[i][j] = sum;
@@ -1771,13 +1360,9 @@ SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
 // computeGlobalMassMatrixMasked - domain-masked mass matrix assembly
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES, physicType PHYSICS>
-void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
-               PHYSICS>::computeGlobalMassMatrixMasked(const VECTOR_INT_VIEW&
-                                                           elem_mask,
-                                                       int active_value)
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES, physicType PHYSICS>
+void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::computeGlobalMassMatrixMasked(
+    const VECTOR_INT_VIEW& elem_mask, int active_value) {
   m_element_mask_ = elem_mask;
   m_mask_active_value_ = active_value;
   m_mask_enabled_ = true;
@@ -1789,13 +1374,9 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
 // computeDampingMatrixMasked - domain-masked damping matrix assembly
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES, physicType PHYSICS>
-void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
-               PHYSICS>::computeDampingMatrixMasked(const VECTOR_INT_VIEW&
-                                                        elem_mask,
-                                                    int active_value)
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES, physicType PHYSICS>
+void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::computeDampingMatrixMasked(
+    const VECTOR_INT_VIEW& elem_mask, int active_value) {
   m_element_mask_ = elem_mask;
   m_mask_active_value_ = active_value;
   m_mask_enabled_ = true;
@@ -1807,13 +1388,9 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
 // computeElementContributionsMasked - domain-masked stiffness assembly
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES, physicType PHYSICS>
-void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::
-    computeElementContributionsMasked(const DataType& data,
-                                      const VECTOR_INT_VIEW& elem_mask,
-                                      int active_value)
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES, physicType PHYSICS>
+void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::computeElementContributionsMasked(
+    const DataType& data, const VECTOR_INT_VIEW& elem_mask, int active_value) {
   m_element_mask_ = elem_mask;
   m_mask_active_value_ = active_value;
   m_mask_enabled_ = true;
@@ -1825,13 +1402,9 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::
 // computeElementContributionsFromList - stiffness assembly from compact list
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES, physicType PHYSICS>
-void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::
-    computeElementContributionsFromList(const DataType& data,
-                                        const VECTOR_INT_VIEW& elem_list,
-                                        int n_elems)
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES, physicType PHYSICS>
+void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::computeElementContributionsFromList(
+    const DataType& data, const VECTOR_INT_VIEW& elem_list, int n_elems) {
   m_elem_list_ = elem_list;
   m_n_elem_list_ = n_elems;
   m_list_mode_ = true;
@@ -1843,13 +1416,9 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::
 // updateFieldsFromList - Verlet update restricted to a compact node list
 //============================================================================
 
-template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE,
-          bool IS_MODEL_ON_NODES, physicType PHYSICS>
-void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES,
-               PHYSICS>::updateFieldsFromList(float dt, const DataType& data,
-                                              const VECTOR_INT_VIEW& node_list,
-                                              int n_nodes)
-{
+template <int ORDER, typename INTEGRAL_TYPE, typename MESH_TYPE, bool IS_MODEL_ON_NODES, physicType PHYSICS>
+void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::updateFieldsFromList(
+    float dt, const DataType& data, const VECTOR_INT_VIEW& node_list, int n_nodes) {
   m_node_list_ = node_list;
   m_n_node_list_ = n_nodes;
   m_node_list_mode_ = true;

--- a/src/solver/fe/impl/common/include/solver_factory.h
+++ b/src/solver/fe/impl/common/include/solver_factory.h
@@ -7,12 +7,9 @@
 #include "sem_enums.h"
 #include "solver.h"
 
-namespace solver
-{
-namespace fe
-{
-namespace solver_factory
-{
+namespace solver {
+namespace fe {
+namespace solver_factory {
 
 /**
  * @brief Creates a SEM solver instance based on the specified configuration.
@@ -31,11 +28,9 @@ namespace solver_factory
  * @return A unique pointer to the created solver
  * @throws std::runtime_error if the configuration is unsupported
  */
-std::unique_ptr<Solver> createSolver(
-    utils::enums::methodType methodType, utils::enums::implemType implemType,
-    utils::enums::meshType meshType,
-    utils::enums::modelLocationType modelLocation,
-    utils::enums::physicType physicType, int order);
+std::unique_ptr<Solver> createSolver(utils::enums::methodType methodType, utils::enums::implemType implemType,
+                                     utils::enums::meshType meshType, utils::enums::modelLocationType modelLocation,
+                                     utils::enums::physicType physicType, int order);
 }  // namespace solver_factory
 }  // namespace fe
 }  // namespace solver

--- a/src/solver/fe/impl/common/src/solver_factory.cc
+++ b/src/solver/fe/impl/common/src/solver_factory.cc
@@ -6,31 +6,22 @@
 #include "sem_solver.h"
 #include "sem_solver_acoustoelastic.h"
 
-namespace solver
-{
-namespace fe
-{
-namespace solver_factory
-{
+namespace solver {
+namespace fe {
+namespace solver_factory {
 
 namespace feenum = utils::enums;
 
 template <int CurrentOrder, typename FUNC>
-std::unique_ptr<Solver> orderDispatch(int const order, FUNC&& func)
-{
-  if (order == CurrentOrder)
-  {
+std::unique_ptr<Solver> orderDispatch(int const order, FUNC&& func) {
+  if (order == CurrentOrder) {
     return func(std::integral_constant<int, CurrentOrder>{});
   }
 
-  if constexpr (CurrentOrder > 1)
-  {
+  if constexpr (CurrentOrder > 1) {
     return orderDispatch<CurrentOrder - 1>(order, std::forward<FUNC>(func));
-  }
-  else
-  {
-    throw std::runtime_error("Unsupported polynomial order: " +
-                             std::to_string(order));
+  } else {
+    throw std::runtime_error("Unsupported polynomial order: " + std::to_string(order));
   }
 }
 
@@ -38,42 +29,30 @@ std::unique_ptr<Solver> orderDispatch(int const order, FUNC&& func)
  * @brief Creates solver for structured mesh.
  */
 template <auto ImplTag, int ORDER>
-std::unique_ptr<Solver> makeSolverStruct(bool isModelOnNodes,
-                                         feenum::physicType physic)
-{
+std::unique_ptr<Solver> makeSolverStruct(bool isModelOnNodes, feenum::physicType physic) {
   using MeshT = model::ModelStruct<float, int, ORDER>;
   using SelectedIntegral = typename IntegralTypeSelector<ORDER, ImplTag>::type;
 
-  if (physic == feenum::physicType::kAcoustic)
+  if (physic == feenum::physicType::kAcoustic) {
+    if (isModelOnNodes)
+      return std::make_unique<
+          solver::fe::SEMsolver<ORDER, SelectedIntegral, MeshT, true, feenum::physicType::kAcoustic>>();
+    else
+      return std::make_unique<
+          solver::fe::SEMsolver<ORDER, SelectedIntegral, MeshT, false, feenum::physicType::kAcoustic>>();
+  } else if (physic == feenum::physicType::kAcoustoElastic) {
+    if (isModelOnNodes)
+      return std::make_unique<solver::fe::SEMsolverAcoustoElastic<ORDER, SelectedIntegral, MeshT, true>>();
+    else
+      return std::make_unique<solver::fe::SEMsolverAcoustoElastic<ORDER, SelectedIntegral, MeshT, false>>();
+  } else  // kElastic
   {
     if (isModelOnNodes)
       return std::make_unique<
-          solver::fe::SEMsolver<ORDER, SelectedIntegral, MeshT, true,
-                                feenum::physicType::kAcoustic>>();
+          solver::fe::SEMsolver<ORDER, SelectedIntegral, MeshT, true, feenum::physicType::kElastic>>();
     else
       return std::make_unique<
-          solver::fe::SEMsolver<ORDER, SelectedIntegral, MeshT, false,
-                                feenum::physicType::kAcoustic>>();
-  }
-  else if (physic == feenum::physicType::kAcoustoElastic)
-  {
-    if (isModelOnNodes)
-      return std::make_unique<solver::fe::SEMsolverAcoustoElastic<
-          ORDER, SelectedIntegral, MeshT, true>>();
-    else
-      return std::make_unique<solver::fe::SEMsolverAcoustoElastic<
-          ORDER, SelectedIntegral, MeshT, false>>();
-  }
-  else  // kElastic
-  {
-    if (isModelOnNodes)
-      return std::make_unique<
-          solver::fe::SEMsolver<ORDER, SelectedIntegral, MeshT, true,
-                                feenum::physicType::kElastic>>();
-    else
-      return std::make_unique<
-          solver::fe::SEMsolver<ORDER, SelectedIntegral, MeshT, false,
-                                feenum::physicType::kElastic>>();
+          solver::fe::SEMsolver<ORDER, SelectedIntegral, MeshT, false, feenum::physicType::kElastic>>();
   }
 }
 
@@ -81,42 +60,30 @@ std::unique_ptr<Solver> makeSolverStruct(bool isModelOnNodes,
  * @brief Creates solver for unstructured mesh.
  */
 template <auto ImplTag, int ORDER>
-std::unique_ptr<Solver> makeSolverUnstruct(bool isModelOnNodes,
-                                           feenum::physicType physic)
-{
+std::unique_ptr<Solver> makeSolverUnstruct(bool isModelOnNodes, feenum::physicType physic) {
   using MeshT = model::ModelUnstruct<float, int>;
   using SelectedIntegral = typename IntegralTypeSelector<ORDER, ImplTag>::type;
 
-  if (physic == feenum::physicType::kAcoustic)
+  if (physic == feenum::physicType::kAcoustic) {
+    if (isModelOnNodes)
+      return std::make_unique<
+          solver::fe::SEMsolver<ORDER, SelectedIntegral, MeshT, true, feenum::physicType::kAcoustic>>();
+    else
+      return std::make_unique<
+          solver::fe::SEMsolver<ORDER, SelectedIntegral, MeshT, false, feenum::physicType::kAcoustic>>();
+  } else if (physic == feenum::physicType::kAcoustoElastic) {
+    if (isModelOnNodes)
+      return std::make_unique<solver::fe::SEMsolverAcoustoElastic<ORDER, SelectedIntegral, MeshT, true>>();
+    else
+      return std::make_unique<solver::fe::SEMsolverAcoustoElastic<ORDER, SelectedIntegral, MeshT, false>>();
+  } else  // kElastic
   {
     if (isModelOnNodes)
       return std::make_unique<
-          solver::fe::SEMsolver<ORDER, SelectedIntegral, MeshT, true,
-                                feenum::physicType::kAcoustic>>();
+          solver::fe::SEMsolver<ORDER, SelectedIntegral, MeshT, true, feenum::physicType::kElastic>>();
     else
       return std::make_unique<
-          solver::fe::SEMsolver<ORDER, SelectedIntegral, MeshT, false,
-                                feenum::physicType::kAcoustic>>();
-  }
-  else if (physic == feenum::physicType::kAcoustoElastic)
-  {
-    if (isModelOnNodes)
-      return std::make_unique<solver::fe::SEMsolverAcoustoElastic<
-          ORDER, SelectedIntegral, MeshT, true>>();
-    else
-      return std::make_unique<solver::fe::SEMsolverAcoustoElastic<
-          ORDER, SelectedIntegral, MeshT, false>>();
-  }
-  else  // kElastic
-  {
-    if (isModelOnNodes)
-      return std::make_unique<
-          solver::fe::SEMsolver<ORDER, SelectedIntegral, MeshT, true,
-                                feenum::physicType::kElastic>>();
-    else
-      return std::make_unique<
-          solver::fe::SEMsolver<ORDER, SelectedIntegral, MeshT, false,
-                                feenum::physicType::kElastic>>();
+          solver::fe::SEMsolver<ORDER, SelectedIntegral, MeshT, false, feenum::physicType::kElastic>>();
   }
 }
 
@@ -124,12 +91,9 @@ std::unique_ptr<Solver> makeSolverUnstruct(bool isModelOnNodes,
  * @brief Creates a SEM solver with the specified integral implementation.
  */
 template <auto ImplTag>
-std::unique_ptr<Solver> makeSemSolver(int order, feenum::meshType mesh,
-                                      feenum::modelLocationType modelLocation,
-                                      feenum::physicType physic)
-{
-  bool const isModelOnNodes =
-      (modelLocation == feenum::modelLocationType::kOnNodes);
+std::unique_ptr<Solver> makeSemSolver(int order, feenum::meshType mesh, feenum::modelLocationType modelLocation,
+                                      feenum::physicType physic) {
+  bool const isModelOnNodes = (modelLocation == feenum::modelLocationType::kOnNodes);
 
   // // fallback macro
   // // Used for IDE static analysis
@@ -143,63 +107,45 @@ std::unique_ptr<Solver> makeSemSolver(int order, feenum::meshType mesh,
   // #define MAX_SOLVER_ELASTOACOUSTIC_ORDER 9
   // #endif
 
-  if (physic == feenum::physicType::kAcoustic)
-  {
+  if (physic == feenum::physicType::kAcoustic) {
     return orderDispatch<MAX_SOLVER_ACOUSTIC_ORDER>(order, [&](auto orderIC) {
       constexpr int ORDER = decltype(orderIC)::value;
-      return (mesh == feenum::meshType::kStruct)
-                 ? makeSolverStruct<ImplTag, ORDER>(isModelOnNodes, physic)
-                 : makeSolverUnstruct<ImplTag, ORDER>(isModelOnNodes, physic);
+      return (mesh == feenum::meshType::kStruct) ? makeSolverStruct<ImplTag, ORDER>(isModelOnNodes, physic)
+                                                 : makeSolverUnstruct<ImplTag, ORDER>(isModelOnNodes, physic);
     });
-  }
-  else if (physic == feenum::physicType::kElastic)
-  {
+  } else if (physic == feenum::physicType::kElastic) {
     return orderDispatch<MAX_SOLVER_ELASTIC_ORDER>(order, [&](auto orderIC) {
       constexpr int ORDER = decltype(orderIC)::value;
-      return (mesh == feenum::meshType::kStruct)
-                 ? makeSolverStruct<ImplTag, ORDER>(isModelOnNodes, physic)
-                 : makeSolverUnstruct<ImplTag, ORDER>(isModelOnNodes, physic);
+      return (mesh == feenum::meshType::kStruct) ? makeSolverStruct<ImplTag, ORDER>(isModelOnNodes, physic)
+                                                 : makeSolverUnstruct<ImplTag, ORDER>(isModelOnNodes, physic);
     });
-  }
-  else if (physic == feenum::physicType::kAcoustoElastic)
-  {
-    return orderDispatch<MAX_SOLVER_ELASTOACOUSTIC_ORDER>(
-        order, [&](auto orderIC) {
-          constexpr int ORDER = decltype(orderIC)::value;
-          return (mesh == feenum::meshType::kStruct)
-                     ? makeSolverStruct<ImplTag, ORDER>(isModelOnNodes, physic)
-                     : makeSolverUnstruct<ImplTag, ORDER>(isModelOnNodes,
-                                                          physic);
-        });
+  } else if (physic == feenum::physicType::kAcoustoElastic) {
+    return orderDispatch<MAX_SOLVER_ELASTOACOUSTIC_ORDER>(order, [&](auto orderIC) {
+      constexpr int ORDER = decltype(orderIC)::value;
+      return (mesh == feenum::meshType::kStruct) ? makeSolverStruct<ImplTag, ORDER>(isModelOnNodes, physic)
+                                                 : makeSolverUnstruct<ImplTag, ORDER>(isModelOnNodes, physic);
+    });
   }
 
   throw std::runtime_error("Unknown physics type");
 }
 
-std::unique_ptr<Solver> createSolver(
-    feenum::methodType const methodType, feenum::implemType const implemType,
-    feenum::meshType const mesh, feenum::modelLocationType const modelLocation,
-    feenum::physicType const physicType, int const order)
-{
-  if (methodType == feenum::methodType::kSem)
-  {
-    switch (implemType)
-    {
+std::unique_ptr<Solver> createSolver(feenum::methodType const methodType, feenum::implemType const implemType,
+                                     feenum::meshType const mesh, feenum::modelLocationType const modelLocation,
+                                     feenum::physicType const physicType, int const order) {
+  if (methodType == feenum::methodType::kSem) {
+    switch (implemType) {
       case feenum::implemType::kMakutu:
-        return makeSemSolver<IntegralType::MAKUTU>(order, mesh, modelLocation,
-                                                   physicType);
+        return makeSemSolver<IntegralType::MAKUTU>(order, mesh, modelLocation, physicType);
       default:
-        throw std::runtime_error("Unknown implementation type: " +
-                                 std::to_string(static_cast<int>(implemType)));
+        throw std::runtime_error("Unknown implementation type: " + std::to_string(static_cast<int>(implemType)));
     }
   }
 
   // Add DG or other methods as needed
   throw std::runtime_error(
-      "Unsupported solver configuration: methodType=" +
-      std::to_string(static_cast<int>(methodType)) +
-      ", implemType=" + std::to_string(static_cast<int>(implemType)) +
-      ", physicType=" + std::to_string(static_cast<int>(physicType)));
+      "Unsupported solver configuration: methodType=" + std::to_string(static_cast<int>(methodType)) + ", implemType=" +
+      std::to_string(static_cast<int>(implemType)) + ", physicType=" + std::to_string(static_cast<int>(physicType)));
 }
 
 }  // namespace solver_factory

--- a/src/solver/fe/impl/elastic/include/physics_traits_elastic.h
+++ b/src/solver/fe/impl/elastic/include/physics_traits_elastic.h
@@ -4,10 +4,8 @@
 #include "rhs_elastic.h"
 #include "wavefield_elastic.h"
 
-namespace solver
-{
-namespace fe
-{
+namespace solver {
+namespace fe {
 
 /**
  * @brief Specialization for elastic physics.
@@ -15,8 +13,7 @@ namespace fe
  * Elastic wave propagation uses three displacement components (ux, uy, uz).
  */
 template <>
-struct PhysicsTraits<utils::enums::physicType::kElastic>
-{
+struct PhysicsTraits<utils::enums::physicType::kElastic> {
   /// Human-readable name for logging
   static constexpr const char* kName = "Elastic";
 

--- a/src/solver/fe/impl/elastic/include/rhs_elastic.h
+++ b/src/solver/fe/impl/elastic/include/rhs_elastic.h
@@ -4,15 +4,12 @@
 
 #include "rhs.h"
 
-namespace solver
-{
-namespace fe
-{
+namespace solver {
+namespace fe {
 /**
  * @brief Elastic RHS data structure.
  */
-struct RhsElastic : public Rhs
-{
+struct RhsElastic : public Rhs {
   /// Number of RHS (source) components
   static constexpr int kNumRhsComponents = 3;
 
@@ -20,25 +17,16 @@ struct RhsElastic : public Rhs
   /// All views are null/zero-extent; safe as long as RHS is not accessed.
   RhsElastic() = default;
 
-  RhsElastic(ARRAY_REAL_VIEW termx, ARRAY_REAL_VIEW termy,
-             ARRAY_REAL_VIEW termz, VECTOR_INT_VIEW element,
+  RhsElastic(ARRAY_REAL_VIEW termx, ARRAY_REAL_VIEW termy, ARRAY_REAL_VIEW termz, VECTOR_INT_VIEW element,
              ARRAY_REAL_VIEW weights)
-      : m_termx(termx),
-        m_termy(termy),
-        m_termz(termz),
-        m_element(element),
-        m_weights(weights)
-  {
-  }
+      : m_termx(termx), m_termy(termy), m_termz(termz), m_element(element), m_weights(weights) {}
 
   int getNumRhsComponents() const override final { return kNumRhsComponents; }
 
   // TODO use template + constexpr if when C++20 is available
   PROXY_HOST_DEVICE
-  ARRAY_REAL_VIEW getTerm(int i) const override
-  {
-    switch (i)
-    {
+  ARRAY_REAL_VIEW getTerm(int i) const override {
+    switch (i) {
       case 0:
         return m_termx;
       case 1:
@@ -56,8 +44,7 @@ struct RhsElastic : public Rhs
   PROXY_HOST_DEVICE
   ARRAY_REAL_VIEW getWeights() const { return m_weights; }
 
-  void print() const override
-  {
+  void print() const override {
     std::cout << "RHSx Term size:   " << m_termx.extent(0) << std::endl;
     std::cout << "RHSy Term size:   " << m_termy.extent(0) << std::endl;
     std::cout << "RHSz Term size:   " << m_termz.extent(0) << std::endl;

--- a/src/solver/fe/impl/elastic/include/wavefield_elastic.h
+++ b/src/solver/fe/impl/elastic/include/wavefield_elastic.h
@@ -4,16 +4,13 @@
 
 #include "wavefield.h"
 
-namespace solver
-{
-namespace fe
-{
+namespace solver {
+namespace fe {
 /**
  * @brief Elastic wavefield data structure.
  * Arrays are kept flat for easy cpp-python-fortran interop.
  */
-struct WavefieldElastic : public Wavefield
-{
+struct WavefieldElastic : public Wavefield {
   /// Field names for each component
   static constexpr const char* kFieldNames[3] = {"ux", "uy", "uz"};
   /// Number of solution fields (3 for displacement vector)
@@ -23,38 +20,26 @@ struct WavefieldElastic : public Wavefield
   PROXY_HOST_DEVICE WavefieldElastic() = default;
   PROXY_HOST_DEVICE ~WavefieldElastic() = default;
   PROXY_HOST_DEVICE WavefieldElastic(const WavefieldElastic&) = default;
-  PROXY_HOST_DEVICE WavefieldElastic& operator=(const WavefieldElastic&) =
-      default;
+  PROXY_HOST_DEVICE WavefieldElastic& operator=(const WavefieldElastic&) = default;
 
   PROXY_HOST_DEVICE
-  WavefieldElastic(VECTOR_REAL_VIEW uxnGlobalPrev,
-                   VECTOR_REAL_VIEW uxnGlobalCurr,
-                   VECTOR_REAL_VIEW uynGlobalPrev,
-                   VECTOR_REAL_VIEW uynGlobalCurr,
-                   VECTOR_REAL_VIEW uznGlobalPrev,
-                   VECTOR_REAL_VIEW uznGlobalCurr)
+  WavefieldElastic(VECTOR_REAL_VIEW uxnGlobalPrev, VECTOR_REAL_VIEW uxnGlobalCurr, VECTOR_REAL_VIEW uynGlobalPrev,
+                   VECTOR_REAL_VIEW uynGlobalCurr, VECTOR_REAL_VIEW uznGlobalPrev, VECTOR_REAL_VIEW uznGlobalCurr)
       : m_uxnGlobalPrev(uxnGlobalPrev),
         m_uxnGlobalCurr(uxnGlobalCurr),
         m_uynGlobalPrev(uynGlobalPrev),
         m_uynGlobalCurr(uynGlobalCurr),
         m_uznGlobalPrev(uznGlobalPrev),
-        m_uznGlobalCurr(uznGlobalCurr)
-  {
-  }
+        m_uznGlobalCurr(uznGlobalCurr) {}
 
   int getNumFields() const override final { return kNumFields; }
 
-  const char* const* getFieldNames() const override final
-  {
-    return kFieldNames;
-  }
+  const char* const* getFieldNames() const override final { return kFieldNames; }
 
   // TODO use template + constexpr if when C++20 is available
   PROXY_HOST_DEVICE
-  VECTOR_REAL_VIEW getCurrentField(int i) const override
-  {
-    switch (i)
-    {
+  VECTOR_REAL_VIEW getCurrentField(int i) const override {
+    switch (i) {
       case 0:
         return m_uxnGlobalCurr;
       case 1:
@@ -68,10 +53,8 @@ struct WavefieldElastic : public Wavefield
 
   // TODO use template + constexpr if when C++20 is available
   PROXY_HOST_DEVICE
-  VECTOR_REAL_VIEW getPreviousField(int i) const override
-  {
-    switch (i)
-    {
+  VECTOR_REAL_VIEW getPreviousField(int i) const override {
+    switch (i) {
       case 0:
         return m_uxnGlobalPrev;
       case 1:
@@ -83,8 +66,7 @@ struct WavefieldElastic : public Wavefield
     }
   }
 
-  void swap() override
-  {
+  void swap() override {
     std::swap(m_uxnGlobalPrev, m_uxnGlobalCurr);
     std::swap(m_uynGlobalPrev, m_uynGlobalCurr);
     std::swap(m_uznGlobalPrev, m_uznGlobalCurr);
@@ -93,11 +75,9 @@ struct WavefieldElastic : public Wavefield
   // NOTE: elastic has 3 components — the caller must manage one extra buffer
   // per component and call swapWithRotation once per component with the
   // appropriate field index (0=ux, 1=uy, 2=uz).
-  void swapWithRotation(VECTOR_REAL_VIEW& prevPrevBuffer, int i) override
-  {
+  void swapWithRotation(VECTOR_REAL_VIEW& prevPrevBuffer, int i) override {
     VECTOR_REAL_VIEW tmp = prevPrevBuffer;
-    switch (i)
-    {
+    switch (i) {
       case 0:  // ux component
         prevPrevBuffer = m_uxnGlobalPrev;
         m_uxnGlobalPrev = m_uxnGlobalCurr;
@@ -119,20 +99,13 @@ struct WavefieldElastic : public Wavefield
     }
   }
 
-  void print() const override
-  {
-    std::cout << "Ux Global Prev size: " << m_uxnGlobalPrev.extent(0)
-              << std::endl;
-    std::cout << "Ux Global Curr size: " << m_uxnGlobalCurr.extent(0)
-              << std::endl;
-    std::cout << "Uy Global Prev size: " << m_uynGlobalPrev.extent(0)
-              << std::endl;
-    std::cout << "Uy Global Curr size: " << m_uynGlobalCurr.extent(0)
-              << std::endl;
-    std::cout << "Uz Global Prev size: " << m_uznGlobalPrev.extent(0)
-              << std::endl;
-    std::cout << "Uz Global Curr size: " << m_uznGlobalCurr.extent(0)
-              << std::endl;
+  void print() const override {
+    std::cout << "Ux Global Prev size: " << m_uxnGlobalPrev.extent(0) << std::endl;
+    std::cout << "Ux Global Curr size: " << m_uxnGlobalCurr.extent(0) << std::endl;
+    std::cout << "Uy Global Prev size: " << m_uynGlobalPrev.extent(0) << std::endl;
+    std::cout << "Uy Global Curr size: " << m_uynGlobalCurr.extent(0) << std::endl;
+    std::cout << "Uz Global Prev size: " << m_uznGlobalPrev.extent(0) << std::endl;
+    std::cout << "Uz Global Curr size: " << m_uznGlobalCurr.extent(0) << std::endl;
   }
 
   VECTOR_REAL_VIEW

--- a/src/solver/fe/pywrap/include/bindings_rhs.h
+++ b/src/solver/fe/pywrap/include/bindings_rhs.h
@@ -15,64 +15,47 @@
 
 namespace py = pybind11;
 
-namespace solver
-{
-namespace fe
-{
+namespace solver {
+namespace fe {
 
-void bind_rhs_base(py::module_& m)
-{
+void bind_rhs_base(py::module_& m) {
   // Bind Rhs (base class)
   py::class_<Rhs, std::shared_ptr<Rhs>>(m, "Rhs").def("print", &Rhs::print);
 }
 
-void bind_rhs_acoustic(py::module_& m)
-{
+void bind_rhs_acoustic(py::module_& m) {
   // Bind RhsAcoustic (inherits from Rhs)
   py::class_<RhsAcoustic, Rhs, std::shared_ptr<RhsAcoustic>>(m, "RhsAcoustic")
-      .def(
-          py::init<Kokkos::Experimental::python_view_type_t<ARRAY_REAL_VIEW>,
-                   Kokkos::Experimental::python_view_type_t<VECTOR_INT_VIEW>,
-                   Kokkos::Experimental::python_view_type_t<ARRAY_REAL_VIEW>>(),
-          py::arg("term"), py::arg("element"), py::arg("weights"))
+      .def(py::init<Kokkos::Experimental::python_view_type_t<ARRAY_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_INT_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<ARRAY_REAL_VIEW>>(),
+           py::arg("term"), py::arg("element"), py::arg("weights"))
       .def("print", &RhsAcoustic::print);
 }
 
-void bind_rhs_elastic(py::module_& m)
-{
+void bind_rhs_elastic(py::module_& m) {
   // Bind RhsElastic (inherits from Rhs)
   py::class_<RhsElastic, Rhs, std::shared_ptr<RhsElastic>>(m, "RhsElastic")
-      .def(
-          py::init<Kokkos::Experimental::python_view_type_t<ARRAY_REAL_VIEW>,
-                   Kokkos::Experimental::python_view_type_t<ARRAY_REAL_VIEW>,
-                   Kokkos::Experimental::python_view_type_t<ARRAY_REAL_VIEW>,
-                   Kokkos::Experimental::python_view_type_t<VECTOR_INT_VIEW>,
-                   Kokkos::Experimental::python_view_type_t<ARRAY_REAL_VIEW>>(),
-          py::arg("termx"), py::arg("termy"), py::arg("termz"),
-          py::arg("element"), py::arg("weights"))
+      .def(py::init<Kokkos::Experimental::python_view_type_t<ARRAY_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<ARRAY_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<ARRAY_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_INT_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<ARRAY_REAL_VIEW>>(),
+           py::arg("termx"), py::arg("termy"), py::arg("termz"), py::arg("element"), py::arg("weights"))
       .def("print", &RhsElastic::print);
 }
 
-void bind_rhs_acoustoelastic(py::module_& m)
-{
-  py::class_<RhsAcoustoElastic, Rhs, std::shared_ptr<RhsAcoustoElastic>>(
-      m, "RhsAcoustoElastic")
-      .def(py::init<Kokkos::Experimental::python_view_type_t<
-                        ARRAY_REAL_VIEW>,  // acoustic_term
-                    Kokkos::Experimental::python_view_type_t<
-                        VECTOR_INT_VIEW>,  // element
-                    Kokkos::Experimental::python_view_type_t<
-                        ARRAY_REAL_VIEW>,  // weights
-                    Kokkos::Experimental::python_view_type_t<
-                        ARRAY_REAL_VIEW>,  // elastic_termx
-                    Kokkos::Experimental::python_view_type_t<
-                        ARRAY_REAL_VIEW>,  // elastic_termy
-                    Kokkos::Experimental::python_view_type_t<
-                        ARRAY_REAL_VIEW>  // elastic_termz
+void bind_rhs_acoustoelastic(py::module_& m) {
+  py::class_<RhsAcoustoElastic, Rhs, std::shared_ptr<RhsAcoustoElastic>>(m, "RhsAcoustoElastic")
+      .def(py::init<Kokkos::Experimental::python_view_type_t<ARRAY_REAL_VIEW>,  // acoustic_term
+                    Kokkos::Experimental::python_view_type_t<VECTOR_INT_VIEW>,  // element
+                    Kokkos::Experimental::python_view_type_t<ARRAY_REAL_VIEW>,  // weights
+                    Kokkos::Experimental::python_view_type_t<ARRAY_REAL_VIEW>,  // elastic_termx
+                    Kokkos::Experimental::python_view_type_t<ARRAY_REAL_VIEW>,  // elastic_termy
+                    Kokkos::Experimental::python_view_type_t<ARRAY_REAL_VIEW>   // elastic_termz
                     >(),
-           py::arg("acoustic_term"), py::arg("element"), py::arg("weights"),
-           py::arg("elastic_termx"), py::arg("elastic_termy"),
-           py::arg("elastic_termz"))
+           py::arg("acoustic_term"), py::arg("element"), py::arg("weights"), py::arg("elastic_termx"),
+           py::arg("elastic_termy"), py::arg("elastic_termz"))
       .def("print", &RhsAcoustoElastic::print);
 }
 }  // namespace fe

--- a/src/solver/fe/pywrap/include/bindings_sem_enums.h
+++ b/src/solver/fe/pywrap/include/bindings_sem_enums.h
@@ -7,41 +7,33 @@
 
 namespace py = pybind11;
 
-namespace solver
-{
-namespace fe
-{
+namespace solver {
+namespace fe {
 
-void bind_method_type(py::module_ &m)
-{
+void bind_method_type(py::module_ &m) {
   py::enum_<utils::enums::methodType>(m, "MethodType")
       .value("SEM", utils::enums::methodType::kSem)
       .value("DG", utils::enums::methodType::kDg);
 }
 
-void bind_implem_type(py::module_ &m)
-{
-  py::enum_<utils::enums::implemType>(m, "ImplemType")
-      .value("MAKUTU", utils::enums::implemType::kMakutu);
+void bind_implem_type(py::module_ &m) {
+  py::enum_<utils::enums::implemType>(m, "ImplemType").value("MAKUTU", utils::enums::implemType::kMakutu);
 }
 
-void bind_mesh_type(py::module_ &m)
-{
+void bind_mesh_type(py::module_ &m) {
   py::enum_<utils::enums::meshType>(m, "MeshType")
       .value("STRUCT", utils::enums::meshType::kStruct)
       .value("UNSTRUCT", utils::enums::meshType::kUnstruct);
 }
 
-void bind_model_location_type(py::module_ &m)
-{
+void bind_model_location_type(py::module_ &m) {
   py::enum_<utils::enums::modelLocationType>(m, "ModelLocationType")
       .value("ONNODES", utils::enums::modelLocationType::kOnNodes)
       .value("ONELEMENTS", utils::enums::modelLocationType::kOnElements)
       .export_values();
 }
 
-void bind_physic_type(py::module_ &m)
-{
+void bind_physic_type(py::module_ &m) {
   py::enum_<utils::enums::physicType>(m, "PhysicType")
       .value("ACOUSTIC", utils::enums::physicType::kAcoustic)
       .value("ELASTIC", utils::enums::physicType::kElastic)
@@ -49,8 +41,7 @@ void bind_physic_type(py::module_ &m)
       .export_values();
 }
 
-void bind_all_sem_enums(py::module_ &m)
-{
+void bind_all_sem_enums(py::module_ &m) {
   bind_method_type(m);
   bind_implem_type(m);
   bind_mesh_type(m);

--- a/src/solver/fe/pywrap/include/bindings_sem_solver.h
+++ b/src/solver/fe/pywrap/include/bindings_sem_solver.h
@@ -20,109 +20,81 @@
 
 namespace py = pybind11;
 
-namespace solver
-{
-namespace fe
-{
+namespace solver {
+namespace fe {
 
-void bind_data_struct(py::module_ &m)
-{
-  py::class_<Solver::DataStruct, std::shared_ptr<Solver::DataStruct>>(
-      m, "DataStruct")
+void bind_data_struct(py::module_ &m) {
+  py::class_<Solver::DataStruct, std::shared_ptr<Solver::DataStruct>>(m, "DataStruct")
       .def("print", &Solver::DataStruct::print);
 }
 
-void bind_acoustic_solver_data(py::module_ &m)
-{
-  py::class_<SEMsolverDataAcoustic, Solver::DataStruct,
-             std::shared_ptr<SEMsolverDataAcoustic>>(m, "SEMsolverDataAcoustic")
-      .def(py::init<const WavefieldAcoustic &, const RhsAcoustic &>(),
-           py::arg("wavefield"), py::arg("rhs"))
+void bind_acoustic_solver_data(py::module_ &m) {
+  py::class_<SEMsolverDataAcoustic, Solver::DataStruct, std::shared_ptr<SEMsolverDataAcoustic>>(m,
+                                                                                                "SEMsolverDataAcoustic")
+      .def(py::init<const WavefieldAcoustic &, const RhsAcoustic &>(), py::arg("wavefield"), py::arg("rhs"))
       .def("swap_wavefields", &SEMsolverDataAcoustic::swapWavefields)
       .def("print", &SEMsolverDataAcoustic::print);
 }
 
-void bind_elastic_solver_data(py::module_ &m)
-{
-  py::class_<SEMsolverDataElastic, Solver::DataStruct,
-             std::shared_ptr<SEMsolverDataElastic>>(m, "SEMsolverDataElastic")
-      .def(py::init<const WavefieldElastic &, const RhsElastic &>(),
-           py::arg("wavefield"), py::arg("rhs"))
+void bind_elastic_solver_data(py::module_ &m) {
+  py::class_<SEMsolverDataElastic, Solver::DataStruct, std::shared_ptr<SEMsolverDataElastic>>(m, "SEMsolverDataElastic")
+      .def(py::init<const WavefieldElastic &, const RhsElastic &>(), py::arg("wavefield"), py::arg("rhs"))
       .def("swap_wavefields", &SEMsolverDataElastic::swapWavefields)
       .def("print", &SEMsolverDataElastic::print);
 }
 
-void bind_acoustoelastic_solver_data(py::module_ &m)
-{
-  py::class_<SEMsolverDataAcoustoElastic, Solver::DataStruct,
-             std::shared_ptr<SEMsolverDataAcoustoElastic>>(
+void bind_acoustoelastic_solver_data(py::module_ &m) {
+  py::class_<SEMsolverDataAcoustoElastic, Solver::DataStruct, std::shared_ptr<SEMsolverDataAcoustoElastic>>(
       m, "SEMsolverDataAcoustoElastic")
-      .def(py::init<const WavefieldAcoustoElastic &,
-                    const RhsAcoustoElastic &>(),
-           py::arg("wavefield"), py::arg("rhs"))
+      .def(py::init<const WavefieldAcoustoElastic &, const RhsAcoustoElastic &>(), py::arg("wavefield"), py::arg("rhs"))
       .def("swap_wavefields", &SEMsolverDataAcoustoElastic::swapWavefields)
       .def("print", &SEMsolverDataAcoustoElastic::print);
 }
 
-void bind_sem_solver_base(py::module_ &m)
-{
+void bind_sem_solver_base(py::module_ &m) {
   py::class_<Solver, std::shared_ptr<Solver>>(m, "Solver")
       .def("compute_fe_init", &Solver::computeFEInit, py::arg("model"),
-           py::arg("sponge_size") = std::array<float, 3>{0.0f, 0.0f, 0.0f},
-           py::arg("sponge_surface") = true, py::arg("taper_delta") = 0)
-      .def("compute_one_step", &Solver::computeOneStep, py::arg("dt"),
-           py::arg("time_sample"), py::arg("data"))
-      .def("compute_forces", &Solver::computeForces, py::arg("dt"),
-           py::arg("time_sample"), py::arg("data"))
-      .def("update_solution", &Solver::updateSolution, py::arg("dt"),
-           py::arg("data"))
+           py::arg("sponge_size") = std::array<float, 3>{0.0f, 0.0f, 0.0f}, py::arg("sponge_surface") = true,
+           py::arg("taper_delta") = 0)
+      .def("compute_one_step", &Solver::computeOneStep, py::arg("dt"), py::arg("time_sample"), py::arg("data"))
+      .def("compute_forces", &Solver::computeForces, py::arg("dt"), py::arg("time_sample"), py::arg("data"))
+      .def("update_solution", &Solver::updateSolution, py::arg("dt"), py::arg("data"))
       .def(
           "get_mass_matrix",
-          [](Solver &self)
-              -> Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW> {
+          [](Solver &self) -> Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW> {
             return self.getMassMatrixAcoustic();
           },
           py::return_value_policy::reference_internal)
-      .def("output_solution_values", &Solver::outputSolutionValues,
-           py::arg("t"), py::arg("e"), py::arg("field_global"),
+      .def("output_solution_values", &Solver::outputSolutionValues, py::arg("t"), py::arg("e"), py::arg("field_global"),
            py::arg("field_name"))
       .def(
           "set_sls_attenuation",
-          [](Solver &self, const std::vector<float> &freqs,
-             const std::vector<float> &coeffs) {
+          [](Solver &self, const std::vector<float> &freqs, const std::vector<float> &coeffs) {
             VECTOR_REAL_VIEW vf;
-            if (!freqs.empty())
-            {
+            if (!freqs.empty()) {
               vf = allocateVector<VECTOR_REAL_VIEW>(freqs.size(), "sls_freqs");
               for (size_t i = 0; i < freqs.size(); ++i) vf[i] = freqs[i];
             }
             VECTOR_REAL_VIEW vc;
-            if (!coeffs.empty())
-            {
-              vc =
-                  allocateVector<VECTOR_REAL_VIEW>(coeffs.size(), "sls_coeffs");
+            if (!coeffs.empty()) {
+              vc = allocateVector<VECTOR_REAL_VIEW>(coeffs.size(), "sls_coeffs");
               for (size_t i = 0; i < coeffs.size(); ++i) vc[i] = coeffs[i];
             }
             self.setSLSAttenuation(vf, vc);
           },
-          py::arg("reference_frequencies"),
-          py::arg("anelasticity_coefficients") = std::vector<float>{});
+          py::arg("reference_frequencies"), py::arg("anelasticity_coefficients") = std::vector<float>{});
 }
 
-void bind_solver_factory(py::module_ &m)
-{
+void bind_solver_factory(py::module_ &m) {
   m.def(
       "create_solver",
-      [](utils::enums::methodType method, utils::enums::implemType implem,
-         utils::enums::meshType mesh,
-         utils::enums::modelLocationType modelLocation,
-         utils::enums::physicType physic, int order) {
-        auto solver = solver_factory::createSolver(
-            method, implem, mesh, modelLocation, physic, order);
+      [](utils::enums::methodType method, utils::enums::implemType implem, utils::enums::meshType mesh,
+         utils::enums::modelLocationType modelLocation, utils::enums::physicType physic, int order) {
+        auto solver = solver_factory::createSolver(method, implem, mesh, modelLocation, physic, order);
         return std::shared_ptr<Solver>(std::move(solver));
       },
-      py::arg("method_type"), py::arg("implem_type"), py::arg("mesh_type"),
-      py::arg("model_location"), py::arg("physic_type"), py::arg("order"));
+      py::arg("method_type"), py::arg("implem_type"), py::arg("mesh_type"), py::arg("model_location"),
+      py::arg("physic_type"), py::arg("order"));
 }
 
 }  // namespace fe

--- a/src/solver/fe/pywrap/include/bindings_wavefield.h
+++ b/src/solver/fe/pywrap/include/bindings_wavefield.h
@@ -14,21 +14,16 @@
 
 namespace py = pybind11;
 
-namespace solver
-{
-namespace fe
-{
+namespace solver {
+namespace fe {
 
-void bind_wavefield_base(py::module_& m)
-{
+void bind_wavefield_base(py::module_& m) {
   // Bind Wavefield (base class)
   py::class_<Wavefield, std::shared_ptr<Wavefield>>(m, "Wavefield")
       .def("swap", &Wavefield::swap)
       .def(
           "swap_with_rotation",
-          [](Wavefield& self,
-             Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>&
-                 prevPrevBuffer) {
+          [](Wavefield& self, Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>& prevPrevBuffer) {
             VECTOR_REAL_VIEW view = prevPrevBuffer;
             self.swapWithRotation(view, 0);  // field index 0 for pressure
             prevPrevBuffer = view;
@@ -37,35 +32,28 @@ void bind_wavefield_base(py::module_& m)
       .def(
           "get_current_field",
           [](const Wavefield& self, int i) {
-            return Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>(
-                self.getCurrentField(i));
+            return Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>(self.getCurrentField(i));
           },
           py::arg("i"))
       .def(
           "get_previous_field",
           [](const Wavefield& self, int i) {
-            return Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>(
-                self.getPreviousField(i));
+            return Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>(self.getPreviousField(i));
           },
           py::arg("i"))
       .def("print", &Wavefield::print);
 }
 
-void bind_wavefield_acoustic(py::module_& m)
-{
+void bind_wavefield_acoustic(py::module_& m) {
   // Bind WavefieldAcoustic (inherits from Wavefield)
-  py::class_<WavefieldAcoustic, Wavefield, std::shared_ptr<WavefieldAcoustic>>(
-      m, "WavefieldAcoustic")
-      .def(py::init<
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>>(),
+  py::class_<WavefieldAcoustic, Wavefield, std::shared_ptr<WavefieldAcoustic>>(m, "WavefieldAcoustic")
+      .def(py::init<Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>>(),
            py::arg("pn_global_prev"), py::arg("pn_global_curr"))
       .def("swap", &WavefieldAcoustic::swap)
       .def(
           "swap_with_rotation",
-          [](WavefieldAcoustic& self,
-             Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>&
-                 prevPrevBuffer) {
+          [](WavefieldAcoustic& self, Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>& prevPrevBuffer) {
             VECTOR_REAL_VIEW view = prevPrevBuffer;
             self.swapWithRotation(view, 0);  // field index 0 for pressure
             prevPrevBuffer = view;
@@ -74,40 +62,33 @@ void bind_wavefield_acoustic(py::module_& m)
       .def(
           "get_current_field",
           [](const WavefieldAcoustic& self, int i) {
-            return Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>(
-                self.getCurrentField(i));
+            return Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>(self.getCurrentField(i));
           },
           py::arg("i"))
       .def(
           "get_previous_field",
           [](const WavefieldAcoustic& self, int i) {
-            return Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>(
-                self.getPreviousField(i));
+            return Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>(self.getPreviousField(i));
           },
           py::arg("i"))
       .def("print", &WavefieldAcoustic::print);
 }
 
-void bind_wavefield_elastic(py::module_& m)
-{
+void bind_wavefield_elastic(py::module_& m) {
   // Bind WavefieldElastic (inherits from Wavefield)
-  py::class_<WavefieldElastic, Wavefield, std::shared_ptr<WavefieldElastic>>(
-      m, "WavefieldElastic")
-      .def(py::init<
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>>(),
-           py::arg("uxn_global_prev"), py::arg("uxn_global_curr"),
-           py::arg("uyn_global_prev"), py::arg("uyn_global_curr"),
-           py::arg("uzn_global_prev"), py::arg("uzn_global_curr"))
+  py::class_<WavefieldElastic, Wavefield, std::shared_ptr<WavefieldElastic>>(m, "WavefieldElastic")
+      .def(py::init<Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>>(),
+           py::arg("uxn_global_prev"), py::arg("uxn_global_curr"), py::arg("uyn_global_prev"),
+           py::arg("uyn_global_curr"), py::arg("uzn_global_prev"), py::arg("uzn_global_curr"))
       .def("swap", &WavefieldElastic::swap)
       .def(
           "swap_with_rotation",
-          [](WavefieldElastic& self,
-             Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>& uxPP,
+          [](WavefieldElastic& self, Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>& uxPP,
              Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>& uyPP,
              Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>& uzPP) {
             VECTOR_REAL_VIEW vux = uxPP, vuy = uyPP, vuz = uzPP;
@@ -118,56 +99,46 @@ void bind_wavefield_elastic(py::module_& m)
             uyPP = vuy;
             uzPP = vuz;
           },
-          py::arg("ux_prev_prev"), py::arg("uy_prev_prev"),
-          py::arg("uz_prev_prev"))
+          py::arg("ux_prev_prev"), py::arg("uy_prev_prev"), py::arg("uz_prev_prev"))
       .def(
           "get_current_field",
           [](const WavefieldElastic& self, int i) {
-            return Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>(
-                self.getCurrentField(i));
+            return Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>(self.getCurrentField(i));
           },
           py::arg("i"))
       .def(
           "get_previous_field",
           [](const WavefieldElastic& self, int i) {
-            return Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>(
-                self.getPreviousField(i));
+            return Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>(self.getPreviousField(i));
           },
           py::arg("i"))
       .def("print", &WavefieldElastic::print);
 }
 
-void bind_wavefield_acoustoelastic(py::module_& m)
-{
-  py::class_<WavefieldAcoustoElastic, Wavefield,
-             std::shared_ptr<WavefieldAcoustoElastic>>(
-      m, "WavefieldAcoustoElastic")
-      .def(py::init<
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
-               Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>>(),
-           py::arg("pn_global_prev"), py::arg("pn_global_curr"),
-           py::arg("uxn_global_prev"), py::arg("uxn_global_curr"),
-           py::arg("uyn_global_prev"), py::arg("uyn_global_curr"),
-           py::arg("uzn_global_prev"), py::arg("uzn_global_curr"))
+void bind_wavefield_acoustoelastic(py::module_& m) {
+  py::class_<WavefieldAcoustoElastic, Wavefield, std::shared_ptr<WavefieldAcoustoElastic>>(m, "WavefieldAcoustoElastic")
+      .def(py::init<Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>,
+                    Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>>(),
+           py::arg("pn_global_prev"), py::arg("pn_global_curr"), py::arg("uxn_global_prev"), py::arg("uxn_global_curr"),
+           py::arg("uyn_global_prev"), py::arg("uyn_global_curr"), py::arg("uzn_global_prev"),
+           py::arg("uzn_global_curr"))
       .def("swap", &WavefieldAcoustoElastic::swap)
       .def(
           "get_current_field",
           [](const WavefieldAcoustoElastic& self, int i) {
-            return Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>(
-                self.getCurrentField(i));
+            return Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>(self.getCurrentField(i));
           },
           py::arg("i"))
       .def(
           "get_previous_field",
           [](const WavefieldAcoustoElastic& self, int i) {
-            return Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>(
-                self.getPreviousField(i));
+            return Kokkos::Experimental::python_view_type_t<VECTOR_REAL_VIEW>(self.getPreviousField(i));
           },
           py::arg("i"))
       .def("print", &WavefieldAcoustoElastic::print);

--- a/src/solver/fe/pywrap/src/bindings.cpp
+++ b/src/solver/fe/pywrap/src/bindings.cpp
@@ -9,8 +9,7 @@
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(solver, m)
-{
+PYBIND11_MODULE(solver, m) {
   // Create submodule 'solver'
   m.attr("__name__") = "pyfuntides.solver";
 

--- a/src/utils/include/args_parse.h
+++ b/src/utils/include/args_parse.h
@@ -15,13 +15,9 @@
  * @return A pointer to the value associated with the option if found,
  *         otherwise returns nullptr.
  */
-inline std::string getCmdOption(char **begin, char **end,
-                                const std::string &option)
-{
-  for (char **itr = begin; itr != end; ++itr)
-  {
-    if (std::string(*itr) == option && (itr + 1) != end)
-    {
+inline std::string getCmdOption(char **begin, char **end, const std::string &option) {
+  for (char **itr = begin; itr != end; ++itr) {
+    if (std::string(*itr) == option && (itr + 1) != end) {
       return std::string(*(itr + 1));
     }
   }
@@ -39,10 +35,7 @@ inline std::string getCmdOption(char **begin, char **end,
  * @param option The option to check for.
  * @return True if the option exists, otherwise false.
  */
-inline bool cmdOptionExists(char **begin, char **end, const std::string &option)
-{
-  return std::find_if(begin, end, [&](char *arg) {
-           return std::string(arg) == option;
-         }) != end;
+inline bool cmdOptionExists(char **begin, char **end, const std::string &option) {
+  return std::find_if(begin, end, [&](char *arg) { return std::string(arg) == option; }) != end;
 }
 #endif  // FUNTIDES_UTILS_INCLUDE_ARGS_PARSE_H_

--- a/src/utils/include/common_macros.h
+++ b/src/utils/include/common_macros.h
@@ -25,30 +25,23 @@
       KOKKOS_CLASS_LAMBDA(const int Index)
 #define MAINLOOPEND );
 
-#define FIND_MAX_1D(Array, Range, Result)                                  \
-  if (Array.extent(0) == 0)                                                \
-    throw std::runtime_error("Error in FIND_MAX_1D: Array has zero size"); \
-  Kokkos::parallel_reduce(                                                 \
-      "FindMax1D", Range,                                                  \
-      KOKKOS_CLASS_LAMBDA(const int i, decltype(Result)& local_max) {      \
-        if (Array[i] > local_max) local_max = Array[i];                    \
-      },                                                                   \
+#define FIND_MAX_1D(Array, Range, Result)                                                          \
+  if (Array.extent(0) == 0) throw std::runtime_error("Error in FIND_MAX_1D: Array has zero size"); \
+  Kokkos::parallel_reduce(                                                                         \
+      "FindMax1D", Range,                                                                          \
+      KOKKOS_CLASS_LAMBDA(const int i, decltype(Result)& local_max) {                              \
+        if (Array[i] > local_max) local_max = Array[i];                                            \
+      },                                                                                           \
       Kokkos::Max<decltype(Result)>(Result));
 
-#define FIND_MIN(Array, Range, Result)                                \
-  Kokkos::parallel_reduce(                                            \
-      Range,                                                          \
-      KOKKOS_CLASS_LAMBDA(const int i, decltype(Result)& local_min) { \
-        local_min = Array[i];                                         \
-      },                                                              \
+#define FIND_MIN(Array, Range, Result)                                                                \
+  Kokkos::parallel_reduce(                                                                            \
+      Range, KOKKOS_CLASS_LAMBDA(const int i, decltype(Result)& local_min) { local_min = Array[i]; }, \
       Kokkos::Min<decltype(Result)>(Result));
 
-#define SUM(Array, Range, Result)                                     \
-  Kokkos::parallel_reduce(                                            \
-      Range,                                                          \
-      KOKKOS_CLASS_LAMBDA(const int i, decltype(Result)& local_sum) { \
-        local_sum = Array[i];                                         \
-      },                                                              \
+#define SUM(Array, Range, Result)                                                                     \
+  Kokkos::parallel_reduce(                                                                            \
+      Range, KOKKOS_CLASS_LAMBDA(const int i, decltype(Result)& local_sum) { local_sum = Array[i]; }, \
       Kokkos::Sum<decltype(Result)>(Result));
 
 #define ARRAY_DOUBLE_VIEW arrayReal

--- a/src/utils/include/data_type.h
+++ b/src/utils/include/data_type.h
@@ -20,8 +20,7 @@ using real_t = float;
 #endif
 
 template <class T>
-T allocateVector(int n1)
-{
+T allocateVector(int n1) {
 #ifdef PRINT_ALLOC_INFO
   std::cout << "allocate vector of size " << n1 << std::endl;
 #endif
@@ -29,8 +28,7 @@ T allocateVector(int n1)
   return vect;
 }
 template <class T>
-T allocateVector(int n1, const char *name)
-{
+T allocateVector(int n1, const char *name) {
 #ifdef PRINT_ALLOC_INFO
   std::cout << "allocate vector: " << name << " of size: " << n1 << std::endl;
 #endif
@@ -38,8 +36,7 @@ T allocateVector(int n1, const char *name)
   return vect;
 }
 template <class T>
-T allocateArray2D(int n1, int n2)
-{
+T allocateArray2D(int n1, int n2) {
 #ifdef PRINT_ALLOC_INFO
   std::cout << "allocate array of size " << n1 << ", " << n2 << std::endl;
 #endif
@@ -47,21 +44,17 @@ T allocateArray2D(int n1, int n2)
   return array;
 }
 template <class T>
-T allocateArray2D(int n1, int n2, const char *name)
-{
+T allocateArray2D(int n1, int n2, const char *name) {
 #ifdef PRINT_ALLOC_INFO
-  std::cout << "allocate array : " << name << " of size: (" << n1 << ", " << n2
-            << ")" << std::endl;
+  std::cout << "allocate array : " << name << " of size: (" << n1 << ", " << n2 << ")" << std::endl;
 #endif
   T array(KOKKOSNAME n1, n2);
   return array;
 }
 template <class T>
-T allocateArray3D(int n1, int n2, int n3)
-{
+T allocateArray3D(int n1, int n2, int n3) {
 #ifdef PRINT_ALLOC_INFO
-  std::cout << "allocate array of size " << n1 << ", " << n2 << ", " << n3
-            << std::endl;
+  std::cout << "allocate array of size " << n1 << ", " << n2 << ", " << n3 << std::endl;
 #endif
   T array(KOKKOSNAME n1, n2, n3);
   return array;
@@ -69,23 +62,18 @@ T allocateArray3D(int n1, int n2, int n3)
 
 // to be placed somewhere else
 template <typename T, typename... Args>
-void printJMatrix(const int &element, T &J, string matrixname, Args... args)
-{
-  if (element < 2)
-  {
+void printJMatrix(const int &element, T &J, string matrixname, Args... args) {
+  if (element < 2) {
     (cout << ... << args) << '\n';
     printf("%s at element %d\n", matrixname.c_str(), element);
-    for (int l = 0; l < 3; l++)
-      printf("%f, %f, %f\n", J[l][0], J[l][1], J[l][2]);
+    for (int l = 0; l < 3; l++) printf("%f, %f, %f\n", J[l][0], J[l][1], J[l][2]);
   }
 }
 
 template <typename T>
-void printBMatrix(const int &element, T &B)
-{
+void printBMatrix(const int &element, T &B) {
   // print B matrix at the first element
-  if (element < 2)
-  {
+  if (element < 2) {
     printf("\nB matrix at element %d\n", element);
     printf("%f, %f, %f\n", B[0], B[5], B[4]);
     printf("%f, %f, %f\n", B[5], B[1], B[3]);
@@ -93,9 +81,6 @@ void printBMatrix(const int &element, T &B)
   }
 }
 
-#define timewatch(timepoint)                                \
-  chrono::time_point<std::chrono::system_clock> timepoint = \
-      chrono::system_clock::now();
-#define accumtime(accumulatedtime, starttime) \
-  accumulatedtime += (chrono::system_clock::now() - starttime).count();
+#define timewatch(timepoint) chrono::time_point<std::chrono::system_clock> timepoint = chrono::system_clock::now();
+#define accumtime(accumulatedtime, starttime) accumulatedtime += (chrono::system_clock::now() - starttime).count();
 #endif  // FUNTIDES_UTILS_INCLUDE_DATA_TYPE_H_

--- a/src/utils/include/distributed_ctx.h
+++ b/src/utils/include/distributed_ctx.h
@@ -1,7 +1,6 @@
 #ifndef FUNTIDES_UTILS_INCLUDE_DISTRIBUTED_CTX_H_
 #define FUNTIDES_UTILS_INCLUDE_DISTRIBUTED_CTX_H_
-namespace utils
-{
+namespace utils {
 
 /**
  * @brief Hold the distributed context.
@@ -9,8 +8,7 @@ namespace utils
  * Discribs the distributed context, such as number of parallel ranks, current
  * rank and later on the MPI context or other kind of communicator.
  * */
-struct DistributedContext
-{
+struct DistributedContext {
   int rank{0};  //< Current rank
   int size{1};  //< Total number of rank
 };

--- a/src/utils/include/parallel_topology.h
+++ b/src/utils/include/parallel_topology.h
@@ -3,8 +3,7 @@
 #include <map>
 #include <vector>
 
-namespace utils
-{
+namespace utils {
 
 /**
  * @brief Describes the distributed connectivity of the mesh.
@@ -19,8 +18,7 @@ namespace utils
  * TopologyFactory and used by BoundarySynchronizer to coordinate
  * data exchange.
  */
-struct ParallelTopology
-{
+struct ParallelTopology {
   int myRank = 0;    //< Current MPI rank (0-based)
   int numRanks = 1;  //< Total number of ranks
 
@@ -34,11 +32,9 @@ struct ParallelTopology
 
   // @brief Returns the total number of boundary nodes across all neighbors.
   // @return Sum of all shared node counts
-  size_t getTotalBoundaryNodes() const
-  {
+  size_t getTotalBoundaryNodes() const {
     size_t total = 0;
-    for (const auto& [rank, nodes] : sharedNodes)
-    {
+    for (const auto& [rank, nodes] : sharedNodes) {
       total += nodes.size();
     }
     return total;

--- a/src/utils/include/sem_enums.h
+++ b/src/utils/include/sem_enums.h
@@ -2,41 +2,17 @@
 #define FUNTIDES_UTILS_INCLUDE_SEM_ENUMS_H_
 #include <string>
 
-namespace utils
-{
-namespace enums
-{
+namespace utils {
+namespace enums {
 
-enum class methodType
-{
-  kSem,
-  kDg
-};
-enum class implemType
-{
-  kMakutu
-};
-enum class meshType
-{
-  kStruct,
-  kUnstruct
-};
-enum class modelLocationType
-{
-  kOnNodes,
-  kOnElements
-};
-enum class physicType : int
-{
-  kAcoustic,
-  kElastic,
-  kAcoustoElastic
-};
+enum class methodType { kSem, kDg };
+enum class implemType { kMakutu };
+enum class meshType { kStruct, kUnstruct };
+enum class modelLocationType { kOnNodes, kOnElements };
+enum class physicType : int { kAcoustic, kElastic, kAcoustoElastic };
 
-inline std::string to_string(methodType m)
-{
-  switch (m)
-  {
+inline std::string to_string(methodType m) {
+  switch (m) {
     case methodType::kSem:
       return "SEM";
     case methodType::kDg:
@@ -46,10 +22,8 @@ inline std::string to_string(methodType m)
   }
 }
 
-inline std::string to_string(implemType i)
-{
-  switch (i)
-  {
+inline std::string to_string(implemType i) {
+  switch (i) {
     case implemType::kMakutu:
       return "MAKUTU";
     default:
@@ -57,10 +31,8 @@ inline std::string to_string(implemType i)
   }
 }
 
-inline std::string to_string(meshType m)
-{
-  switch (m)
-  {
+inline std::string to_string(meshType m) {
+  switch (m) {
     case meshType::kStruct:
       return "Struct";
     case meshType::kUnstruct:
@@ -70,10 +42,8 @@ inline std::string to_string(meshType m)
   }
 }
 
-inline std::string to_string(modelLocationType loc)
-{
-  switch (loc)
-  {
+inline std::string to_string(modelLocationType loc) {
+  switch (loc) {
     case modelLocationType::kOnNodes:
       return "OnNodes";
     case modelLocationType::kOnElements:
@@ -83,10 +53,8 @@ inline std::string to_string(modelLocationType loc)
   }
 }
 
-inline std::string to_string(physicType p)
-{
-  switch (p)
-  {
+inline std::string to_string(physicType p) {
+  switch (p) {
     case physicType::kAcoustic:
       return "Acoustic";
     case physicType::kElastic:

--- a/src/utils/include/source_and_receiver_utils.h
+++ b/src/utils/include/source_and_receiver_utils.h
@@ -8,86 +8,69 @@
 
 using namespace std::chrono;
 
-namespace SourceAndReceiverUtils
-{
+namespace SourceAndReceiverUtils {
 
 /// Selector for the 1D Lagrange basis type given the polynomial order.
 template <int ORDER>
 struct LagrangeBasisSelector;
 
 template <>
-struct LagrangeBasisSelector<1>
-{
+struct LagrangeBasisSelector<1> {
   using type = LagrangeBasis1;
 };
 template <>
-struct LagrangeBasisSelector<2>
-{
+struct LagrangeBasisSelector<2> {
   using type = LagrangeBasis2;
 };
 template <>
-struct LagrangeBasisSelector<3>
-{
+struct LagrangeBasisSelector<3> {
   using type = LagrangeBasis3GL;
 };
 template <>
-struct LagrangeBasisSelector<4>
-{
+struct LagrangeBasisSelector<4> {
   using type = LagrangeBasis4GL;
 };
 template <>
-struct LagrangeBasisSelector<5>
-{
+struct LagrangeBasisSelector<5> {
   using type = LagrangeBasis5GL;
 };
 
 /// DAS (Distributed Acoustic Sensing) receiver type.
 /// Ported from GEOS WaveSolverUtils::DASType.
-enum class DASType
-{
-  kNone,    ///< Standard point receiver (no DAS)
-  kDipole,  ///< Displacement difference at two endpoints / gauge length
+enum class DASType {
+  kNone,               ///< Standard point receiver (no DAS)
+  kDipole,             ///< Displacement difference at two endpoints / gauge length
   kStrainIntegration,  ///< Integrate strain along fiber direction
 };
 
 /// Compute fiber direction unit vector from dip and azimuth angles (degrees).
 /// Convention: dip = angle from horizontal, azimuth = angle in XY plane from X.
-inline std::array<float, 3> ComputeDASVector(float dip_deg, float azimuth_deg)
-{
+inline std::array<float, 3> ComputeDASVector(float dip_deg, float azimuth_deg) {
   const float dip = dip_deg * static_cast<float>(M_PI) / 180.0f;
   const float az = azimuth_deg * static_cast<float>(M_PI) / 180.0f;
-  return {std::cos(dip) * std::cos(az), std::cos(dip) * std::sin(az),
-          std::sin(dip)};
+  return {std::cos(dip) * std::cos(az), std::cos(dip) * std::sin(az), std::sin(dip)};
 }
 
 template <int ORDER>
-void ComputeRHSWeights(real_t const (&cornerCoords)[8][3],
-                       std::array<float, 3> coordsReal,
-                       ARRAY_REAL_VIEW& rhsWeights)
-{
-  constexpr int numNodes =
-      Qk_Hexahedron_Lagrange_GaussLobatto_Selector<ORDER>::type::numNodes;
+void ComputeRHSWeights(real_t const (&cornerCoords)[8][3], std::array<float, 3> coordsReal,
+                       ARRAY_REAL_VIEW& rhsWeights) {
+  constexpr int numNodes = Qk_Hexahedron_Lagrange_GaussLobatto_Selector<ORDER>::type::numNodes;
 
   // Compute coordinates on reference element
   double coordsRef[3]{};
   float invJ[3][3] = {{0}};
-  Qk_Hexahedron_Lagrange_GaussLobatto_Selector<
-      ORDER>::type::invJacobianTransformation(0, cornerCoords, invJ);
-  for (int i = 0; i < 3; i++)
-  {
+  Qk_Hexahedron_Lagrange_GaussLobatto_Selector<ORDER>::type::invJacobianTransformation(0, cornerCoords, invJ);
+  for (int i = 0; i < 3; i++) {
     coordsRef[i] = -1.0;
-    for (int j = 0; j < 3; j++)
-    {
+    for (int j = 0; j < 3; j++) {
       coordsRef[i] += invJ[i][j] * (coordsReal[j] - cornerCoords[0][j]);
     }
   }
 
   // ComputeRhsWeights
   double N[numNodes] = {0};
-  Qk_Hexahedron_Lagrange_GaussLobatto_Selector<ORDER>::type::calcN(coordsRef,
-                                                                   N);
-  for (int i = 0; i < numNodes; i++)
-  {
+  Qk_Hexahedron_Lagrange_GaussLobatto_Selector<ORDER>::type::calcN(coordsRef, N);
+  for (int i = 0; i < numNodes; i++) {
     rhsWeights(0, i) = N[i];
   }
 }
@@ -103,14 +86,10 @@ void ComputeRHSWeights(real_t const (&cornerCoords)[8][3],
 /// @param dasType       dipole or strain integration
 /// @param dasWeights    output array [numNodes], ACCUMULATED (caller must init)
 template <int ORDER>
-void ComputeDASWeightsForSample(real_t const (&cornerCoords)[8][3],
-                                std::array<float, 3> coordsReal,
-                                const std::array<float, 3>& direction,
-                                float integrationConstant, DASType dasType,
-                                float* dasWeights)
-{
-  using FEType =
-      typename Qk_Hexahedron_Lagrange_GaussLobatto_Selector<ORDER>::type;
+void ComputeDASWeightsForSample(real_t const (&cornerCoords)[8][3], std::array<float, 3> coordsReal,
+                                const std::array<float, 3>& direction, float integrationConstant, DASType dasType,
+                                float* dasWeights) {
+  using FEType = typename Qk_Hexahedron_Lagrange_GaussLobatto_Selector<ORDER>::type;
   using Basis = typename LagrangeBasisSelector<ORDER>::type;
   constexpr int numNodes = FEType::numNodes;
 
@@ -118,29 +97,22 @@ void ComputeDASWeightsForSample(real_t const (&cornerCoords)[8][3],
   real_t invJ[3][3] = {{0}};
   FEType::invJacobianTransformation(0, cornerCoords, invJ);
   double coordsRef[3]{};
-  for (int i = 0; i < 3; i++)
-  {
+  for (int i = 0; i < 3; i++) {
     coordsRef[i] = -1.0;
-    for (int j = 0; j < 3; j++)
-    {
+    for (int j = 0; j < 3; j++) {
       coordsRef[i] += invJ[i][j] * (coordsReal[j] - cornerCoords[0][j]);
     }
   }
 
-  if (dasType == DASType::kStrainIntegration)
-  {
+  if (dasType == DASType::kStrainIntegration) {
     // Compute parent gradients (dN/dxi) at coordsRef for each node
     // and transform to physical gradients using the inverse Jacobian.
     // We call GL_BASIS value/gradient directly (in double) and cast
     // explicitly to avoid narrowing warnings in the FE kernel.
-    for (int c = 0; c < ORDER + 1; ++c)
-    {
-      for (int b = 0; b < ORDER + 1; ++b)
-      {
-        for (int a_idx = 0; a_idx < ORDER + 1; ++a_idx)
-        {
-          int nodeIndex =
-              a_idx + b * (ORDER + 1) + c * (ORDER + 1) * (ORDER + 1);
+    for (int c = 0; c < ORDER + 1; ++c) {
+      for (int b = 0; b < ORDER + 1; ++b) {
+        for (int a_idx = 0; a_idx < ORDER + 1; ++a_idx) {
+          int nodeIndex = a_idx + b * (ORDER + 1) + c * (ORDER + 1) * (ORDER + 1);
 
           double Na = Basis::value(a_idx, coordsRef[0]);
           double Nb = Basis::value(b, coordsRef[1]);
@@ -149,33 +121,26 @@ void ComputeDASWeightsForSample(real_t const (&cornerCoords)[8][3],
           double dNb = Basis::gradient(b, coordsRef[1]);
           double dNc = Basis::gradient(c, coordsRef[2]);
 
-          real_t dNdXi[3] = {static_cast<real_t>(dNa * Nb * Nc),
-                             static_cast<real_t>(Na * dNb * Nc),
+          real_t dNdXi[3] = {static_cast<real_t>(dNa * Nb * Nc), static_cast<real_t>(Na * dNb * Nc),
                              static_cast<real_t>(Na * Nb * dNc)};
 
           // Transform to physical gradients: gradN_i = sum_j invJ[j][i] *
           // dNdXi[j]
           real_t gx = 0, gy = 0, gz = 0;
-          for (int j = 0; j < 3; ++j)
-          {
+          for (int j = 0; j < 3; ++j) {
             gx += invJ[j][0] * dNdXi[j];
             gy += invJ[j][1] * dNdXi[j];
             gz += invJ[j][2] * dNdXi[j];
           }
-          dasWeights[nodeIndex] +=
-              (gx * direction[0] + gy * direction[1] + gz * direction[2]) *
-              integrationConstant;
+          dasWeights[nodeIndex] += (gx * direction[0] + gy * direction[1] + gz * direction[2]) * integrationConstant;
         }
       }
     }
-  }
-  else
-  {
+  } else {
     // Dipole: use basis function values
     double N[numNodes] = {0};
     FEType::calcN(coordsRef, N);
-    for (int a = 0; a < numNodes; ++a)
-    {
+    for (int a = 0; a < numNodes; ++a) {
       dasWeights[a] += static_cast<float>(N[a]) * integrationConstant;
     }
   }

--- a/src/utils/include/utils.h
+++ b/src/utils/include/utils.h
@@ -4,70 +4,50 @@
 
 using namespace std::chrono;
 
-struct SolverUtils
-{
-  float evaluateRicker(float const& time_n, float const& f0, int order,
-                       float const& tpeak)
-  {
+struct SolverUtils {
+  float evaluateRicker(float const& time_n, float const& f0, int order, float const& tpeak) {
     // float const tpeak = 1.0 / f0;
     float pulse = 0.0;
-    if ((time_n <= -0.9 * tpeak) || (time_n >= 2.9 * tpeak))
-    {
+    if ((time_n <= -0.9 * tpeak) || (time_n >= 2.9 * tpeak)) {
       return pulse;
     }
 
     constexpr float pi = M_PI;
     float const lam = (f0 * pi) * (f0 * pi);
 
-    switch (order)
-    {
+    switch (order) {
       case 4: {
         pulse = 4.0 * lam * lam *
                 (3.0 - 12.0 * lam * (time_n - tpeak) * (time_n - tpeak) +
-                 4.0 * lam * lam * (time_n - tpeak) * (time_n - tpeak) *
-                     (time_n - tpeak) * (time_n - tpeak)) *
+                 4.0 * lam * lam * (time_n - tpeak) * (time_n - tpeak) * (time_n - tpeak) * (time_n - tpeak)) *
                 exp(-lam * (time_n - tpeak) * (time_n - tpeak));
-      }
-      break;
+      } break;
       case 3: {
-        pulse = 4.0 * lam * lam * (time_n - tpeak) *
-                (3.0 - 2.0 * lam * (time_n - tpeak) * (time_n - tpeak)) *
+        pulse = 4.0 * lam * lam * (time_n - tpeak) * (3.0 - 2.0 * lam * (time_n - tpeak) * (time_n - tpeak)) *
                 exp(-lam * (time_n - tpeak) * (time_n - tpeak));
-      }
-      break;
+      } break;
       case 2: {
-        pulse = 2.0 * lam *
-                (2.0 * lam * (time_n - tpeak) * (time_n - tpeak) - 1.0) *
+        pulse = 2.0 * lam * (2.0 * lam * (time_n - tpeak) * (time_n - tpeak) - 1.0) *
                 exp(-lam * (time_n - tpeak) * (time_n - tpeak));
-      }
-      break;
+      } break;
       case 1: {
-        pulse = -2.0 * lam * (time_n - tpeak) *
-                exp(-lam * (time_n - tpeak) * (time_n - tpeak));
-      }
-      break;
+        pulse = -2.0 * lam * (time_n - tpeak) * exp(-lam * (time_n - tpeak) * (time_n - tpeak));
+      } break;
       case 0: {
-        pulse = -(time_n - tpeak) *
-                exp(-2 * lam * (time_n - tpeak) * (time_n - tpeak));
-      }
-      break;
+        pulse = -(time_n - tpeak) * exp(-2 * lam * (time_n - tpeak) * (time_n - tpeak));
+      } break;
       default:
-        std::cout
-            << "This option is not supported yet, rickerOrder must be 0, 1 or 2"
-            << std::endl;
+        std::cout << "This option is not supported yet, rickerOrder must be 0, 1 or 2" << std::endl;
         break;
     }
 
     return pulse;
   }
 
-  std::vector<float> computeSourceTerm(const int nSamples,
-                                       const float timeSample, const float f0,
-                                       const int order, const float tpeak)
-  {
+  std::vector<float> computeSourceTerm(const int nSamples, const float timeSample, const float f0, const int order,
+                                       const float tpeak) {
     std::vector<float> sourceTerm(nSamples);
-    for (int i = 0; i < nSamples; i++)
-    {
+    for (int i = 0; i < nSamples; i++) {
       float time_n = i * timeSample;
       sourceTerm[i] = evaluateRicker(time_n, f0, order, tpeak);
     }

--- a/tests/benchmarks/cpp/include/bench_main.h
+++ b/tests/benchmarks/cpp/include/bench_main.h
@@ -17,28 +17,21 @@
  * @return Number of Kokkos threads specified
  * @throws std::invalid_argument if argument is missing, malformed, or negative
  */
-static int parseKokkosThreads(int argc, char** argv)
-{
+static int parseKokkosThreads(int argc, char** argv) {
   const char prefix[] = "--kokkos-threads=";
   const std::size_t len = sizeof(prefix) - 1;
-  for (int i = 1; i < argc; ++i)
-  {
+  for (int i = 1; i < argc; ++i) {
     const char* arg = argv[i];
-    if (std::strncmp(arg, prefix, len) == 0)
-    {
+    if (std::strncmp(arg, prefix, len) == 0) {
       const char* value = arg + len;
-      if (*value == '\0')
-        throw std::invalid_argument("--kokkos-threads requires a value");
+      if (*value == '\0') throw std::invalid_argument("--kokkos-threads requires a value");
       char* end = nullptr;
       long v = std::strtol(value, &end, 10);
-      if (*end != '\0' || v < 0)
-        throw std::invalid_argument(
-            "--kokkos-threads must be a non-negative integer");
+      if (*end != '\0' || v < 0) throw std::invalid_argument("--kokkos-threads must be a non-negative integer");
       return static_cast<int>(v);
     }
   }
-  throw std::invalid_argument(
-      "--kokkos-threads must be set to > 0, e.g. --kokkos-threads=4");
+  throw std::invalid_argument("--kokkos-threads must be set to > 0, e.g. --kokkos-threads=4");
 }
 
 /**
@@ -61,8 +54,7 @@ static int parseKokkosThreads(int argc, char** argv)
  * @note This function ensures proper cleanup (Kokkos finalization) even when
  *       unrecognized arguments are detected.
  */
-static int runBenchmarks(int argc, char** argv)
-{
+static int runBenchmarks(int argc, char** argv) {
 #ifdef USE_KOKKOS
   int nThreads = parseKokkosThreads(argc, argv);
   Kokkos::InitializationSettings kkSettings;

--- a/tests/benchmarks/cpp/src/bench_solver_fe_cartesian_struct_acoustic.cc
+++ b/tests/benchmarks/cpp/src/bench_solver_fe_cartesian_struct_acoustic.cc
@@ -18,23 +18,19 @@
 using namespace solver::fe;
 using namespace utils::enums;
 
-namespace model
-{
-namespace bench
-{
+namespace model {
+namespace bench {
 
 // Template config for the fixture
 template <int Order>
-struct BuilderConfig
-{
+struct BuilderConfig {
   using Builder = CartesianStructBuilder<float, int, Order>;
   static constexpr int order = Order;
 };
 
 // Template fixture for the benchmarks
 template <typename T>
-class SolverStructFixture : public benchmark::Fixture
-{
+class SolverStructFixture : public benchmark::Fixture {
  protected:
   // domain decomposition
   static constexpr int rank = 0;
@@ -48,13 +44,11 @@ class SolverStructFixture : public benchmark::Fixture
   static constexpr int ez = 100;
   static constexpr float domain_size = 2000.0f;
   static constexpr int order = T::order;
-  static constexpr int n_dof =
-      (ex * order + 1) * (ey * order + 1) * (ez * order + 1);
+  static constexpr int n_dof = (ex * order + 1) * (ey * order + 1) * (ez * order + 1);
   bool isModelOnNodes_;
 
   // sponge
-  inline static constexpr std::array<float, 3> sponge_size = {200.0f, 200.0f,
-                                                              200.0f};
+  inline static constexpr std::array<float, 3> sponge_size = {200.0f, 200.0f, 200.0f};
   inline static constexpr bool surface_sponge = false;
   inline static constexpr float taper_delta = 100.0f;
 
@@ -66,15 +60,13 @@ class SolverStructFixture : public benchmark::Fixture
   static constexpr float f0 = 5.0f;
   implemType implem_;
 
-  void SetUp(const ::benchmark::State& state) override
-  {
+  void SetUp(const ::benchmark::State& state) override {
     isModelOnNodes_ = state.range(0);
     implem_ = static_cast<implemType>(state.range(1));
     local_l = domain_size;
   }
 
-  std::shared_ptr<model::ModelApi<float, int>> createModel()
-  {
+  std::shared_ptr<model::ModelApi<float, int>> createModel() {
     float hx = domain_size / ex;
     float hy = domain_size / ey;
     float hz = domain_size / ez;
@@ -84,17 +76,14 @@ class SolverStructFixture : public benchmark::Fixture
     return builder.getModel(true);
   }
 
-  void setLabel(benchmark::State& state) const
-  {
-    state.SetLabel("Order=" + to_string(order) +
-                   " OnNodes=" + to_string(isModelOnNodes_) + " Implem=" +
-                   to_string(implem_) + " IsElastic=" + std::to_string(false));
+  void setLabel(benchmark::State& state) const {
+    state.SetLabel("Order=" + to_string(order) + " OnNodes=" + to_string(isModelOnNodes_) +
+                   " Implem=" + to_string(implem_) + " IsElastic=" + std::to_string(false));
   }
 };
 
 // Structure to hold allocated arrays for benchmarks
-struct BenchmarkArrays
-{
+struct BenchmarkArrays {
   arrayReal rhsTerm;
   vectorInt rhsElement;
   arrayReal rhsWeights;
@@ -102,13 +91,10 @@ struct BenchmarkArrays
   vectorReal pnGlobalCurr;
   arrayReal rhsLocation;
 
-  BenchmarkArrays(int n_rhs, int n_time_steps, int n_dof,
-                  int nb_points_per_element)
-  {
+  BenchmarkArrays(int n_rhs, int n_time_steps, int n_dof, int nb_points_per_element) {
     rhsTerm = allocateArray2D<arrayReal>(n_rhs, n_time_steps, "rhsTerm");
     rhsElement = allocateVector<vectorInt>(n_rhs, "rhsElement");
-    rhsWeights =
-        allocateArray2D<arrayReal>(n_rhs, nb_points_per_element, "rhsWeights");
+    rhsWeights = allocateArray2D<arrayReal>(n_rhs, nb_points_per_element, "rhsWeights");
     pnGlobalPrev = allocateVector<vectorReal>(n_dof, "pnGlobalPrev");
     pnGlobalCurr = allocateVector<vectorReal>(n_dof, "pnGlobalCurr");
     rhsLocation = allocateArray2D<arrayReal>(1, 3, "rhsLocation");
@@ -118,22 +104,18 @@ struct BenchmarkArrays
 };
 
 BENCHMARK_TEMPLATE_METHOD_F(SolverStructFixture, FEInit)
-(benchmark::State& state)
-{
+(benchmark::State& state) {
   // Prepare
   auto model = this->createModel();
 
-  auto solver = solver_factory::createSolver(
-      methodType::kSem, this->implem_, meshType::kStruct,
-      this->isModelOnNodes_ ? modelLocationType::kOnNodes
-                            : modelLocationType::kOnElements,
-      physicType::kAcoustic, this->order);
+  auto solver =
+      solver_factory::createSolver(methodType::kSem, this->implem_, meshType::kStruct,
+                                   this->isModelOnNodes_ ? modelLocationType::kOnNodes : modelLocationType::kOnElements,
+                                   physicType::kAcoustic, this->order);
 
   // Bench
-  for (auto _ : state)
-  {
-    solver->computeFEInit(*model, this->sponge_size, this->surface_sponge,
-                          this->taper_delta);
+  for (auto _ : state) {
+    solver->computeFEInit(*model, this->sponge_size, this->surface_sponge, this->taper_delta);
   }
 
   // Label
@@ -141,35 +123,27 @@ BENCHMARK_TEMPLATE_METHOD_F(SolverStructFixture, FEInit)
 }
 
 BENCHMARK_TEMPLATE_METHOD_F(SolverStructFixture, OneStep)
-(benchmark::State& state)
-{
+(benchmark::State& state) {
   // Prepare
   auto model = this->createModel();
 
-  auto solver = solver_factory::createSolver(
-      methodType::kSem, this->implem_, meshType::kStruct,
-      this->isModelOnNodes_ ? modelLocationType::kOnNodes
-                            : modelLocationType::kOnElements,
-      physicType::kAcoustic, this->order);
+  auto solver =
+      solver_factory::createSolver(methodType::kSem, this->implem_, meshType::kStruct,
+                                   this->isModelOnNodes_ ? modelLocationType::kOnNodes : modelLocationType::kOnElements,
+                                   physicType::kAcoustic, this->order);
 
-  solver->computeFEInit(*model, this->sponge_size, this->surface_sponge,
-                        this->taper_delta);
+  solver->computeFEInit(*model, this->sponge_size, this->surface_sponge, this->taper_delta);
 
-  BenchmarkArrays arrays(this->n_rhs, this->n_time_steps, this->n_dof,
-                         model->getNumberOfPointsPerElement());
+  BenchmarkArrays arrays(this->n_rhs, this->n_time_steps, this->n_dof, model->getNumberOfPointsPerElement());
   // sources at the center of the domain
-  arrays.rhsElement(0) = this->ex / 2 + this->ey / 2 * this->ex +
-                         this->ez / 2 * this->ey * this->ex;
-  arrays.rhsElement(1) = this->ex / 3 + this->ey / 2 * this->ex +
-                         this->ez / 2 * this->ey * this->ex;
+  arrays.rhsElement(0) = this->ex / 2 + this->ey / 2 * this->ex + this->ez / 2 * this->ey * this->ex;
+  arrays.rhsElement(1) = this->ex / 3 + this->ey / 2 * this->ex + this->ez / 2 * this->ey * this->ex;
 
   // ricker wavelet
   SolverUtils myUtils;
   float const tpeak = 1.0f / this->f0;
-  std::vector<float> sourceTerm = myUtils.computeSourceTerm(
-      this->n_time_steps, this->dt, this->f0, 2, tpeak);
-  for (int j = 0; j < this->n_time_steps; j++)
-  {
+  std::vector<float> sourceTerm = myUtils.computeSourceTerm(this->n_time_steps, this->dt, this->f0, 2, tpeak);
+  for (int j = 0; j < this->n_time_steps; j++) {
     arrays.rhsTerm(0, j) = sourceTerm[j];
   }
 
@@ -178,8 +152,7 @@ BENCHMARK_TEMPLATE_METHOD_F(SolverStructFixture, OneStep)
   SEMsolverDataAcoustic data(wavefield, rhs);
 
   // Bench
-  for (auto _ : state)
-  {
+  for (auto _ : state) {
     solver->computeForces(this->dt, this->time_sample, data);
     solver->updateSolution(this->dt, data);
   }
@@ -191,14 +164,10 @@ BENCHMARK_TEMPLATE_METHOD_F(SolverStructFixture, OneStep)
 // Instantiate for all order/isModelOnNodes/implemType combinations
 BENCHMARK_FOR_ALL_ORDERS(
     SolverStructFixture, FEInit,
-    BuilderConfig,
-        ->ArgsProduct({{0, 1}, {static_cast<int64_t>(implemType::kMakutu)}})
-        ->Unit(benchmark::kMillisecond))
+    BuilderConfig, ->ArgsProduct({{0, 1}, {static_cast<int64_t>(implemType::kMakutu)}})->Unit(benchmark::kMillisecond))
 BENCHMARK_FOR_ALL_ORDERS(
     SolverStructFixture, OneStep,
-    BuilderConfig,
-        ->ArgsProduct({{0, 1}, {static_cast<int64_t>(implemType::kMakutu)}})
-        ->Unit(benchmark::kMillisecond))
+    BuilderConfig, ->ArgsProduct({{0, 1}, {static_cast<int64_t>(implemType::kMakutu)}})->Unit(benchmark::kMillisecond))
 
 }  // namespace bench
 }  // namespace model

--- a/tests/benchmarks/cpp/src/bench_solver_fe_cartesian_struct_elastic.cc
+++ b/tests/benchmarks/cpp/src/bench_solver_fe_cartesian_struct_elastic.cc
@@ -18,23 +18,19 @@
 using namespace solver::fe;
 using namespace utils::enums;
 
-namespace model
-{
-namespace bench
-{
+namespace model {
+namespace bench {
 
 // Template config for the fixture
 template <int Order>
-struct BuilderConfig
-{
+struct BuilderConfig {
   using Builder = CartesianStructBuilder<float, int, Order>;
   static constexpr int order = Order;
 };
 
 // Template fixture for the benchmarks
 template <typename T>
-class SolverStructFixture : public benchmark::Fixture
-{
+class SolverStructFixture : public benchmark::Fixture {
  protected:
   // domain decomposition (Mock Serial)
   static constexpr int rank = 0;
@@ -48,13 +44,11 @@ class SolverStructFixture : public benchmark::Fixture
   static constexpr int ez = 100;
   static constexpr float domain_size = 2000.0f;
   static constexpr int order = T::order;
-  static constexpr int n_dof =
-      (ex * order + 1) * (ey * order + 1) * (ez * order + 1);
+  static constexpr int n_dof = (ex * order + 1) * (ey * order + 1) * (ez * order + 1);
   bool isModelOnNodes_;
 
   // sponge
-  inline static constexpr std::array<float, 3> sponge_size = {200.0f, 200.0f,
-                                                              200.0f};
+  inline static constexpr std::array<float, 3> sponge_size = {200.0f, 200.0f, 200.0f};
   inline static constexpr bool surface_sponge = false;
   inline static constexpr float taper_delta = 100.0f;
 
@@ -66,15 +60,13 @@ class SolverStructFixture : public benchmark::Fixture
   static constexpr float f0 = 5.0f;
   implemType implem_;
 
-  void SetUp(const ::benchmark::State& state) override
-  {
+  void SetUp(const ::benchmark::State& state) override {
     isModelOnNodes_ = state.range(0);
     implem_ = static_cast<implemType>(state.range(1));
     local_l = domain_size;
   }
 
-  std::shared_ptr<model::ModelApi<float, int>> createModel()
-  {
+  std::shared_ptr<model::ModelApi<float, int>> createModel() {
     float hx = domain_size / ex;
     float hy = domain_size / ey;
     float hz = domain_size / ez;
@@ -84,17 +76,14 @@ class SolverStructFixture : public benchmark::Fixture
     return builder.getModel(true);
   }
 
-  void setLabel(benchmark::State& state) const
-  {
-    state.SetLabel(
-        "Order=" + to_string(order) + " OnNodes=" + to_string(isModelOnNodes_) +
-        " Implem=" + to_string(implem_) + " IsElastic=" + std::to_string(true));
+  void setLabel(benchmark::State& state) const {
+    state.SetLabel("Order=" + to_string(order) + " OnNodes=" + to_string(isModelOnNodes_) +
+                   " Implem=" + to_string(implem_) + " IsElastic=" + std::to_string(true));
   }
 };
 
 // Structure to hold allocated arrays for benchmarks
-struct BenchmarkArrays
-{
+struct BenchmarkArrays {
   arrayReal rhsTermx;
   arrayReal rhsTermy;
   arrayReal rhsTermz;
@@ -108,15 +97,12 @@ struct BenchmarkArrays
   vectorReal uznGlobalCurr;
   arrayReal rhsLocation;
 
-  BenchmarkArrays(int n_rhs, int n_time_steps, int n_dof,
-                  int nb_points_per_element)
-  {
+  BenchmarkArrays(int n_rhs, int n_time_steps, int n_dof, int nb_points_per_element) {
     rhsTermx = allocateArray2D<arrayReal>(n_rhs, n_time_steps, "rhsTermx");
     rhsTermy = allocateArray2D<arrayReal>(n_rhs, n_time_steps, "rhsTermy");
     rhsTermz = allocateArray2D<arrayReal>(n_rhs, n_time_steps, "rhsTermz");
     rhsElement = allocateVector<vectorInt>(n_rhs, "rhsElement");
-    rhsWeights =
-        allocateArray2D<arrayReal>(n_rhs, nb_points_per_element, "rhsWeights");
+    rhsWeights = allocateArray2D<arrayReal>(n_rhs, nb_points_per_element, "rhsWeights");
     uxnGlobalPrev = allocateVector<vectorReal>(n_dof, "uxnGlobalPrev");
     uynGlobalPrev = allocateVector<vectorReal>(n_dof, "uynGlobalPrev");
     uznGlobalPrev = allocateVector<vectorReal>(n_dof, "uznGlobalPrev");
@@ -130,22 +116,18 @@ struct BenchmarkArrays
 };
 
 BENCHMARK_TEMPLATE_METHOD_F(SolverStructFixture, FEInit)
-(benchmark::State& state)
-{
+(benchmark::State& state) {
   // Prepare
   auto model = this->createModel();
 
-  auto solver = solver_factory::createSolver(
-      methodType::kSem, this->implem_, meshType::kStruct,
-      this->isModelOnNodes_ ? modelLocationType::kOnNodes
-                            : modelLocationType::kOnElements,
-      physicType::kElastic, this->order);
+  auto solver =
+      solver_factory::createSolver(methodType::kSem, this->implem_, meshType::kStruct,
+                                   this->isModelOnNodes_ ? modelLocationType::kOnNodes : modelLocationType::kOnElements,
+                                   physicType::kElastic, this->order);
 
   // Bench
-  for (auto _ : state)
-  {
-    solver->computeFEInit(*model, this->sponge_size, this->surface_sponge,
-                          this->taper_delta);
+  for (auto _ : state) {
+    solver->computeFEInit(*model, this->sponge_size, this->surface_sponge, this->taper_delta);
   }
 
   // Label
@@ -153,50 +135,39 @@ BENCHMARK_TEMPLATE_METHOD_F(SolverStructFixture, FEInit)
 }
 
 BENCHMARK_TEMPLATE_METHOD_F(SolverStructFixture, OneStep)
-(benchmark::State& state)
-{
+(benchmark::State& state) {
   // Prepare
   auto model = this->createModel();
 
-  auto solver = solver_factory::createSolver(
-      methodType::kSem, this->implem_, meshType::kStruct,
-      this->isModelOnNodes_ ? modelLocationType::kOnNodes
-                            : modelLocationType::kOnElements,
-      physicType::kElastic, this->order);
+  auto solver =
+      solver_factory::createSolver(methodType::kSem, this->implem_, meshType::kStruct,
+                                   this->isModelOnNodes_ ? modelLocationType::kOnNodes : modelLocationType::kOnElements,
+                                   physicType::kElastic, this->order);
 
-  solver->computeFEInit(*model, this->sponge_size, this->surface_sponge,
-                        this->taper_delta);
+  solver->computeFEInit(*model, this->sponge_size, this->surface_sponge, this->taper_delta);
 
-  BenchmarkArrays arrays(this->n_rhs, this->n_time_steps, this->n_dof,
-                         model->getNumberOfPointsPerElement());
+  BenchmarkArrays arrays(this->n_rhs, this->n_time_steps, this->n_dof, model->getNumberOfPointsPerElement());
   // sources at the center of the domain
-  arrays.rhsElement(0) = this->ex / 2 + this->ey / 2 * this->ex +
-                         this->ez / 2 * this->ey * this->ex;
-  arrays.rhsElement(1) = this->ex / 3 + this->ey / 2 * this->ex +
-                         this->ez / 2 * this->ey * this->ex;
+  arrays.rhsElement(0) = this->ex / 2 + this->ey / 2 * this->ex + this->ez / 2 * this->ey * this->ex;
+  arrays.rhsElement(1) = this->ex / 3 + this->ey / 2 * this->ex + this->ez / 2 * this->ey * this->ex;
 
   // ricker wavelet
   SolverUtils myUtils;
   float const tpeak = 1.0f / this->f0;
-  std::vector<float> sourceTerm = myUtils.computeSourceTerm(
-      this->n_time_steps, this->dt, this->f0, 2, tpeak);
-  for (int j = 0; j < this->n_time_steps; j++)
-  {
+  std::vector<float> sourceTerm = myUtils.computeSourceTerm(this->n_time_steps, this->dt, this->f0, 2, tpeak);
+  for (int j = 0; j < this->n_time_steps; j++) {
     arrays.rhsTermx(0, j) = sourceTerm[j];
     arrays.rhsTermy(0, j) = sourceTerm[j];
     arrays.rhsTermz(0, j) = sourceTerm[j];
   }
 
-  auto wavefield = WavefieldElastic(arrays.uxnGlobalPrev, arrays.uynGlobalPrev,
-                                    arrays.uznGlobalPrev, arrays.uxnGlobalCurr,
-                                    arrays.uynGlobalCurr, arrays.uznGlobalCurr);
-  auto rhs = RhsElastic(arrays.rhsTermx, arrays.rhsTermy, arrays.rhsTermz,
-                        arrays.rhsElement, arrays.rhsWeights);
+  auto wavefield = WavefieldElastic(arrays.uxnGlobalPrev, arrays.uynGlobalPrev, arrays.uznGlobalPrev,
+                                    arrays.uxnGlobalCurr, arrays.uynGlobalCurr, arrays.uznGlobalCurr);
+  auto rhs = RhsElastic(arrays.rhsTermx, arrays.rhsTermy, arrays.rhsTermz, arrays.rhsElement, arrays.rhsWeights);
   SEMsolverDataElastic data(wavefield, rhs);
 
   // Bench
-  for (auto _ : state)
-  {
+  for (auto _ : state) {
     solver->computeForces(this->dt, this->time_sample, data);
     solver->updateSolution(this->dt, data);
   }
@@ -208,14 +179,10 @@ BENCHMARK_TEMPLATE_METHOD_F(SolverStructFixture, OneStep)
 // Instantiate for all order/isModelOnNodes/implemType combinations
 BENCHMARK_FOR_ALL_ORDERS(
     SolverStructFixture, FEInit,
-    BuilderConfig,
-        ->ArgsProduct({{0, 1}, {static_cast<int64_t>(implemType::kMakutu)}})
-        ->Unit(benchmark::kMillisecond))
+    BuilderConfig, ->ArgsProduct({{0, 1}, {static_cast<int64_t>(implemType::kMakutu)}})->Unit(benchmark::kMillisecond))
 BENCHMARK_FOR_ALL_ORDERS(
     SolverStructFixture, OneStep,
-    BuilderConfig,
-        ->ArgsProduct({{0, 1}, {static_cast<int64_t>(implemType::kMakutu)}})
-        ->Unit(benchmark::kMillisecond))
+    BuilderConfig, ->ArgsProduct({{0, 1}, {static_cast<int64_t>(implemType::kMakutu)}})->Unit(benchmark::kMillisecond))
 
 }  // namespace bench
 }  // namespace model

--- a/tests/benchmarks/cpp/src/bench_solver_fe_cartesian_unstruct_acoustic.cc
+++ b/tests/benchmarks/cpp/src/bench_solver_fe_cartesian_unstruct_acoustic.cc
@@ -17,15 +17,12 @@
 using namespace solver::fe;
 using namespace utils::enums;
 
-namespace model
-{
-namespace bench
-{
+namespace model {
+namespace bench {
 
 // Template config for the fixture
 template <int Order>
-struct BuilderConfig
-{
+struct BuilderConfig {
   using Builder = CartesianUnstructBuilder<float, int>;
   using BuilderParams = CartesianParams<float, int>;
   static constexpr int order = Order;
@@ -33,8 +30,7 @@ struct BuilderConfig
 
 // Template fixture for the benchmarks
 template <typename T>
-class SolverUnstructFixture : public benchmark::Fixture
-{
+class SolverUnstructFixture : public benchmark::Fixture {
  protected:
   // domain decomposition (Mock Serial)
   static constexpr int rank = 0;
@@ -50,13 +46,11 @@ class SolverUnstructFixture : public benchmark::Fixture
   static constexpr float ly = 2000.0f;
   static constexpr float lz = 2000.0f;
   static constexpr int order = T::order;
-  static constexpr int n_dof =
-      (ex * order + 1) * (ey * order + 1) * (ez * order + 1);
+  static constexpr int n_dof = (ex * order + 1) * (ey * order + 1) * (ez * order + 1);
   bool isModelOnNodes_;
 
   // sponge
-  inline static constexpr std::array<float, 3> sponge_size = {200.0f, 200.0f,
-                                                              200.0f};
+  inline static constexpr std::array<float, 3> sponge_size = {200.0f, 200.0f, 200.0f};
   inline static constexpr bool surface_sponge = false;
   inline static constexpr float taper_delta = 100.0f;
 
@@ -68,33 +62,27 @@ class SolverUnstructFixture : public benchmark::Fixture
   static constexpr float f0 = 5.0f;
   implemType implem_;
 
-  void SetUp(const ::benchmark::State& state) override
-  {
+  void SetUp(const ::benchmark::State& state) override {
     isModelOnNodes_ = state.range(0);
     implem_ = static_cast<implemType>(state.range(1));
     local_l = lx;
   }
 
-  std::shared_ptr<model::ModelApi<float, int>> createModel()
-  {
-    typename T::BuilderParams params(order, ex, ey, ez, lx, ly, lz,
-                                     isModelOnNodes_, false);
+  std::shared_ptr<model::ModelApi<float, int>> createModel() {
+    typename T::BuilderParams params(order, ex, ey, ez, lx, ly, lz, isModelOnNodes_, false);
     // params defaults origins to 0.0, correct for serial
     typename T::Builder builder(params);
     return builder.getModel(true);
   }
 
-  void setLabel(benchmark::State& state) const
-  {
-    state.SetLabel("Order=" + std::to_string(order) +
-                   " OnNodes=" + to_string(isModelOnNodes_) + " Implem=" +
-                   to_string(implem_) + " IsElastic=" + std::to_string(false));
+  void setLabel(benchmark::State& state) const {
+    state.SetLabel("Order=" + std::to_string(order) + " OnNodes=" + to_string(isModelOnNodes_) +
+                   " Implem=" + to_string(implem_) + " IsElastic=" + std::to_string(false));
   }
 };
 
 // Unstructure to hold allocated arrays for benchmarks
-struct BenchmarkArrays
-{
+struct BenchmarkArrays {
   arrayReal rhsTerm;
   vectorInt rhsElement;
   arrayReal rhsWeights;
@@ -102,13 +90,10 @@ struct BenchmarkArrays
   vectorReal pnGlobalCurr;
   arrayReal rhsLocation;
 
-  BenchmarkArrays(int n_rhs, int n_time_steps, int n_dof,
-                  int nb_points_per_element)
-  {
+  BenchmarkArrays(int n_rhs, int n_time_steps, int n_dof, int nb_points_per_element) {
     rhsTerm = allocateArray2D<arrayReal>(n_rhs, n_time_steps, "rhsTerm");
     rhsElement = allocateVector<vectorInt>(n_rhs, "rhsElement");
-    rhsWeights =
-        allocateArray2D<arrayReal>(n_rhs, nb_points_per_element, "rhsWeights");
+    rhsWeights = allocateArray2D<arrayReal>(n_rhs, nb_points_per_element, "rhsWeights");
     pnGlobalPrev = allocateVector<vectorReal>(n_dof, "pnGlobalPrev");
     pnGlobalCurr = allocateVector<vectorReal>(n_dof, "pnGlobalCurr");
     rhsLocation = allocateArray2D<arrayReal>(1, 3, "rhsLocation");
@@ -118,22 +103,18 @@ struct BenchmarkArrays
 };
 
 BENCHMARK_TEMPLATE_METHOD_F(SolverUnstructFixture, FEInit)
-(benchmark::State& state)
-{
+(benchmark::State& state) {
   // Prepare
   auto model = this->createModel();
 
-  auto solver = solver_factory::createSolver(
-      methodType::kSem, this->implem_, meshType::kUnstruct,
-      this->isModelOnNodes_ ? modelLocationType::kOnNodes
-                            : modelLocationType::kOnElements,
-      physicType::kAcoustic, this->order);
+  auto solver =
+      solver_factory::createSolver(methodType::kSem, this->implem_, meshType::kUnstruct,
+                                   this->isModelOnNodes_ ? modelLocationType::kOnNodes : modelLocationType::kOnElements,
+                                   physicType::kAcoustic, this->order);
 
   // Bench
-  for (auto _ : state)
-  {
-    solver->computeFEInit(*model, this->sponge_size, this->surface_sponge,
-                          this->taper_delta);
+  for (auto _ : state) {
+    solver->computeFEInit(*model, this->sponge_size, this->surface_sponge, this->taper_delta);
   }
 
   // Label
@@ -141,35 +122,27 @@ BENCHMARK_TEMPLATE_METHOD_F(SolverUnstructFixture, FEInit)
 }
 
 BENCHMARK_TEMPLATE_METHOD_F(SolverUnstructFixture, OneStep)
-(benchmark::State& state)
-{
+(benchmark::State& state) {
   // Prepare
   auto model = this->createModel();
 
-  auto solver = solver_factory::createSolver(
-      methodType::kSem, this->implem_, meshType::kUnstruct,
-      this->isModelOnNodes_ ? modelLocationType::kOnNodes
-                            : modelLocationType::kOnElements,
-      physicType::kAcoustic, this->order);
+  auto solver =
+      solver_factory::createSolver(methodType::kSem, this->implem_, meshType::kUnstruct,
+                                   this->isModelOnNodes_ ? modelLocationType::kOnNodes : modelLocationType::kOnElements,
+                                   physicType::kAcoustic, this->order);
 
-  solver->computeFEInit(*model, this->sponge_size, this->surface_sponge,
-                        this->taper_delta);
+  solver->computeFEInit(*model, this->sponge_size, this->surface_sponge, this->taper_delta);
 
-  BenchmarkArrays arrays(this->n_rhs, this->n_time_steps, this->n_dof,
-                         model->getNumberOfPointsPerElement());
+  BenchmarkArrays arrays(this->n_rhs, this->n_time_steps, this->n_dof, model->getNumberOfPointsPerElement());
   // sources at the center of the domain
-  arrays.rhsElement(0) = this->ex / 2 + this->ey / 2 * this->ex +
-                         this->ez / 2 * this->ey * this->ex;
-  arrays.rhsElement(1) = this->ex / 3 + this->ey / 2 * this->ex +
-                         this->ez / 2 * this->ey * this->ex;
+  arrays.rhsElement(0) = this->ex / 2 + this->ey / 2 * this->ex + this->ez / 2 * this->ey * this->ex;
+  arrays.rhsElement(1) = this->ex / 3 + this->ey / 2 * this->ex + this->ez / 2 * this->ey * this->ex;
 
   // ricker wavelet
   SolverUtils myUtils;
   float const tpeak = 1.0f / this->f0;
-  std::vector<float> sourceTerm = myUtils.computeSourceTerm(
-      this->n_time_steps, this->dt, this->f0, 2, tpeak);
-  for (int j = 0; j < this->n_time_steps; j++)
-  {
+  std::vector<float> sourceTerm = myUtils.computeSourceTerm(this->n_time_steps, this->dt, this->f0, 2, tpeak);
+  for (int j = 0; j < this->n_time_steps; j++) {
     arrays.rhsTerm(0, j) = sourceTerm[j];
   }
 
@@ -178,8 +151,7 @@ BENCHMARK_TEMPLATE_METHOD_F(SolverUnstructFixture, OneStep)
   SEMsolverDataAcoustic data(wavefield, rhs);
 
   // Bench
-  for (auto _ : state)
-  {
+  for (auto _ : state) {
     solver->computeForces(this->dt, this->time_sample, data);
     solver->updateSolution(this->dt, data);
   }
@@ -191,14 +163,10 @@ BENCHMARK_TEMPLATE_METHOD_F(SolverUnstructFixture, OneStep)
 // Instantiate for all order/isModelOnNodes/implemType combinations
 BENCHMARK_FOR_ALL_ORDERS(
     SolverUnstructFixture, FEInit,
-    BuilderConfig,
-        ->ArgsProduct({{0, 1}, {static_cast<int64_t>(implemType::kMakutu)}})
-        ->Unit(benchmark::kMillisecond))
+    BuilderConfig, ->ArgsProduct({{0, 1}, {static_cast<int64_t>(implemType::kMakutu)}})->Unit(benchmark::kMillisecond))
 BENCHMARK_FOR_ALL_ORDERS(
     SolverUnstructFixture, OneStep,
-    BuilderConfig,
-        ->ArgsProduct({{0, 1}, {static_cast<int64_t>(implemType::kMakutu)}})
-        ->Unit(benchmark::kMillisecond))
+    BuilderConfig, ->ArgsProduct({{0, 1}, {static_cast<int64_t>(implemType::kMakutu)}})->Unit(benchmark::kMillisecond))
 
 }  // namespace bench
 }  // namespace model

--- a/tests/benchmarks/cpp/src/bench_solver_fe_cartesian_unstruct_elastic.cc
+++ b/tests/benchmarks/cpp/src/bench_solver_fe_cartesian_unstruct_elastic.cc
@@ -17,15 +17,12 @@
 using namespace solver::fe;
 using namespace utils::enums;
 
-namespace model
-{
-namespace bench
-{
+namespace model {
+namespace bench {
 
 // Template config for the fixture
 template <int Order>
-struct BuilderConfig
-{
+struct BuilderConfig {
   using Builder = CartesianUnstructBuilder<float, int>;
   using BuilderParams = CartesianParams<float, int>;
   static constexpr int order = Order;
@@ -33,8 +30,7 @@ struct BuilderConfig
 
 // Template fixture for the benchmarks
 template <typename T>
-class SolverUnstructFixture : public benchmark::Fixture
-{
+class SolverUnstructFixture : public benchmark::Fixture {
  protected:
   // domain decomposition (Mock Serial)
   static constexpr int rank = 0;
@@ -50,13 +46,11 @@ class SolverUnstructFixture : public benchmark::Fixture
   static constexpr float ly = 2000.0f;
   static constexpr float lz = 2000.0f;
   static constexpr int order = T::order;
-  static constexpr int n_dof =
-      (ex * order + 1) * (ey * order + 1) * (ez * order + 1);
+  static constexpr int n_dof = (ex * order + 1) * (ey * order + 1) * (ez * order + 1);
   bool isModelOnNodes_;
 
   // sponge
-  inline static constexpr std::array<float, 3> sponge_size = {200.0f, 200.0f,
-                                                              200.0f};
+  inline static constexpr std::array<float, 3> sponge_size = {200.0f, 200.0f, 200.0f};
   inline static constexpr bool surface_sponge = false;
   inline static constexpr float taper_delta = 100.0f;
 
@@ -68,32 +62,26 @@ class SolverUnstructFixture : public benchmark::Fixture
   static constexpr float f0 = 5.0f;
   implemType implem_;
 
-  void SetUp(const ::benchmark::State& state) override
-  {
+  void SetUp(const ::benchmark::State& state) override {
     isModelOnNodes_ = state.range(0);
     implem_ = static_cast<implemType>(state.range(1));
     local_l = lx;
   }
 
-  std::shared_ptr<model::ModelApi<float, int>> createModel()
-  {
-    typename T::BuilderParams params(order, ex, ey, ez, lx, ly, lz,
-                                     isModelOnNodes_, true);
+  std::shared_ptr<model::ModelApi<float, int>> createModel() {
+    typename T::BuilderParams params(order, ex, ey, ez, lx, ly, lz, isModelOnNodes_, true);
     typename T::Builder builder(params);
     return builder.getModel(true);
   }
 
-  void setLabel(benchmark::State& state) const
-  {
-    state.SetLabel("Order=" + std::to_string(order) +
-                   " OnNodes=" + to_string(isModelOnNodes_) + " Implem=" +
-                   to_string(implem_) + " IsElastic=" + std::to_string(true));
+  void setLabel(benchmark::State& state) const {
+    state.SetLabel("Order=" + std::to_string(order) + " OnNodes=" + to_string(isModelOnNodes_) +
+                   " Implem=" + to_string(implem_) + " IsElastic=" + std::to_string(true));
   }
 };
 
 // Unstructure to hold allocated arrays for benchmarks
-struct BenchmarkArrays
-{
+struct BenchmarkArrays {
   arrayReal rhsTermx;
   arrayReal rhsTermy;
   arrayReal rhsTermz;
@@ -107,15 +95,12 @@ struct BenchmarkArrays
   vectorReal uznGlobalCurr;
   arrayReal rhsLocation;
 
-  BenchmarkArrays(int n_rhs, int n_time_steps, int n_dof,
-                  int nb_points_per_element)
-  {
+  BenchmarkArrays(int n_rhs, int n_time_steps, int n_dof, int nb_points_per_element) {
     rhsTermx = allocateArray2D<arrayReal>(n_rhs, n_time_steps, "rhsTermx");
     rhsTermy = allocateArray2D<arrayReal>(n_rhs, n_time_steps, "rhsTermy");
     rhsTermz = allocateArray2D<arrayReal>(n_rhs, n_time_steps, "rhsTermz");
     rhsElement = allocateVector<vectorInt>(n_rhs, "rhsElement");
-    rhsWeights =
-        allocateArray2D<arrayReal>(n_rhs, nb_points_per_element, "rhsWeights");
+    rhsWeights = allocateArray2D<arrayReal>(n_rhs, nb_points_per_element, "rhsWeights");
     uxnGlobalPrev = allocateVector<vectorReal>(n_dof, "uxnGlobalPrev");
     uynGlobalPrev = allocateVector<vectorReal>(n_dof, "uynGlobalPrev");
     uznGlobalPrev = allocateVector<vectorReal>(n_dof, "uznGlobalPrev");
@@ -129,22 +114,18 @@ struct BenchmarkArrays
 };
 
 BENCHMARK_TEMPLATE_METHOD_F(SolverUnstructFixture, FEInit)
-(benchmark::State& state)
-{
+(benchmark::State& state) {
   // Prepare
   auto model = this->createModel();
 
-  auto solver = solver_factory::createSolver(
-      methodType::kSem, this->implem_, meshType::kUnstruct,
-      this->isModelOnNodes_ ? modelLocationType::kOnNodes
-                            : modelLocationType::kOnElements,
-      physicType::kElastic, this->order);
+  auto solver =
+      solver_factory::createSolver(methodType::kSem, this->implem_, meshType::kUnstruct,
+                                   this->isModelOnNodes_ ? modelLocationType::kOnNodes : modelLocationType::kOnElements,
+                                   physicType::kElastic, this->order);
 
   // Bench
-  for (auto _ : state)
-  {
-    solver->computeFEInit(*model, this->sponge_size, this->surface_sponge,
-                          this->taper_delta);
+  for (auto _ : state) {
+    solver->computeFEInit(*model, this->sponge_size, this->surface_sponge, this->taper_delta);
   }
 
   // Label
@@ -152,50 +133,39 @@ BENCHMARK_TEMPLATE_METHOD_F(SolverUnstructFixture, FEInit)
 }
 
 BENCHMARK_TEMPLATE_METHOD_F(SolverUnstructFixture, OneStep)
-(benchmark::State& state)
-{
+(benchmark::State& state) {
   // Prepare
   auto model = this->createModel();
 
-  auto solver = solver_factory::createSolver(
-      methodType::kSem, this->implem_, meshType::kUnstruct,
-      this->isModelOnNodes_ ? modelLocationType::kOnNodes
-                            : modelLocationType::kOnElements,
-      physicType::kElastic, this->order);
+  auto solver =
+      solver_factory::createSolver(methodType::kSem, this->implem_, meshType::kUnstruct,
+                                   this->isModelOnNodes_ ? modelLocationType::kOnNodes : modelLocationType::kOnElements,
+                                   physicType::kElastic, this->order);
 
-  solver->computeFEInit(*model, this->sponge_size, this->surface_sponge,
-                        this->taper_delta);
+  solver->computeFEInit(*model, this->sponge_size, this->surface_sponge, this->taper_delta);
 
-  BenchmarkArrays arrays(this->n_rhs, this->n_time_steps, this->n_dof,
-                         model->getNumberOfPointsPerElement());
+  BenchmarkArrays arrays(this->n_rhs, this->n_time_steps, this->n_dof, model->getNumberOfPointsPerElement());
   // sources at the center of the domain
-  arrays.rhsElement(0) = this->ex / 2 + this->ey / 2 * this->ex +
-                         this->ez / 2 * this->ey * this->ex;
-  arrays.rhsElement(1) = this->ex / 3 + this->ey / 2 * this->ex +
-                         this->ez / 2 * this->ey * this->ex;
+  arrays.rhsElement(0) = this->ex / 2 + this->ey / 2 * this->ex + this->ez / 2 * this->ey * this->ex;
+  arrays.rhsElement(1) = this->ex / 3 + this->ey / 2 * this->ex + this->ez / 2 * this->ey * this->ex;
 
   // ricker wavelet
   SolverUtils myUtils;
   float const tpeak = 1.0f / this->f0;
-  std::vector<float> sourceTerm = myUtils.computeSourceTerm(
-      this->n_time_steps, this->dt, this->f0, 2, tpeak);
-  for (int j = 0; j < this->n_time_steps; j++)
-  {
+  std::vector<float> sourceTerm = myUtils.computeSourceTerm(this->n_time_steps, this->dt, this->f0, 2, tpeak);
+  for (int j = 0; j < this->n_time_steps; j++) {
     arrays.rhsTermx(0, j) = sourceTerm[j];
     arrays.rhsTermy(0, j) = sourceTerm[j];
     arrays.rhsTermz(0, j) = sourceTerm[j];
   }
 
-  auto wavefield = WavefieldElastic(arrays.uxnGlobalPrev, arrays.uynGlobalPrev,
-                                    arrays.uznGlobalPrev, arrays.uxnGlobalCurr,
-                                    arrays.uynGlobalCurr, arrays.uznGlobalCurr);
-  auto rhs = RhsElastic(arrays.rhsTermx, arrays.rhsTermy, arrays.rhsTermz,
-                        arrays.rhsElement, arrays.rhsWeights);
+  auto wavefield = WavefieldElastic(arrays.uxnGlobalPrev, arrays.uynGlobalPrev, arrays.uznGlobalPrev,
+                                    arrays.uxnGlobalCurr, arrays.uynGlobalCurr, arrays.uznGlobalCurr);
+  auto rhs = RhsElastic(arrays.rhsTermx, arrays.rhsTermy, arrays.rhsTermz, arrays.rhsElement, arrays.rhsWeights);
   SEMsolverDataElastic data(wavefield, rhs);
 
   // Bench
-  for (auto _ : state)
-  {
+  for (auto _ : state) {
     solver->computeForces(this->dt, this->time_sample, data);
     solver->updateSolution(this->dt, data);
   }
@@ -207,14 +177,10 @@ BENCHMARK_TEMPLATE_METHOD_F(SolverUnstructFixture, OneStep)
 // Instantiate for all order/isModelOnNodes/implemType combinations
 BENCHMARK_FOR_ALL_ORDERS(
     SolverUnstructFixture, FEInit,
-    BuilderConfig,
-        ->ArgsProduct({{0, 1}, {static_cast<int64_t>(implemType::kMakutu)}})
-        ->Unit(benchmark::kMillisecond))
+    BuilderConfig, ->ArgsProduct({{0, 1}, {static_cast<int64_t>(implemType::kMakutu)}})->Unit(benchmark::kMillisecond))
 BENCHMARK_FOR_ALL_ORDERS(
     SolverUnstructFixture, OneStep,
-    BuilderConfig,
-        ->ArgsProduct({{0, 1}, {static_cast<int64_t>(implemType::kMakutu)}})
-        ->Unit(benchmark::kMillisecond))
+    BuilderConfig, ->ArgsProduct({{0, 1}, {static_cast<int64_t>(implemType::kMakutu)}})->Unit(benchmark::kMillisecond))
 
 }  // namespace bench
 }  // namespace model

--- a/tests/units/discretization/fe/makutu/test_Qk_Hexahedron.cpp
+++ b/tests/units/discretization/fe/makutu/test_Qk_Hexahedron.cpp
@@ -12,9 +12,8 @@
 
 // Tolerances for floating point comparisons
 // Adapted for float precision (real_t is float by default)
-constexpr double TOL = 1.0e-10;  // For exact tests
-constexpr double TOL_NUMERICAL =
-    1.0e-4;  // For numerical integration (accumulation errors)
+constexpr double TOL = 1.0e-10;           // For exact tests
+constexpr double TOL_NUMERICAL = 1.0e-4;  // For numerical integration (accumulation errors)
 
 #ifdef USE_DOUBLE
 constexpr double TOL_MATRIX_INVERSION = 1e-12;  // For double precision
@@ -30,9 +29,7 @@ constexpr double TOL_MATRIX_INVERSION = 1e-6;  // For float precision
  * @brief Creates an arbitrary cube [x0, x0+size]^3
  */
 template <typename BASIS>
-void createArbitraryCube(real_t (&X)[8][3], real_t x0, real_t y0, real_t z0,
-                         real_t size)
-{
+void createArbitraryCube(real_t (&X)[8][3], real_t x0, real_t y0, real_t z0, real_t size) {
   X[0][0] = x0;
   X[0][1] = y0;
   X[0][2] = z0;
@@ -63,8 +60,7 @@ void createArbitraryCube(real_t (&X)[8][3], real_t x0, real_t y0, real_t z0,
  * @brief Creates a reference hexahedron [-1,1]^3
  */
 template <typename BASIS>
-void createReferenceHex(real_t (&X)[8][3])
-{
+void createReferenceHex(real_t (&X)[8][3]) {
   createArbitraryCube<BASIS>(X, -1.0, -1.0, -1.0, 2.0);
 }
 
@@ -72,20 +68,16 @@ void createReferenceHex(real_t (&X)[8][3])
  * @brief Creates a unit hexahedron [0,1]^3
  */
 template <typename BASIS>
-void createUnitHex(real_t (&X)[8][3])
-{
+void createUnitHex(real_t (&X)[8][3]) {
   createArbitraryCube<BASIS>(X, 0.0, 0.0, 0.0, 1.0);
 }
 
 /**
  * @brief Helper to compute matrix-matrix product
  */
-void matMul3x3(real_t const (&A)[3][3], real_t const (&B)[3][3],
-               real_t (&C)[3][3])
-{
+void matMul3x3(real_t const (&A)[3][3], real_t const (&B)[3][3], real_t (&C)[3][3]) {
   for (int i = 0; i < 3; ++i)
-    for (int j = 0; j < 3; ++j)
-    {
+    for (int j = 0; j < 3; ++j) {
       C[i][j] = 0.0;
       for (int k = 0; k < 3; ++k) C[i][j] += A[i][k] * B[k][j];
     }
@@ -94,11 +86,9 @@ void matMul3x3(real_t const (&A)[3][3], real_t const (&B)[3][3],
 /**
  * @brief Check if matrix is identity
  */
-bool isIdentity(real_t const (&M)[3][3], double tol = TOL)
-{
+bool isIdentity(real_t const (&M)[3][3], double tol = TOL) {
   for (int i = 0; i < 3; ++i)
-    for (int j = 0; j < 3; ++j)
-    {
+    for (int j = 0; j < 3; ++j) {
       real_t expected = (i == j) ? 1.0 : 0.0;
       if (std::abs(M[i][j] - expected) > tol) return false;
     }
@@ -109,55 +99,36 @@ bool isIdentity(real_t const (&M)[3][3], double tol = TOL)
 // TEST FIXTURES
 // ============================================================================
 
-using TestedBases = ::testing::Types<
-    Q1_Hexahedron_Lagrange_GaussLobatto, Q2_Hexahedron_Lagrange_GaussLobatto,
-    Q3_Hexahedron_Lagrange_GaussLobatto, Q4_Hexahedron_Lagrange_GaussLobatto,
-    Q5_Hexahedron_Lagrange_GaussLobatto>;
+using TestedBases = ::testing::Types<Q1_Hexahedron_Lagrange_GaussLobatto, Q2_Hexahedron_Lagrange_GaussLobatto,
+                                     Q3_Hexahedron_Lagrange_GaussLobatto, Q4_Hexahedron_Lagrange_GaussLobatto,
+                                     Q5_Hexahedron_Lagrange_GaussLobatto>;
 
 template <typename QK_BASIS>
-class MassMatrixTest : public ::testing::Test
-{
-};
+class MassMatrixTest : public ::testing::Test {};
 
 template <typename QK_BASIS>
-class StiffnessMatrixTest : public ::testing::Test
-{
-};
+class StiffnessMatrixTest : public ::testing::Test {};
 
 template <typename QK_BASIS>
-class JacobianTest : public ::testing::Test
-{
-};
+class JacobianTest : public ::testing::Test {};
 
 template <typename QK_BASIS>
-class InterpolationTest : public ::testing::Test
-{
-};
+class InterpolationTest : public ::testing::Test {};
 
 template <typename QK_BASIS>
-class GradientTest : public ::testing::Test
-{
-};
+class GradientTest : public ::testing::Test {};
 
 template <typename QK_BASIS>
-class IndexingTest : public ::testing::Test
-{
-};
+class IndexingTest : public ::testing::Test {};
 
 template <typename QK_BASIS>
-class BMatrixTest : public ::testing::Test
-{
-};
+class BMatrixTest : public ::testing::Test {};
 
 template <typename QK_BASIS>
-class BasisGradientTest : public ::testing::Test
-{
-};
+class BasisGradientTest : public ::testing::Test {};
 
 template <typename QK_BASIS>
-class FaceOperationsTest : public ::testing::Test
-{
-};
+class FaceOperationsTest : public ::testing::Test {};
 
 TYPED_TEST_SUITE(MassMatrixTest, TestedBases);
 TYPED_TEST_SUITE(StiffnessMatrixTest, TestedBases);
@@ -173,14 +144,12 @@ TYPED_TEST_SUITE(FaceOperationsTest, TestedBases);
 // MASS MATRIX TESTS
 // ============================================================================
 
-TYPED_TEST(MassMatrixTest, MassMatrixSumEqualsVolume_VariousCubes)
-{
+TYPED_TEST(MassMatrixTest, MassMatrixSumEqualsVolume_VariousCubes) {
   using QK = TypeParam;
   constexpr int numNodes = QK::numNodes;
 
   // Test with different cube configurations
-  struct CubeConfig
-  {
+  struct CubeConfig {
     real_t x0, y0, z0, size;
     real_t expectedVolume;
   };
@@ -193,8 +162,7 @@ TYPED_TEST(MassMatrixTest, MassMatrixSumEqualsVolume_VariousCubes)
       {1.5, -0.5, 0.3, 2.5, 15.625}   // Another arbitrary cube
   };
 
-  for (const auto& config : configs)
-  {
+  for (const auto& config : configs) {
     real_t X[8][3];
     createArbitraryCube<QK>(X, config.x0, config.y0, config.z0, config.size);
 
@@ -203,21 +171,18 @@ TYPED_TEST(MassMatrixTest, MassMatrixSumEqualsVolume_VariousCubes)
       for (int i = 0; i < 3; ++i) transformData.data[k][i] = X[k][i];
 
     real_t mass[numNodes] = {0};
-    QK::computeMassTerm(transformData,
-                        [&](int q, real_t val) { mass[q] = val; });
+    QK::computeMassTerm(transformData, [&](int q, real_t val) { mass[q] = val; });
 
     real_t totalMass = 0.0;
     for (int i = 0; i < numNodes; ++i) totalMass += mass[i];
 
     EXPECT_NEAR(totalMass, config.expectedVolume, TOL_NUMERICAL)
-        << "Sum of mass matrix should equal element volume" << " for cube at ("
-        << config.x0 << "," << config.y0 << "," << config.z0 << ") with size "
-        << config.size;
+        << "Sum of mass matrix should equal element volume" << " for cube at (" << config.x0 << "," << config.y0 << ","
+        << config.z0 << ") with size " << config.size;
   }
 }
 
-TYPED_TEST(MassMatrixTest, MassMatrixPositive)
-{
+TYPED_TEST(MassMatrixTest, MassMatrixPositive) {
   using QK = TypeParam;
   constexpr int numNodes = QK::numNodes;
 
@@ -231,8 +196,7 @@ TYPED_TEST(MassMatrixTest, MassMatrixPositive)
   real_t mass[numNodes] = {0};
   QK::computeMassTerm(transformData, [&](int q, real_t val) { mass[q] = val; });
 
-  for (int i = 0; i < numNodes; ++i)
-  {
+  for (int i = 0; i < numNodes; ++i) {
     EXPECT_GT(mass[i], 0.0) << "All mass matrix entries should be positive";
   }
 }
@@ -241,22 +205,18 @@ TYPED_TEST(MassMatrixTest, MassMatrixPositive)
 // STIFFNESS MATRIX TESTS
 // ============================================================================
 
-TYPED_TEST(StiffnessMatrixTest, StiffnessTimesConstantIsZero_VariousCubes)
-{
+TYPED_TEST(StiffnessMatrixTest, StiffnessTimesConstantIsZero_VariousCubes) {
   using QK = TypeParam;
   constexpr int numNodes = QK::numNodes;
 
   // Test with different cubes
-  struct CubeConfig
-  {
+  struct CubeConfig {
     real_t x0, y0, z0, size;
   };
 
-  CubeConfig configs[] = {
-      {0.0, 0.0, 0.0, 1.0}, {-5.0, 2.0, -1.0, 2.5}, {10.0, -3.0, 5.0, 0.75}};
+  CubeConfig configs[] = {{0.0, 0.0, 0.0, 1.0}, {-5.0, 2.0, -1.0, 2.5}, {10.0, -3.0, 5.0, 0.75}};
 
-  for (const auto& config : configs)
-  {
+  for (const auto& config : configs) {
     real_t X[8][3];
     createArbitraryCube<QK>(X, config.x0, config.y0, config.z0, config.size);
 
@@ -270,21 +230,17 @@ TYPED_TEST(StiffnessMatrixTest, StiffnessTimesConstantIsZero_VariousCubes)
     for (int i = 0; i < numNodes; ++i) u[i] = 1.0;
 
     QK::computeStiffnessTerm(
-        transformData, [](int qa, int qb, int qc) {},
-        [&](int i, int j, real_t Kij) { Ku[i] += Kij * u[j]; });
+        transformData, [](int qa, int qb, int qc) {}, [&](int i, int j, real_t Kij) { Ku[i] += Kij * u[j]; });
 
-    for (int i = 0; i < numNodes; ++i)
-    {
+    for (int i = 0; i < numNodes; ++i) {
       EXPECT_NEAR(Ku[i], 0.0, TOL_NUMERICAL)
           << "K*u should be zero for constant u (partition of unity property)"
-          << " for cube at (" << config.x0 << "," << config.y0 << ","
-          << config.z0 << ") with size " << config.size;
+          << " for cube at (" << config.x0 << "," << config.y0 << "," << config.z0 << ") with size " << config.size;
     }
   }
 }
 
-TYPED_TEST(StiffnessMatrixTest, StiffnessMatrixIsSymmetric)
-{
+TYPED_TEST(StiffnessMatrixTest, StiffnessMatrixIsSymmetric) {
   using QK = TypeParam;
   constexpr int numNodes = QK::numNodes;
 
@@ -298,16 +254,12 @@ TYPED_TEST(StiffnessMatrixTest, StiffnessMatrixIsSymmetric)
   real_t K[numNodes][numNodes] = {{0}};
 
   QK::computeStiffnessTerm(
-      transformData, [](int qa, int qb, int qc) {},
-      [&](int i, int j, real_t Kij) { K[i][j] += Kij; });
+      transformData, [](int qa, int qb, int qc) {}, [&](int i, int j, real_t Kij) { K[i][j] += Kij; });
 
-  for (int i = 0; i < numNodes; ++i)
-  {
-    for (int j = i + 1; j < numNodes; ++j)
-    {
+  for (int i = 0; i < numNodes; ++i) {
+    for (int j = i + 1; j < numNodes; ++j) {
       EXPECT_NEAR(K[i][j], K[j][i], TOL_NUMERICAL)
-          << "Stiffness matrix should be symmetric: K[" << i << "][" << j
-          << "] != K[" << j << "][" << i << "]";
+          << "Stiffness matrix should be symmetric: K[" << i << "][" << j << "] != K[" << j << "][" << i << "]";
     }
   }
 }
@@ -316,26 +268,21 @@ TYPED_TEST(StiffnessMatrixTest, StiffnessMatrixIsSymmetric)
 // JACOBIAN TESTS
 // ============================================================================
 
-TYPED_TEST(JacobianTest, JacobianDeterminantPositive_VariousCubes)
-{
+TYPED_TEST(JacobianTest, JacobianDeterminantPositive_VariousCubes) {
   using QK = TypeParam;
 
   // Test with different cubes
-  struct CubeConfig
-  {
+  struct CubeConfig {
     real_t x0, y0, z0, size;
   };
 
-  CubeConfig configs[] = {
-      {0.0, 0.0, 0.0, 1.0}, {-2.0, 3.0, -1.0, 0.5}, {5.0, -5.0, 2.0, 3.0}};
+  CubeConfig configs[] = {{0.0, 0.0, 0.0, 1.0}, {-2.0, 3.0, -1.0, 0.5}, {5.0, -5.0, 2.0, 3.0}};
 
-  for (const auto& config : configs)
-  {
+  for (const auto& config : configs) {
     real_t X[8][3];
     createArbitraryCube<QK>(X, config.x0, config.y0, config.z0, config.size);
 
-    for (int q = 0; q < QK::numQuadraturePoints; ++q)
-    {
+    for (int q = 0; q < QK::numQuadraturePoints; ++q) {
       int qa, qb, qc;
       QK::BasisType::TensorProduct3D::multiIndex(q, qa, qb, qc);
 
@@ -344,37 +291,29 @@ TYPED_TEST(JacobianTest, JacobianDeterminantPositive_VariousCubes)
 
       real_t detJ = determinant(J);
 
-      EXPECT_GT(detJ, 0.0)
-          << "Jacobian determinant should be positive at quadrature point " << q
-          << " for cube at (" << config.x0 << "," << config.y0 << ","
-          << config.z0 << ") with size " << config.size;
+      EXPECT_GT(detJ, 0.0) << "Jacobian determinant should be positive at quadrature point " << q << " for cube at ("
+                           << config.x0 << "," << config.y0 << "," << config.z0 << ") with size " << config.size;
     }
   }
 }
 
-TYPED_TEST(JacobianTest, InverseJacobianCorrectness_VariousCubes)
-{
+TYPED_TEST(JacobianTest, InverseJacobianCorrectness_VariousCubes) {
   using QK = TypeParam;
 
   // Test with different cubes
-  struct CubeConfig
-  {
+  struct CubeConfig {
     real_t x0, y0, z0, size;
   };
 
-  CubeConfig configs[] = {
-      {0.0, 0.0, 0.0, 1.0}, {-10.0, 5.0, -3.0, 2.0}, {3.5, -1.5, 0.5, 0.8}};
+  CubeConfig configs[] = {{0.0, 0.0, 0.0, 1.0}, {-10.0, 5.0, -3.0, 2.0}, {3.5, -1.5, 0.5, 0.8}};
 
-  for (const auto& config : configs)
-  {
+  for (const auto& config : configs) {
     real_t X[8][3];
     createArbitraryCube<QK>(X, config.x0, config.y0, config.z0, config.size);
 
     // Test a few quadrature points
-    int numTestPoints =
-        (QK::numQuadraturePoints < 5) ? QK::numQuadraturePoints : 5;
-    for (int q = 0; q < numTestPoints; ++q)
-    {
+    int numTestPoints = (QK::numQuadraturePoints < 5) ? QK::numQuadraturePoints : 5;
+    for (int q = 0; q < numTestPoints; ++q) {
       real_t J[3][3] = {{0}};
       real_t invJ[3][3] = {{0}};
       real_t identity[3][3] = {{0}};
@@ -392,40 +331,33 @@ TYPED_TEST(JacobianTest, InverseJacobianCorrectness_VariousCubes)
       matMul3x3(J, invJ, identity);
 
       EXPECT_TRUE(isIdentity(identity, TOL_MATRIX_INVERSION))
-          << "J * J^-1 should equal identity matrix at quadrature point " << q
-          << " for cube at (" << config.x0 << "," << config.y0 << ","
-          << config.z0 << ") with size " << config.size;
+          << "J * J^-1 should equal identity matrix at quadrature point " << q << " for cube at (" << config.x0 << ","
+          << config.y0 << "," << config.z0 << ") with size " << config.size;
     }
   }
 }
 
-TYPED_TEST(JacobianTest, ShapeFunctionsPartitionOfUnity)
-{
+TYPED_TEST(JacobianTest, ShapeFunctionsPartitionOfUnity) {
   using QK = TypeParam;
   constexpr int numNodes = QK::numNodes;
 
   // Test points in reference space
-  real_t testPoints[][3] = {
-      {0.0, 0.0, 0.0}, {0.5, 0.5, 0.5}, {-0.7, 0.3, 0.1}, {0.9, -0.5, 0.8}};
+  real_t testPoints[][3] = {{0.0, 0.0, 0.0}, {0.5, 0.5, 0.5}, {-0.7, 0.3, 0.1}, {0.9, -0.5, 0.8}};
   constexpr int numTestPoints = 4;
 
-  for (int pt = 0; pt < numTestPoints; ++pt)
-  {
+  for (int pt = 0; pt < numTestPoints; ++pt) {
     double N[numNodes];
-    double coords[3] = {testPoints[pt][0], testPoints[pt][1],
-                        testPoints[pt][2]};
+    double coords[3] = {testPoints[pt][0], testPoints[pt][1], testPoints[pt][2]};
     QK::calcN(coords, N);
 
     double sum = 0.0;
     for (int i = 0; i < numNodes; ++i) sum += N[i];
 
-    EXPECT_NEAR(sum, 1.0, TOL)
-        << "Sum of shape functions should be 1 (partition of unity)";
+    EXPECT_NEAR(sum, 1.0, TOL) << "Sum of shape functions should be 1 (partition of unity)";
   }
 }
 
-TYPED_TEST(JacobianTest, GradientConsistency)
-{
+TYPED_TEST(JacobianTest, GradientConsistency) {
   using QK = TypeParam;
   constexpr int numNodes = QK::numNodes;
 
@@ -433,13 +365,10 @@ TYPED_TEST(JacobianTest, GradientConsistency)
   createArbitraryCube<QK>(X, -1.2, 0.5, 2.3, 1.5);
 
   real_t Xfull[numNodes][3];
-  if constexpr (numNodes == 8)
-  {
+  if constexpr (numNodes == 8) {
     for (int i = 0; i < 8; ++i)
       for (int j = 0; j < 3; ++j) Xfull[i][j] = X[i][j];
-  }
-  else
-  {
+  } else {
     QK::computeLocalCoords(X, Xfull);
   }
 
@@ -451,48 +380,38 @@ TYPED_TEST(JacobianTest, GradientConsistency)
   real_t detJ1 = QK::calcGradN(q, Xfull, gradN1);
   real_t detJ2 = QK::calcGradNWithCorners(q, X, gradN2);
 
-  EXPECT_NEAR(detJ1, detJ2, TOL_NUMERICAL)
-      << "Two gradient computation methods should be consistent";
+  EXPECT_NEAR(detJ1, detJ2, TOL_NUMERICAL) << "Two gradient computation methods should be consistent";
 
-  for (int i = 0; i < numNodes; ++i)
-  {
-    for (int j = 0; j < 3; ++j)
-    {
+  for (int i = 0; i < numNodes; ++i) {
+    for (int j = 0; j < 3; ++j) {
       EXPECT_NEAR(gradN1[i][j], gradN2[i][j], TOL_NUMERICAL)
           << "gradN[" << i << "][" << j << "] inconsistent between methods";
     }
   }
 }
 
-TYPED_TEST(JacobianTest, QuadratureRuleIntegratesConstant_VariousCubes)
-{
+TYPED_TEST(JacobianTest, QuadratureRuleIntegratesConstant_VariousCubes) {
   using QK = TypeParam;
 
   // Test with different cubes
-  struct CubeConfig
-  {
+  struct CubeConfig {
     real_t x0, y0, z0, size;
     real_t expectedVolume;
   };
 
-  CubeConfig configs[] = {{0.0, 0.0, 0.0, 1.0, 1.0},
-                          {-5.0, 2.0, -1.0, 2.0, 8.0},
-                          {3.0, -2.0, 1.0, 0.5, 0.125}};
+  CubeConfig configs[] = {{0.0, 0.0, 0.0, 1.0, 1.0}, {-5.0, 2.0, -1.0, 2.0, 8.0}, {3.0, -2.0, 1.0, 0.5, 0.125}};
 
-  for (const auto& config : configs)
-  {
+  for (const auto& config : configs) {
     real_t X[8][3];
     createArbitraryCube<QK>(X, config.x0, config.y0, config.z0, config.size);
 
     real_t integral = 0.0;
 
-    for (int q = 0; q < QK::numQuadraturePoints; ++q)
-    {
+    for (int q = 0; q < QK::numQuadraturePoints; ++q) {
       int qa, qb, qc;
       QK::BasisType::TensorProduct3D::multiIndex(q, qa, qb, qc);
 
-      real_t w = QK::BasisType::weight(qa) * QK::BasisType::weight(qb) *
-                 QK::BasisType::weight(qc);
+      real_t w = QK::BasisType::weight(qa) * QK::BasisType::weight(qb) * QK::BasisType::weight(qc);
 
       real_t J[3][3] = {{0}};
       QK::jacobianTransformation(qa, qb, qc, X, J);
@@ -503,13 +422,11 @@ TYPED_TEST(JacobianTest, QuadratureRuleIntegratesConstant_VariousCubes)
 
     EXPECT_NEAR(integral, config.expectedVolume, TOL_NUMERICAL)
         << "Quadrature rule should exactly integrate constant functions"
-        << " for cube at (" << config.x0 << "," << config.y0 << "," << config.z0
-        << ") with size " << config.size;
+        << " for cube at (" << config.x0 << "," << config.y0 << "," << config.z0 << ") with size " << config.size;
   }
 }
 
-TYPED_TEST(JacobianTest, TransformedQuadratureWeightConsistency)
-{
+TYPED_TEST(JacobianTest, TransformedQuadratureWeightConsistency) {
   using QK = TypeParam;
 
   real_t X[8][3];
@@ -518,13 +435,11 @@ TYPED_TEST(JacobianTest, TransformedQuadratureWeightConsistency)
   real_t totalWeight = 0.0;
   real_t expectedVolume = 1.8 * 1.8 * 1.8;
 
-  for (int q = 0; q < QK::numQuadraturePoints; ++q)
-  {
+  for (int q = 0; q < QK::numQuadraturePoints; ++q) {
     int qa, qb, qc;
     QK::BasisType::TensorProduct3D::multiIndex(q, qa, qb, qc);
 
-    real_t w = QK::BasisType::weight(qa) * QK::BasisType::weight(qb) *
-               QK::BasisType::weight(qc);
+    real_t w = QK::BasisType::weight(qa) * QK::BasisType::weight(qb) * QK::BasisType::weight(qc);
 
     real_t J[3][3] = {{0}};
     QK::jacobianTransformation(qa, qb, qc, X, J);
@@ -541,42 +456,33 @@ TYPED_TEST(JacobianTest, TransformedQuadratureWeightConsistency)
 // INTERPOLATION TESTS
 // ============================================================================
 
-TYPED_TEST(InterpolationTest, TrilinearInterpAtCorners)
-{
+TYPED_TEST(InterpolationTest, TrilinearInterpAtCorners) {
   using QK = TypeParam;
 
   real_t X[8][3];
   createUnitHex<QK>(X);
 
   // Corner test data: alpha, beta, gamma, expected corner index
-  struct CornerTest
-  {
+  struct CornerTest {
     real_t alpha, beta, gamma;
     int idx;
   };
 
-  CornerTest corners[] = {{0.0, 0.0, 0.0, 0}, {1.0, 0.0, 0.0, 1},
-                          {0.0, 1.0, 0.0, 2}, {1.0, 1.0, 0.0, 3},
-                          {0.0, 0.0, 1.0, 4}, {1.0, 0.0, 1.0, 5},
-                          {0.0, 1.0, 1.0, 6}, {1.0, 1.0, 1.0, 7}};
+  CornerTest corners[] = {{0.0, 0.0, 0.0, 0}, {1.0, 0.0, 0.0, 1}, {0.0, 1.0, 0.0, 2}, {1.0, 1.0, 0.0, 3},
+                          {0.0, 0.0, 1.0, 4}, {1.0, 0.0, 1.0, 5}, {0.0, 1.0, 1.0, 6}, {1.0, 1.0, 1.0, 7}};
 
-  for (int c = 0; c < 8; ++c)
-  {
+  for (int c = 0; c < 8; ++c) {
     real_t coords[3];
-    QK::trilinearInterp(corners[c].alpha, corners[c].beta, corners[c].gamma, X,
-                        coords);
+    QK::trilinearInterp(corners[c].alpha, corners[c].beta, corners[c].gamma, X, coords);
 
-    for (int i = 0; i < 3; ++i)
-    {
+    for (int i = 0; i < 3; ++i) {
       EXPECT_NEAR(coords[i], X[corners[c].idx][i], TOL)
-          << "Trilinear interpolation at corner " << corners[c].idx
-          << " should match corner coordinates";
+          << "Trilinear interpolation at corner " << corners[c].idx << " should match corner coordinates";
     }
   }
 }
 
-TYPED_TEST(InterpolationTest, TrilinearInterpAtCenter_ArbitraryCube)
-{
+TYPED_TEST(InterpolationTest, TrilinearInterpAtCenter_ArbitraryCube) {
   using QK = TypeParam;
 
   real_t x0 = 3.5, y0 = -2.0, z0 = 1.5, size = 2.0;
@@ -594,8 +500,7 @@ TYPED_TEST(InterpolationTest, TrilinearInterpAtCenter_ArbitraryCube)
   EXPECT_NEAR(coords[2], expectedCenter[2], TOL);
 }
 
-TYPED_TEST(InterpolationTest, ComputeLocalCoordsConsistency)
-{
+TYPED_TEST(InterpolationTest, ComputeLocalCoordsConsistency) {
   using QK = TypeParam;
   constexpr int numNodes = QK::numNodes;
 
@@ -605,29 +510,22 @@ TYPED_TEST(InterpolationTest, ComputeLocalCoordsConsistency)
   real_t X[numNodes][3];
   QK::computeLocalCoords(Xmesh, X);
 
-  for (int k = 0; k < 8; ++k)
-  {
+  for (int k = 0; k < 8; ++k) {
     int nodeIdx = QK::meshIndexToLinearIndex3D(k);
-    for (int i = 0; i < 3; ++i)
-    {
-      EXPECT_NEAR(X[nodeIdx][i], Xmesh[k][i], TOL)
-          << "Corner node " << k << " should match mesh corner";
+    for (int i = 0; i < 3; ++i) {
+      EXPECT_NEAR(X[nodeIdx][i], Xmesh[k][i], TOL) << "Corner node " << k << " should match mesh corner";
     }
   }
 }
 
-TYPED_TEST(InterpolationTest, InterpolationCoefficientsSum)
-{
+TYPED_TEST(InterpolationTest, InterpolationCoefficientsSum) {
   using QK = TypeParam;
 
-  for (int q = 0; q < QK::num1dNodes; ++q)
-  {
+  for (int q = 0; q < QK::num1dNodes; ++q) {
     real_t c0 = QK::interpolationCoord(q, 0);
     real_t c1 = QK::interpolationCoord(q, 1);
 
-    EXPECT_NEAR(c0 + c1, 1.0, TOL)
-        << "Interpolation coefficients should sum to 1 at quadrature point "
-        << q;
+    EXPECT_NEAR(c0 + c1, 1.0, TOL) << "Interpolation coefficients should sum to 1 at quadrature point " << q;
 
     EXPECT_GE(c0, 0.0) << "Interpolation coefficient should be non-negative";
     EXPECT_LE(c0, 1.0) << "Interpolation coefficient should be ≤ 1";
@@ -636,18 +534,15 @@ TYPED_TEST(InterpolationTest, InterpolationCoefficientsSum)
   }
 }
 
-TYPED_TEST(InterpolationTest, InterpolationCoefficientsAtBoundaries)
-{
+TYPED_TEST(InterpolationTest, InterpolationCoefficientsAtBoundaries) {
   using QK = TypeParam;
   constexpr int num1d = QK::num1dNodes;
 
   real_t c0_first = QK::interpolationCoord(0, 0);
   real_t c1_first = QK::interpolationCoord(0, 1);
 
-  EXPECT_NEAR(c0_first, 1.0, TOL)
-      << "At first node, k=0 coefficient should be 1";
-  EXPECT_NEAR(c1_first, 0.0, TOL)
-      << "At first node, k=1 coefficient should be 0";
+  EXPECT_NEAR(c0_first, 1.0, TOL) << "At first node, k=0 coefficient should be 1";
+  EXPECT_NEAR(c1_first, 0.0, TOL) << "At first node, k=1 coefficient should be 0";
 
   real_t c0_last = QK::interpolationCoord(num1d - 1, 0);
   real_t c1_last = QK::interpolationCoord(num1d - 1, 1);
@@ -660,8 +555,7 @@ TYPED_TEST(InterpolationTest, InterpolationCoefficientsAtBoundaries)
 // GRADIENT OPERATOR TESTS
 // ============================================================================
 
-TYPED_TEST(GradientTest, GradientOfLinearFieldIsConstant_ArbitraryCube)
-{
+TYPED_TEST(GradientTest, GradientOfLinearFieldIsConstant_ArbitraryCube) {
   using QK = TypeParam;
   constexpr int numNodes = QK::numNodes;
 
@@ -669,31 +563,24 @@ TYPED_TEST(GradientTest, GradientOfLinearFieldIsConstant_ArbitraryCube)
   createArbitraryCube<QK>(X, -2.0, 1.5, 0.3, 1.7);
 
   real_t Xfull[numNodes][3];
-  if constexpr (numNodes == 8)
-  {
+  if constexpr (numNodes == 8) {
     for (int i = 0; i < 8; ++i)
       for (int j = 0; j < 3; ++j) Xfull[i][j] = X[i][j];
-  }
-  else
-  {
+  } else {
     QK::computeLocalCoords(X, Xfull);
   }
 
   real_t u[numNodes][3];
-  for (int i = 0; i < numNodes; ++i)
-  {
+  for (int i = 0; i < numNodes; ++i) {
     u[i][0] = Xfull[i][0];
     u[i][1] = 2.0 * Xfull[i][1];
     u[i][2] = 3.0 * Xfull[i][2];
   }
 
-  real_t expectedGrad[3][3] = {
-      {1.0, 0.0, 0.0}, {0.0, 2.0, 0.0}, {0.0, 0.0, 3.0}};
+  real_t expectedGrad[3][3] = {{1.0, 0.0, 0.0}, {0.0, 2.0, 0.0}, {0.0, 0.0, 3.0}};
 
-  int numTestPoints =
-      (QK::numQuadraturePoints < 5) ? QK::numQuadraturePoints : 5;
-  for (int q = 0; q < numTestPoints; ++q)
-  {
+  int numTestPoints = (QK::numQuadraturePoints < 5) ? QK::numQuadraturePoints : 5;
+  for (int q = 0; q < numTestPoints; ++q) {
     real_t J[3][3] = {{0}};
     real_t invJ[3][3] = {{0}};
     real_t grad[3][3] = {{0}};
@@ -708,10 +595,8 @@ TYPED_TEST(GradientTest, GradientOfLinearFieldIsConstant_ArbitraryCube)
 
     QK::gradient(q, invJ, u, grad);
 
-    for (int i = 0; i < 3; ++i)
-    {
-      for (int j = 0; j < 3; ++j)
-      {
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 3; ++j) {
         EXPECT_NEAR(grad[i][j], expectedGrad[i][j], TOL_NUMERICAL)
             << "Gradient of linear field should be constant at all quadrature "
                "points";
@@ -720,8 +605,7 @@ TYPED_TEST(GradientTest, GradientOfLinearFieldIsConstant_ArbitraryCube)
   }
 }
 
-TYPED_TEST(GradientTest, SymmetricGradientIsSymmetric)
-{
+TYPED_TEST(GradientTest, SymmetricGradientIsSymmetric) {
   using QK = TypeParam;
   constexpr int numNodes = QK::numNodes;
 
@@ -729,29 +613,23 @@ TYPED_TEST(GradientTest, SymmetricGradientIsSymmetric)
   createArbitraryCube<QK>(X, 0.5, -1.2, 3.0, 2.1);
 
   real_t Xfull[numNodes][3];
-  if constexpr (numNodes == 8)
-  {
+  if constexpr (numNodes == 8) {
     for (int i = 0; i < 8; ++i)
       for (int j = 0; j < 3; ++j) Xfull[i][j] = X[i][j];
-  }
-  else
-  {
+  } else {
     QK::computeLocalCoords(X, Xfull);
   }
 
   real_t u[numNodes][3];
-  for (int i = 0; i < numNodes; ++i)
-  {
+  for (int i = 0; i < numNodes; ++i) {
     u[i][0] = Xfull[i][0] + 0.5 * Xfull[i][1];
     u[i][1] = Xfull[i][1] + 0.3 * Xfull[i][2];
     u[i][2] = Xfull[i][2] + 0.2 * Xfull[i][0];
   }
 
   // Test a few quadrature points
-  int numTestPoints =
-      (QK::numQuadraturePoints < 10) ? QK::numQuadraturePoints : 10;
-  for (int q = 0; q < numTestPoints; ++q)
-  {
+  int numTestPoints = (QK::numQuadraturePoints < 10) ? QK::numQuadraturePoints : 10;
+  for (int q = 0; q < numTestPoints; ++q) {
     real_t J[3][3] = {{0}};
     real_t invJ[3][3] = {{0}};
 
@@ -779,17 +657,13 @@ TYPED_TEST(GradientTest, SymmetricGradientIsSymmetric)
 // INDEXING TESTS
 // ============================================================================
 
-TYPED_TEST(IndexingTest, LinearIndex3DConsistency)
-{
+TYPED_TEST(IndexingTest, LinearIndex3DConsistency) {
   using QK = TypeParam;
   constexpr int num1d = QK::num1dNodes;
 
-  for (int c = 0; c < num1d; ++c)
-  {
-    for (int b = 0; b < num1d; ++b)
-    {
-      for (int a = 0; a < num1d; ++a)
-      {
+  for (int c = 0; c < num1d; ++c) {
+    for (int b = 0; b < num1d; ++b) {
+      for (int a = 0; a < num1d; ++a) {
         int idx1 = QK::linearIndex3DVal(a, b, c);
         int idx2 = QK::BasisType::TensorProduct3D::linearIndex(a, b, c);
 
@@ -799,13 +673,11 @@ TYPED_TEST(IndexingTest, LinearIndex3DConsistency)
   }
 }
 
-TYPED_TEST(IndexingTest, MeshIndexToLinearIndexBijection)
-{
+TYPED_TEST(IndexingTest, MeshIndexToLinearIndexBijection) {
   using QK = TypeParam;
 
   std::set<int> nodeIndices;
-  for (int k = 0; k < 8; ++k)
-  {
+  for (int k = 0; k < 8; ++k) {
     int nodeIdx = QK::meshIndexToLinearIndex3D(k);
     nodeIndices.insert(nodeIdx);
 
@@ -813,19 +685,15 @@ TYPED_TEST(IndexingTest, MeshIndexToLinearIndexBijection)
     EXPECT_LT(nodeIdx, QK::numNodes);
   }
 
-  EXPECT_EQ(nodeIndices.size(), 8)
-      << "Mesh corners should map to 8 distinct node indices";
+  EXPECT_EQ(nodeIndices.size(), 8) << "Mesh corners should map to 8 distinct node indices";
 }
 
-TYPED_TEST(IndexingTest, LinearIndex2DConsistency)
-{
+TYPED_TEST(IndexingTest, LinearIndex2DConsistency) {
   using QK = TypeParam;
   constexpr int num1d = QK::num1dNodes;
 
-  for (int b = 0; b < num1d; ++b)
-  {
-    for (int a = 0; a < num1d; ++a)
-    {
+  for (int b = 0; b < num1d; ++b) {
+    for (int a = 0; a < num1d; ++a) {
       int idx1 = QK::linearIndex2DVal(a, b);
       int idx2 = QK::BasisType::TensorProduct2D::linearIndex(a, b);
 
@@ -838,17 +706,14 @@ TYPED_TEST(IndexingTest, LinearIndex2DConsistency)
 // B MATRIX TESTS
 // ============================================================================
 
-TYPED_TEST(BMatrixTest, BMatrixSymmetry_ArbitraryCube)
-{
+TYPED_TEST(BMatrixTest, BMatrixSymmetry_ArbitraryCube) {
   using QK = TypeParam;
 
   real_t X[8][3];
   createArbitraryCube<QK>(X, -3.0, 1.5, -0.5, 1.8);
 
-  int numTestPoints =
-      (QK::numQuadraturePoints < 5) ? QK::numQuadraturePoints : 5;
-  for (int q = 0; q < numTestPoints; ++q)
-  {
+  int numTestPoints = (QK::numQuadraturePoints < 5) ? QK::numQuadraturePoints : 5;
+  for (int q = 0; q < numTestPoints; ++q) {
     int qa, qb, qc;
     QK::BasisType::TensorProduct3D::multiIndex(q, qa, qb, qc);
 
@@ -857,10 +722,8 @@ TYPED_TEST(BMatrixTest, BMatrixSymmetry_ArbitraryCube)
 
     QK::computeBMatrix(qa, qb, qc, X, J, B);
 
-    for (int i = 0; i < 6; ++i)
-    {
-      EXPECT_TRUE(std::isfinite(B[i]))
-          << "B matrix component " << i << " should be finite";
+    for (int i = 0; i < 6; ++i) {
+      EXPECT_TRUE(std::isfinite(B[i])) << "B matrix component " << i << " should be finite";
     }
 
     EXPECT_GT(B[0], 0.0) << "B[0] (xx component) should be positive";
@@ -873,36 +736,28 @@ TYPED_TEST(BMatrixTest, BMatrixSymmetry_ArbitraryCube)
 // BASIS GRADIENT TESTS
 // ============================================================================
 
-TYPED_TEST(BasisGradientTest, BasisGradientSymmetryProperty)
-{
+TYPED_TEST(BasisGradientTest, BasisGradientSymmetryProperty) {
   using QK = TypeParam;
   constexpr int num1d = QK::num1dNodes;
 
-  for (int q = 0; q < num1d; ++q)
-  {
-    for (int p = QK::halfNodes + 1; p < num1d; ++p)
-    {
+  for (int q = 0; q < num1d; ++q) {
+    for (int p = QK::halfNodes + 1; p < num1d; ++p) {
       real_t g1 = QK::basisGradientAt(q, p);
       real_t g2 = QK::basisGradientAt(num1d - 1 - q, num1d - 1 - p);
 
-      EXPECT_NEAR(g1, -g2, TOL)
-          << "Basis gradient should satisfy symmetry property: " << "grad(" << q
-          << "," << p << ") = -grad(" << (num1d - 1 - q) << ","
-          << (num1d - 1 - p) << ")";
+      EXPECT_NEAR(g1, -g2, TOL) << "Basis gradient should satisfy symmetry property: " << "grad(" << q << "," << p
+                                << ") = -grad(" << (num1d - 1 - q) << "," << (num1d - 1 - p) << ")";
     }
   }
 }
 
-TYPED_TEST(BasisGradientTest, BasisGradientZeroAtSameNode)
-{
+TYPED_TEST(BasisGradientTest, BasisGradientZeroAtSameNode) {
   using QK = TypeParam;
   constexpr int num1d = QK::num1dNodes;
 
-  for (int q = 1; q < num1d - 1; ++q)
-  {
+  for (int q = 1; q < num1d - 1; ++q) {
     real_t grad = QK::basisGradientAt(q, q);
-    EXPECT_NEAR(grad, 0.0, TOL)
-        << "Basis gradient should be zero at its own interior node";
+    EXPECT_NEAR(grad, 0.0, TOL) << "Basis gradient should be zero at its own interior node";
   }
 }
 
@@ -910,8 +765,7 @@ TYPED_TEST(BasisGradientTest, BasisGradientZeroAtSameNode)
 // 2D FACE OPERATIONS TESTS
 // ============================================================================
 
-TYPED_TEST(FaceOperationsTest, Jacobian2DRankTwo)
-{
+TYPED_TEST(FaceOperationsTest, Jacobian2DRankTwo) {
   using QK = TypeParam;
 
   real_t X[4][3];
@@ -943,8 +797,7 @@ TYPED_TEST(FaceOperationsTest, Jacobian2DRankTwo)
   EXPECT_NEAR(J[2][1], 0.0, TOL) << "J[2][1] should be ~0";
 }
 
-TYPED_TEST(FaceOperationsTest, DampingTermPositive_ArbitrarySquare)
-{
+TYPED_TEST(FaceOperationsTest, DampingTermPositive_ArbitrarySquare) {
   using QK = TypeParam;
   constexpr int numNodesPerFace = QK::numNodesPerFace;
 
@@ -967,8 +820,7 @@ TYPED_TEST(FaceOperationsTest, DampingTermPositive_ArbitrarySquare)
   real_t totalDamping = 0.0;
   real_t expectedArea = size * size;
 
-  for (int q = 0; q < numNodesPerFace; ++q)
-  {
+  for (int q = 0; q < numNodesPerFace; ++q) {
     real_t damping = QK::computeDampingTerm(q, X);
 
     EXPECT_GT(damping, 0.0) << "Damping term should be positive at node " << q;
@@ -976,12 +828,10 @@ TYPED_TEST(FaceOperationsTest, DampingTermPositive_ArbitrarySquare)
     totalDamping += damping;
   }
 
-  EXPECT_NEAR(totalDamping, expectedArea, TOL_NUMERICAL)
-      << "Sum of damping terms should equal face area";
+  EXPECT_NEAR(totalDamping, expectedArea, TOL_NUMERICAL) << "Sum of damping terms should equal face area";
 }
 
-TYPED_TEST(FaceOperationsTest, DampingTermScaling)
-{
+TYPED_TEST(FaceOperationsTest, DampingTermScaling) {
   using QK = TypeParam;
 
   real_t X1[4][3], X2[4][3];
@@ -1006,6 +856,5 @@ TYPED_TEST(FaceOperationsTest, DampingTermScaling)
   real_t d1 = QK::computeDampingTerm(q, X1);
   real_t d2 = QK::computeDampingTerm(q, X2);
 
-  EXPECT_NEAR(d2 / d1, 4.0, TOL_NUMERICAL)
-      << "Damping term should scale quadratically with element size";
+  EXPECT_NEAR(d2 / d1, 4.0, TOL_NUMERICAL) << "Damping term should scale quadratically with element size";
 }

--- a/tests/units/gradient/impl/acoustic/makutu/test_differentiator_acoustic_makutu_struct.cc
+++ b/tests/units/gradient/impl/acoustic/makutu/test_differentiator_acoustic_makutu_struct.cc
@@ -9,25 +9,20 @@
 #include "differentiator_data_acoustic.h"
 #include "model_struct.h"
 
-namespace gradient
-{
-namespace test
-{
+namespace gradient {
+namespace test {
 
 // =============================================================================
 // Order wrappers — Google Test requires types, not non-type parameters.
 // =============================================================================
 
-struct Order1
-{
+struct Order1 {
   static constexpr int kOrder = 1;
 };
-struct Order2
-{
+struct Order2 {
   static constexpr int kOrder = 2;
 };
-struct Order3
-{
+struct Order3 {
   static constexpr int kOrder = 3;
 };
 
@@ -45,8 +40,7 @@ using OrderTypes = ::testing::Types<Order1, Order2, Order3>;
 // =============================================================================
 
 template <int ORDER>
-static model::ModelStruct<float, int, ORDER> makeMesh1x1x1()
-{
+static model::ModelStruct<float, int, ORDER> makeMesh1x1x1() {
   model::ModelStructData<float, int> data;
   data.ex_ = 1;
   data.ey_ = 1;
@@ -70,30 +64,25 @@ static model::ModelStruct<float, int, ORDER> makeMesh1x1x1()
 // =============================================================================
 
 template <typename OrderWrapper>
-class DifferentiatorAcousticElemTest : public ::testing::Test
-{
+class DifferentiatorAcousticElemTest : public ::testing::Test {
  protected:
   static constexpr int kOrder = OrderWrapper::kOrder;
   static constexpr int kNumNodes = (kOrder + 1) * (kOrder + 1) * (kOrder + 1);
   static constexpr int kNumElements = 1;
 
   using Mesh = model::ModelStruct<float, int, kOrder>;
-  using Integral =
-      typename IntegralTypeSelector<kOrder, IntegralType::MAKUTU>::type;
+  using Integral = typename IntegralTypeSelector<kOrder, IntegralType::MAKUTU>::type;
   using Diff = DifferentiatorAcoustic<kOrder, Integral, Mesh, false>;
 
-  void SetUp() override
-  {
+  void SetUp() override {
     pn = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "pn");
     qn = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "qn");
     qnPrev = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "qnPrev");
     qnPrevPrev = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "qnPrevPrev");
     gradKappa = allocateVector<VECTOR_REAL_VIEW>(kNumElements, "gradKappa");
-    gradBuoyancy =
-        allocateVector<VECTOR_REAL_VIEW>(kNumElements, "gradBuoyancy");
+    gradBuoyancy = allocateVector<VECTOR_REAL_VIEW>(kNumElements, "gradBuoyancy");
 
-    for (int i = 0; i < kNumNodes; ++i)
-    {
+    for (int i = 0; i < kNumNodes; ++i) {
       pn(i) = 0.0f;
       qn(i) = 0.0f;
       qnPrev(i) = 0.0f;
@@ -111,47 +100,36 @@ TYPED_TEST_SUITE(DifferentiatorAcousticElemTest, OrderTypes);
 
 // --- Static constants ---
 
-TYPED_TEST(DifferentiatorAcousticElemTest, OrderConstant)
-{
-  EXPECT_EQ(TestFixture::Diff::kOrder, TestFixture::kOrder);
-}
+TYPED_TEST(DifferentiatorAcousticElemTest, OrderConstant) { EXPECT_EQ(TestFixture::Diff::kOrder, TestFixture::kOrder); }
 
-TYPED_TEST(DifferentiatorAcousticElemTest, IsModelOnNodesConstant)
-{
-  EXPECT_FALSE(TestFixture::Diff::kIsModelOnNodes);
-}
+TYPED_TEST(DifferentiatorAcousticElemTest, IsModelOnNodesConstant) { EXPECT_FALSE(TestFixture::Diff::kIsModelOnNodes); }
 
-TYPED_TEST(DifferentiatorAcousticElemTest, PointsPerElementConstant)
-{
+TYPED_TEST(DifferentiatorAcousticElemTest, PointsPerElementConstant) {
   EXPECT_EQ(TestFixture::Diff::kPointsPerElement, TestFixture::kNumNodes);
 }
 
 // --- Virtual getters ---
 
-TYPED_TEST(DifferentiatorAcousticElemTest, GetOrderReturnsCorrectOrder)
-{
+TYPED_TEST(DifferentiatorAcousticElemTest, GetOrderReturnsCorrectOrder) {
   typename TestFixture::Diff diff;
   EXPECT_EQ(diff.getOrder(), TestFixture::kOrder);
 }
 
-TYPED_TEST(DifferentiatorAcousticElemTest, IsModelOnNodesReturnsFalse)
-{
+TYPED_TEST(DifferentiatorAcousticElemTest, IsModelOnNodesReturnsFalse) {
   typename TestFixture::Diff diff;
   EXPECT_FALSE(diff.isModelOnNodes());
 }
 
 // --- Print ---
 
-TYPED_TEST(DifferentiatorAcousticElemTest, PrintDoesNotThrow)
-{
+TYPED_TEST(DifferentiatorAcousticElemTest, PrintDoesNotThrow) {
   typename TestFixture::Diff diff;
   EXPECT_NO_THROW(diff.print());
 }
 
 // --- compute() correctness ---
 
-TYPED_TEST(DifferentiatorAcousticElemTest, ZeroWavefieldsYieldZeroGradients)
-{
+TYPED_TEST(DifferentiatorAcousticElemTest, ZeroWavefieldsYieldZeroGradients) {
   typename TestFixture::Diff diff;
   auto mesh = makeMesh1x1x1<TestFixture::kOrder>();
 
@@ -166,12 +144,10 @@ TYPED_TEST(DifferentiatorAcousticElemTest, ZeroWavefieldsYieldZeroGradients)
   EXPECT_FLOAT_EQ(this->gradBuoyancy(0), 0.0f);
 }
 
-TYPED_TEST(DifferentiatorAcousticElemTest, UniformFieldGradKappaEqualsVolume)
-{
+TYPED_TEST(DifferentiatorAcousticElemTest, UniformFieldGradKappaEqualsVolume) {
   // pn = 1, qn = 1e-6 (qdt2 = 1 with dt=0.001)  =>  gradKappa = ∑_q
   // mass_weight_q = ∫_Ω 1 dΩ = 1.0
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->pn(i) = 1.0f;
     this->qn(i) = 1e-6f;
     this->qnPrev(i) = 0.0f;
@@ -191,11 +167,9 @@ TYPED_TEST(DifferentiatorAcousticElemTest, UniformFieldGradKappaEqualsVolume)
   EXPECT_NEAR(this->gradKappa(0), 1.0f, 1e-5f);
 }
 
-TYPED_TEST(DifferentiatorAcousticElemTest, ConstantFieldGradBuoyancyIsZero)
-{
+TYPED_TEST(DifferentiatorAcousticElemTest, ConstantFieldGradBuoyancyIsZero) {
   // pn = qn = const  =>  ∇pn = ∇qn = 0  =>  stiffness contribution = 0
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->pn(i) = 1.0f;
     this->qn(i) = 1.0f;
   }
@@ -213,11 +187,9 @@ TYPED_TEST(DifferentiatorAcousticElemTest, ConstantFieldGradBuoyancyIsZero)
   EXPECT_NEAR(this->gradBuoyancy(0), 0.0f, 1e-5f);
 }
 
-TYPED_TEST(DifferentiatorAcousticElemTest, GradKappaScalesWithAmplitude)
-{
+TYPED_TEST(DifferentiatorAcousticElemTest, GradKappaScalesWithAmplitude) {
   // Doubling pn doubles gradKappa
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->pn(i) = 1.0f;
     this->qn(i) = 1e-6f;
     this->qnPrev(i) = 0.0f;
@@ -250,12 +222,9 @@ TYPED_TEST(DifferentiatorAcousticElemTest, GradKappaScalesWithAmplitude)
   EXPECT_NEAR(this->gradKappa(0), 2.0f * single, 1e-5f);
 }
 
-TYPED_TEST(DifferentiatorAcousticElemTest,
-           ComputeAccumulatesIntoExistingGradient)
-{
+TYPED_TEST(DifferentiatorAcousticElemTest, ComputeAccumulatesIntoExistingGradient) {
   // gradKappa starts at some non-zero value; compute() must add to it
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->pn(i) = 1.0f;
     this->qn(i) = 1e-6f;
     this->qnPrev(i) = 0.0f;
@@ -279,18 +248,15 @@ TYPED_TEST(DifferentiatorAcousticElemTest,
 
 // --- Polymorphic interface ---
 
-TYPED_TEST(DifferentiatorAcousticElemTest, PolymorphicInterface)
-{
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+TYPED_TEST(DifferentiatorAcousticElemTest, PolymorphicInterface) {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->pn(i) = 1.0f;
     this->qn(i) = 1e-6f;
     this->qnPrev(i) = 0.0f;
     this->qnPrevPrev(i) = 0.0f;
   }
 
-  std::unique_ptr<Differentiator> diff =
-      std::make_unique<typename TestFixture::Diff>();
+  std::unique_ptr<Differentiator> diff = std::make_unique<typename TestFixture::Diff>();
   auto mesh = makeMesh1x1x1<TestFixture::kOrder>();
 
   EXPECT_EQ(diff->getOrder(), TestFixture::kOrder);
@@ -314,21 +280,18 @@ TYPED_TEST(DifferentiatorAcousticElemTest, PolymorphicInterface)
 // =============================================================================
 
 template <typename OrderWrapper>
-class DifferentiatorAcousticNodeTest : public ::testing::Test
-{
+class DifferentiatorAcousticNodeTest : public ::testing::Test {
  protected:
   static constexpr int kOrder = OrderWrapper::kOrder;
   static constexpr int kNumNodes = (kOrder + 1) * (kOrder + 1) * (kOrder + 1);
   static constexpr int kNumElements = 1;
 
   using Mesh = model::ModelStruct<float, int, kOrder>;
-  using Integral =
-      typename IntegralTypeSelector<kOrder, IntegralType::MAKUTU>::type;
+  using Integral = typename IntegralTypeSelector<kOrder, IntegralType::MAKUTU>::type;
   using DiffNode = DifferentiatorAcoustic<kOrder, Integral, Mesh, true>;
   using DiffElem = DifferentiatorAcoustic<kOrder, Integral, Mesh, false>;
 
-  void SetUp() override
-  {
+  void SetUp() override {
     pn = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "pn");
     qn = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "qn");
     qnPrev = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "qnPrev");
@@ -336,8 +299,7 @@ class DifferentiatorAcousticNodeTest : public ::testing::Test
     gradKappa = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "gradKappa");
     gradBuoyancy = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "gradBuoyancy");
 
-    for (int i = 0; i < kNumNodes; ++i)
-    {
+    for (int i = 0; i < kNumNodes; ++i) {
       pn(i) = 0.0f;
       qn(i) = 0.0f;
       qnPrev(i) = 0.0f;
@@ -347,15 +309,13 @@ class DifferentiatorAcousticNodeTest : public ::testing::Test
     }
   }
 
-  float sumGradKappa() const
-  {
+  float sumGradKappa() const {
     float s = 0.0f;
     for (int i = 0; i < kNumNodes; ++i) s += gradKappa(i);
     return s;
   }
 
-  float sumGradBuoyancy() const
-  {
+  float sumGradBuoyancy() const {
     float s = 0.0f;
     for (int i = 0; i < kNumNodes; ++i) s += gradBuoyancy(i);
     return s;
@@ -369,37 +329,32 @@ TYPED_TEST_SUITE(DifferentiatorAcousticNodeTest, OrderTypes);
 
 // --- Static constants ---
 
-TYPED_TEST(DifferentiatorAcousticNodeTest, IsModelOnNodesConstant)
-{
+TYPED_TEST(DifferentiatorAcousticNodeTest, IsModelOnNodesConstant) {
   EXPECT_TRUE(TestFixture::DiffNode::kIsModelOnNodes);
 }
 
 // --- Virtual getters ---
 
-TYPED_TEST(DifferentiatorAcousticNodeTest, GetOrderReturnsCorrectOrder)
-{
+TYPED_TEST(DifferentiatorAcousticNodeTest, GetOrderReturnsCorrectOrder) {
   typename TestFixture::DiffNode diff;
   EXPECT_EQ(diff.getOrder(), TestFixture::kOrder);
 }
 
-TYPED_TEST(DifferentiatorAcousticNodeTest, IsModelOnNodesReturnsTrue)
-{
+TYPED_TEST(DifferentiatorAcousticNodeTest, IsModelOnNodesReturnsTrue) {
   typename TestFixture::DiffNode diff;
   EXPECT_TRUE(diff.isModelOnNodes());
 }
 
 // --- Print ---
 
-TYPED_TEST(DifferentiatorAcousticNodeTest, PrintDoesNotThrow)
-{
+TYPED_TEST(DifferentiatorAcousticNodeTest, PrintDoesNotThrow) {
   typename TestFixture::DiffNode diff;
   EXPECT_NO_THROW(diff.print());
 }
 
 // --- compute() correctness ---
 
-TYPED_TEST(DifferentiatorAcousticNodeTest, ZeroWavefieldsYieldZeroGradients)
-{
+TYPED_TEST(DifferentiatorAcousticNodeTest, ZeroWavefieldsYieldZeroGradients) {
   typename TestFixture::DiffNode diff;
   auto mesh = makeMesh1x1x1<TestFixture::kOrder>();
 
@@ -414,12 +369,10 @@ TYPED_TEST(DifferentiatorAcousticNodeTest, ZeroWavefieldsYieldZeroGradients)
   EXPECT_FLOAT_EQ(this->sumGradBuoyancy(), 0.0f);
 }
 
-TYPED_TEST(DifferentiatorAcousticNodeTest, UniformFieldGradKappaSumsToVolume)
-{
+TYPED_TEST(DifferentiatorAcousticNodeTest, UniformFieldGradKappaSumsToVolume) {
   // pn = 1, qn = 1e-6 (qdt2 = 1 with dt=0.001) on all nodes.
   // With massDiag normalization, the sum equals the number of nodes.
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->pn(i) = 1.0f;
     this->qn(i) = 1e-6f;
     this->qnPrev(i) = 0.0f;
@@ -439,11 +392,9 @@ TYPED_TEST(DifferentiatorAcousticNodeTest, UniformFieldGradKappaSumsToVolume)
   EXPECT_NEAR(this->sumGradKappa(), (float)TestFixture::kNumNodes, 1e-5f);
 }
 
-TYPED_TEST(DifferentiatorAcousticNodeTest, ConstantFieldGradBuoyancySumsToZero)
-{
+TYPED_TEST(DifferentiatorAcousticNodeTest, ConstantFieldGradBuoyancySumsToZero) {
   // pn = qn = 1  =>  ∇p = ∇q = 0  =>  stiffness contribution sums to 0
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->pn(i) = 1.0f;
     this->qn(i) = 1.0f;
   }
@@ -462,13 +413,11 @@ TYPED_TEST(DifferentiatorAcousticNodeTest, ConstantFieldGradBuoyancySumsToZero)
   EXPECT_NEAR(this->sumGradBuoyancy(), 0.0f, 2e-4f);
 }
 
-TYPED_TEST(DifferentiatorAcousticNodeTest, NodeBasedSumEqualsElementBasedResult)
-{
+TYPED_TEST(DifferentiatorAcousticNodeTest, NodeBasedSumEqualsElementBasedResult) {
   // For a single-element mesh with massDiag normalization, the sum of
   // node-scattered gradients is scaled by the number of nodes relative to
   // the element-accumulated value: nodeSum ≈ kNumNodes * elementValue.
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->pn(i) = 1.0f;
     this->qn(i) = 1e-6f;
     this->qnPrev(i) = 0.0f;
@@ -489,8 +438,7 @@ TYPED_TEST(DifferentiatorAcousticNodeTest, NodeBasedSumEqualsElementBasedResult)
 
   // Element-based
   auto gradKappaElem = allocateVector<VECTOR_REAL_VIEW>(1, "gradKappaElem");
-  auto gradBuoyancyElem =
-      allocateVector<VECTOR_REAL_VIEW>(1, "gradBuoyancyElem");
+  auto gradBuoyancyElem = allocateVector<VECTOR_REAL_VIEW>(1, "gradBuoyancyElem");
   gradKappaElem(0) = 0.0f;
   gradBuoyancyElem(0) = 0.0f;
 
@@ -504,18 +452,15 @@ TYPED_TEST(DifferentiatorAcousticNodeTest, NodeBasedSumEqualsElementBasedResult)
 
 // --- Polymorphic interface ---
 
-TYPED_TEST(DifferentiatorAcousticNodeTest, PolymorphicInterface)
-{
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+TYPED_TEST(DifferentiatorAcousticNodeTest, PolymorphicInterface) {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->pn(i) = 1.0f;
     this->qn(i) = 1e-6f;
     this->qnPrev(i) = 0.0f;
     this->qnPrevPrev(i) = 0.0f;
   }
 
-  std::unique_ptr<Differentiator> diff =
-      std::make_unique<typename TestFixture::DiffNode>();
+  std::unique_ptr<Differentiator> diff = std::make_unique<typename TestFixture::DiffNode>();
   auto mesh = makeMesh1x1x1<TestFixture::kOrder>();
 
   EXPECT_EQ(diff->getOrder(), TestFixture::kOrder);

--- a/tests/units/gradient/impl/acoustic/makutu/test_differentiator_acoustic_makutu_unstruct.cc
+++ b/tests/units/gradient/impl/acoustic/makutu/test_differentiator_acoustic_makutu_unstruct.cc
@@ -8,25 +8,20 @@
 #include "differentiator_data_acoustic.h"
 #include "model_unstruct.h"
 
-namespace gradient
-{
-namespace test
-{
+namespace gradient {
+namespace test {
 
 // =============================================================================
 // Order wrappers — Google Test requires types, not non-type parameters.
 // =============================================================================
 
-struct Order1U
-{
+struct Order1U {
   static constexpr int kOrder = 1;
 };
-struct Order2U
-{
+struct Order2U {
   static constexpr int kOrder = 2;
 };
-struct Order3U
-{
+struct Order3U {
   static constexpr int kOrder = 3;
 };
 
@@ -52,8 +47,7 @@ using OrderTypesU = ::testing::Types<Order1U, Order2U, Order3U>;
 // =============================================================================
 
 template <int ORDER>
-static model::ModelUnstruct<float, int> makeUnstructMesh1x1x1()
-{
+static model::ModelUnstruct<float, int> makeUnstructMesh1x1x1() {
   constexpr int npe = (ORDER + 1) * (ORDER + 1) * (ORDER + 1);
 
   model::ModelUnstructData<float, int> data;
@@ -69,8 +63,7 @@ static model::ModelUnstruct<float, int> makeUnstructMesh1x1x1()
   data.nodes_coords_y_ = allocateVector<VECTOR_REAL_VIEW>(npe, "cy");
   data.nodes_coords_z_ = allocateVector<VECTOR_REAL_VIEW>(npe, "cz");
 
-  for (int lDof = 0; lDof < npe; ++lDof)
-  {
+  for (int lDof = 0; lDof < npe; ++lDof) {
     data.global_node_index_(0, lDof) = lDof;
 
     int k = lDof / ((ORDER + 1) * (ORDER + 1));
@@ -93,30 +86,25 @@ static model::ModelUnstruct<float, int> makeUnstructMesh1x1x1()
 // =============================================================================
 
 template <typename OrderWrapper>
-class DifferentiatorAcousticElemUnstructTest : public ::testing::Test
-{
+class DifferentiatorAcousticElemUnstructTest : public ::testing::Test {
  protected:
   static constexpr int kOrder = OrderWrapper::kOrder;
   static constexpr int kNumNodes = (kOrder + 1) * (kOrder + 1) * (kOrder + 1);
   static constexpr int kNumElements = 1;
 
   using Mesh = model::ModelUnstruct<float, int>;
-  using Integral =
-      typename IntegralTypeSelector<kOrder, IntegralType::MAKUTU>::type;
+  using Integral = typename IntegralTypeSelector<kOrder, IntegralType::MAKUTU>::type;
   using Diff = DifferentiatorAcoustic<kOrder, Integral, Mesh, false>;
 
-  void SetUp() override
-  {
+  void SetUp() override {
     pn = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "pn");
     qn = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "qn");
     qnPrev = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "qnPrev");
     qnPrevPrev = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "qnPrevPrev");
     gradKappa = allocateVector<VECTOR_REAL_VIEW>(kNumElements, "gradKappa");
-    gradBuoyancy =
-        allocateVector<VECTOR_REAL_VIEW>(kNumElements, "gradBuoyancy");
+    gradBuoyancy = allocateVector<VECTOR_REAL_VIEW>(kNumElements, "gradBuoyancy");
 
-    for (int i = 0; i < kNumNodes; ++i)
-    {
+    for (int i = 0; i < kNumNodes; ++i) {
       pn(i) = 0.0f;
       qn(i) = 0.0f;
       qnPrev(i) = 0.0f;
@@ -134,48 +122,40 @@ TYPED_TEST_SUITE(DifferentiatorAcousticElemUnstructTest, OrderTypesU);
 
 // --- Static constants ---
 
-TYPED_TEST(DifferentiatorAcousticElemUnstructTest, OrderConstant)
-{
+TYPED_TEST(DifferentiatorAcousticElemUnstructTest, OrderConstant) {
   EXPECT_EQ(TestFixture::Diff::kOrder, TestFixture::kOrder);
 }
 
-TYPED_TEST(DifferentiatorAcousticElemUnstructTest, IsModelOnNodesConstant)
-{
+TYPED_TEST(DifferentiatorAcousticElemUnstructTest, IsModelOnNodesConstant) {
   EXPECT_FALSE(TestFixture::Diff::kIsModelOnNodes);
 }
 
-TYPED_TEST(DifferentiatorAcousticElemUnstructTest, PointsPerElementConstant)
-{
+TYPED_TEST(DifferentiatorAcousticElemUnstructTest, PointsPerElementConstant) {
   EXPECT_EQ(TestFixture::Diff::kPointsPerElement, TestFixture::kNumNodes);
 }
 
 // --- Virtual getters ---
 
-TYPED_TEST(DifferentiatorAcousticElemUnstructTest, GetOrderReturnsCorrectOrder)
-{
+TYPED_TEST(DifferentiatorAcousticElemUnstructTest, GetOrderReturnsCorrectOrder) {
   typename TestFixture::Diff diff;
   EXPECT_EQ(diff.getOrder(), TestFixture::kOrder);
 }
 
-TYPED_TEST(DifferentiatorAcousticElemUnstructTest, IsModelOnNodesReturnsFalse)
-{
+TYPED_TEST(DifferentiatorAcousticElemUnstructTest, IsModelOnNodesReturnsFalse) {
   typename TestFixture::Diff diff;
   EXPECT_FALSE(diff.isModelOnNodes());
 }
 
 // --- Print ---
 
-TYPED_TEST(DifferentiatorAcousticElemUnstructTest, PrintDoesNotThrow)
-{
+TYPED_TEST(DifferentiatorAcousticElemUnstructTest, PrintDoesNotThrow) {
   typename TestFixture::Diff diff;
   EXPECT_NO_THROW(diff.print());
 }
 
 // --- compute() correctness ---
 
-TYPED_TEST(DifferentiatorAcousticElemUnstructTest,
-           ZeroWavefieldsYieldZeroGradients)
-{
+TYPED_TEST(DifferentiatorAcousticElemUnstructTest, ZeroWavefieldsYieldZeroGradients) {
   typename TestFixture::Diff diff;
   auto mesh = makeUnstructMesh1x1x1<TestFixture::kOrder>();
 
@@ -190,13 +170,10 @@ TYPED_TEST(DifferentiatorAcousticElemUnstructTest,
   EXPECT_FLOAT_EQ(this->gradBuoyancy(0), 0.0f);
 }
 
-TYPED_TEST(DifferentiatorAcousticElemUnstructTest,
-           UniformFieldGradKappaEqualsVolume)
-{
+TYPED_TEST(DifferentiatorAcousticElemUnstructTest, UniformFieldGradKappaEqualsVolume) {
   // pn = 1, qn = 1e-6 (qdt2 = 1 with dt=0.001)  =>  gradKappa = ∫_Ω 1 dΩ = 1.0
   // (unit cube)
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->pn(i) = 1.0f;
     this->qn(i) = 1e-6f;
     this->qnPrev(i) = 0.0f;
@@ -216,12 +193,9 @@ TYPED_TEST(DifferentiatorAcousticElemUnstructTest,
   EXPECT_NEAR(this->gradKappa(0), 1.0f, 1e-5f);
 }
 
-TYPED_TEST(DifferentiatorAcousticElemUnstructTest,
-           ConstantFieldGradBuoyancyIsZero)
-{
+TYPED_TEST(DifferentiatorAcousticElemUnstructTest, ConstantFieldGradBuoyancyIsZero) {
   // pn = qn = const  =>  ∇pn = ∇qn = 0  =>  stiffness contribution = 0
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->pn(i) = 1.0f;
     this->qn(i) = 1.0f;
   }
@@ -239,11 +213,9 @@ TYPED_TEST(DifferentiatorAcousticElemUnstructTest,
   EXPECT_NEAR(this->gradBuoyancy(0), 0.0f, 1e-5f);
 }
 
-TYPED_TEST(DifferentiatorAcousticElemUnstructTest, GradKappaScalesWithAmplitude)
-{
+TYPED_TEST(DifferentiatorAcousticElemUnstructTest, GradKappaScalesWithAmplitude) {
   // Doubling pn doubles gradKappa
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->pn(i) = 1.0f;
     this->qn(i) = 1e-6f;
     this->qnPrev(i) = 0.0f;
@@ -276,11 +248,8 @@ TYPED_TEST(DifferentiatorAcousticElemUnstructTest, GradKappaScalesWithAmplitude)
   EXPECT_NEAR(this->gradKappa(0), 2.0f * single, 1e-5f);
 }
 
-TYPED_TEST(DifferentiatorAcousticElemUnstructTest,
-           ComputeAccumulatesIntoExistingGradient)
-{
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+TYPED_TEST(DifferentiatorAcousticElemUnstructTest, ComputeAccumulatesIntoExistingGradient) {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->pn(i) = 1.0f;
     this->qn(i) = 1e-6f;
     this->qnPrev(i) = 0.0f;
@@ -304,18 +273,15 @@ TYPED_TEST(DifferentiatorAcousticElemUnstructTest,
 
 // --- Polymorphic interface ---
 
-TYPED_TEST(DifferentiatorAcousticElemUnstructTest, PolymorphicInterface)
-{
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+TYPED_TEST(DifferentiatorAcousticElemUnstructTest, PolymorphicInterface) {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->pn(i) = 1.0f;
     this->qn(i) = 1e-6f;
     this->qnPrev(i) = 0.0f;
     this->qnPrevPrev(i) = 0.0f;
   }
 
-  std::unique_ptr<Differentiator> diff =
-      std::make_unique<typename TestFixture::Diff>();
+  std::unique_ptr<Differentiator> diff = std::make_unique<typename TestFixture::Diff>();
   auto mesh = makeUnstructMesh1x1x1<TestFixture::kOrder>();
 
   EXPECT_EQ(diff->getOrder(), TestFixture::kOrder);
@@ -338,21 +304,18 @@ TYPED_TEST(DifferentiatorAcousticElemUnstructTest, PolymorphicInterface)
 // =============================================================================
 
 template <typename OrderWrapper>
-class DifferentiatorAcousticNodeUnstructTest : public ::testing::Test
-{
+class DifferentiatorAcousticNodeUnstructTest : public ::testing::Test {
  protected:
   static constexpr int kOrder = OrderWrapper::kOrder;
   static constexpr int kNumNodes = (kOrder + 1) * (kOrder + 1) * (kOrder + 1);
   static constexpr int kNumElements = 1;
 
   using Mesh = model::ModelUnstruct<float, int>;
-  using Integral =
-      typename IntegralTypeSelector<kOrder, IntegralType::MAKUTU>::type;
+  using Integral = typename IntegralTypeSelector<kOrder, IntegralType::MAKUTU>::type;
   using DiffNode = DifferentiatorAcoustic<kOrder, Integral, Mesh, true>;
   using DiffElem = DifferentiatorAcoustic<kOrder, Integral, Mesh, false>;
 
-  void SetUp() override
-  {
+  void SetUp() override {
     pn = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "pn");
     qn = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "qn");
     qnPrev = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "qnPrev");
@@ -360,8 +323,7 @@ class DifferentiatorAcousticNodeUnstructTest : public ::testing::Test
     gradKappa = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "gradKappa");
     gradBuoyancy = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "gradBuoyancy");
 
-    for (int i = 0; i < kNumNodes; ++i)
-    {
+    for (int i = 0; i < kNumNodes; ++i) {
       pn(i) = 0.0f;
       qn(i) = 0.0f;
       qnPrev(i) = 0.0f;
@@ -371,15 +333,13 @@ class DifferentiatorAcousticNodeUnstructTest : public ::testing::Test
     }
   }
 
-  float sumGradKappa() const
-  {
+  float sumGradKappa() const {
     float s = 0.0f;
     for (int i = 0; i < kNumNodes; ++i) s += gradKappa(i);
     return s;
   }
 
-  float sumGradBuoyancy() const
-  {
+  float sumGradBuoyancy() const {
     float s = 0.0f;
     for (int i = 0; i < kNumNodes; ++i) s += gradBuoyancy(i);
     return s;
@@ -393,38 +353,32 @@ TYPED_TEST_SUITE(DifferentiatorAcousticNodeUnstructTest, OrderTypesU);
 
 // --- Static constants ---
 
-TYPED_TEST(DifferentiatorAcousticNodeUnstructTest, IsModelOnNodesConstant)
-{
+TYPED_TEST(DifferentiatorAcousticNodeUnstructTest, IsModelOnNodesConstant) {
   EXPECT_TRUE(TestFixture::DiffNode::kIsModelOnNodes);
 }
 
 // --- Virtual getters ---
 
-TYPED_TEST(DifferentiatorAcousticNodeUnstructTest, GetOrderReturnsCorrectOrder)
-{
+TYPED_TEST(DifferentiatorAcousticNodeUnstructTest, GetOrderReturnsCorrectOrder) {
   typename TestFixture::DiffNode diff;
   EXPECT_EQ(diff.getOrder(), TestFixture::kOrder);
 }
 
-TYPED_TEST(DifferentiatorAcousticNodeUnstructTest, IsModelOnNodesReturnsTrue)
-{
+TYPED_TEST(DifferentiatorAcousticNodeUnstructTest, IsModelOnNodesReturnsTrue) {
   typename TestFixture::DiffNode diff;
   EXPECT_TRUE(diff.isModelOnNodes());
 }
 
 // --- Print ---
 
-TYPED_TEST(DifferentiatorAcousticNodeUnstructTest, PrintDoesNotThrow)
-{
+TYPED_TEST(DifferentiatorAcousticNodeUnstructTest, PrintDoesNotThrow) {
   typename TestFixture::DiffNode diff;
   EXPECT_NO_THROW(diff.print());
 }
 
 // --- compute() correctness ---
 
-TYPED_TEST(DifferentiatorAcousticNodeUnstructTest,
-           ZeroWavefieldsYieldZeroGradients)
-{
+TYPED_TEST(DifferentiatorAcousticNodeUnstructTest, ZeroWavefieldsYieldZeroGradients) {
   typename TestFixture::DiffNode diff;
   auto mesh = makeUnstructMesh1x1x1<TestFixture::kOrder>();
 
@@ -439,13 +393,10 @@ TYPED_TEST(DifferentiatorAcousticNodeUnstructTest,
   EXPECT_FLOAT_EQ(this->sumGradBuoyancy(), 0.0f);
 }
 
-TYPED_TEST(DifferentiatorAcousticNodeUnstructTest,
-           UniformFieldGradKappaSumsToVolume)
-{
+TYPED_TEST(DifferentiatorAcousticNodeUnstructTest, UniformFieldGradKappaSumsToVolume) {
   // pn = 1, qn = 1e-6 (qdt2 = 1 with dt=0.001)  =>  scattered contributions
   // With massDiag normalization, the sum equals the number of nodes.
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->pn(i) = 1.0f;
     this->qn(i) = 1e-6f;
     this->qnPrev(i) = 0.0f;
@@ -465,12 +416,9 @@ TYPED_TEST(DifferentiatorAcousticNodeUnstructTest,
   EXPECT_NEAR(this->sumGradKappa(), (float)TestFixture::kNumNodes, 1e-5f);
 }
 
-TYPED_TEST(DifferentiatorAcousticNodeUnstructTest,
-           ConstantFieldGradBuoyancySumsToZero)
-{
+TYPED_TEST(DifferentiatorAcousticNodeUnstructTest, ConstantFieldGradBuoyancySumsToZero) {
   // pn = qn = 1  =>  ∇p = ∇q = 0  =>  stiffness contribution sums to 0
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->pn(i) = 1.0f;
     this->qn(i) = 1.0f;
   }
@@ -489,14 +437,11 @@ TYPED_TEST(DifferentiatorAcousticNodeUnstructTest,
   EXPECT_NEAR(this->sumGradBuoyancy(), 0.0f, 2e-4f);
 }
 
-TYPED_TEST(DifferentiatorAcousticNodeUnstructTest,
-           NodeBasedSumEqualsElementBasedResult)
-{
+TYPED_TEST(DifferentiatorAcousticNodeUnstructTest, NodeBasedSumEqualsElementBasedResult) {
   // For a single-element mesh with massDiag normalization, the sum of
   // node-scattered gradients is scaled by the number of nodes relative to
   // the element-accumulated value: nodeSum ≈ kNumNodes * elementValue.
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->pn(i) = 1.0f;
     this->qn(i) = 1e-6f;
     this->qnPrev(i) = 0.0f;
@@ -517,8 +462,7 @@ TYPED_TEST(DifferentiatorAcousticNodeUnstructTest,
 
   // Element-based
   auto gradKappaElem = allocateVector<VECTOR_REAL_VIEW>(1, "gradKappaElem");
-  auto gradBuoyancyElem =
-      allocateVector<VECTOR_REAL_VIEW>(1, "gradBuoyancyElem");
+  auto gradBuoyancyElem = allocateVector<VECTOR_REAL_VIEW>(1, "gradBuoyancyElem");
   gradKappaElem(0) = 0.0f;
   gradBuoyancyElem(0) = 0.0f;
 
@@ -532,18 +476,15 @@ TYPED_TEST(DifferentiatorAcousticNodeUnstructTest,
 
 // --- Polymorphic interface ---
 
-TYPED_TEST(DifferentiatorAcousticNodeUnstructTest, PolymorphicInterface)
-{
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+TYPED_TEST(DifferentiatorAcousticNodeUnstructTest, PolymorphicInterface) {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->pn(i) = 1.0f;
     this->qn(i) = 1e-6f;
     this->qnPrev(i) = 0.0f;
     this->qnPrevPrev(i) = 0.0f;
   }
 
-  std::unique_ptr<Differentiator> diff =
-      std::make_unique<typename TestFixture::DiffNode>();
+  std::unique_ptr<Differentiator> diff = std::make_unique<typename TestFixture::DiffNode>();
   auto mesh = makeUnstructMesh1x1x1<TestFixture::kOrder>();
 
   EXPECT_EQ(diff->getOrder(), TestFixture::kOrder);

--- a/tests/units/gradient/impl/acoustic/test_gradient_acoustic.cc
+++ b/tests/units/gradient/impl/acoustic/test_gradient_acoustic.cc
@@ -3,34 +3,25 @@
 #include "data_type.h"
 #include "gradient_acoustic.h"
 
-namespace gradient
-{
-namespace test
-{
+namespace gradient {
+namespace test {
 
-class GradientAcousticTest : public ::testing::Test
-{
+class GradientAcousticTest : public ::testing::Test {
  protected:
-  void SetUp() override
-  {
+  void SetUp() override {
     numElements = 8;
     numNodes = 27;
 
-    gradKappaElem =
-        allocateVector<VECTOR_REAL_VIEW>(numElements, "gradKappaElem");
-    gradBuoyancyElem =
-        allocateVector<VECTOR_REAL_VIEW>(numElements, "gradBuoyancyElem");
+    gradKappaElem = allocateVector<VECTOR_REAL_VIEW>(numElements, "gradKappaElem");
+    gradBuoyancyElem = allocateVector<VECTOR_REAL_VIEW>(numElements, "gradBuoyancyElem");
     gradKappaNode = allocateVector<VECTOR_REAL_VIEW>(numNodes, "gradKappaNode");
-    gradBuoyancyNode =
-        allocateVector<VECTOR_REAL_VIEW>(numNodes, "gradBuoyancyNode");
+    gradBuoyancyNode = allocateVector<VECTOR_REAL_VIEW>(numNodes, "gradBuoyancyNode");
 
-    for (int i = 0; i < numElements; ++i)
-    {
+    for (int i = 0; i < numElements; ++i) {
       gradKappaElem(i) = static_cast<float>(i) * 1.5f;
       gradBuoyancyElem(i) = static_cast<float>(i) * 2.5f;
     }
-    for (int i = 0; i < numNodes; ++i)
-    {
+    for (int i = 0; i < numNodes; ++i) {
       gradKappaNode(i) = static_cast<float>(i) * 0.5f;
       gradBuoyancyNode(i) = static_cast<float>(i) * 1.0f;
     }
@@ -46,20 +37,15 @@ class GradientAcousticTest : public ::testing::Test
 
 // --- Static constants ---
 
-TEST_F(GradientAcousticTest, NumGradsConstant)
-{
-  EXPECT_EQ(GradientAcoustic::kNumGrads, 2);
-}
+TEST_F(GradientAcousticTest, NumGradsConstant) { EXPECT_EQ(GradientAcoustic::kNumGrads, 2); }
 
-TEST_F(GradientAcousticTest, GetGradientNamesCorrect)
-{
+TEST_F(GradientAcousticTest, GetGradientNamesCorrect) {
   GradientAcoustic grad(gradKappaElem, gradBuoyancyElem);
   EXPECT_EQ(grad.getGradientName(0), "gradKappa");
   EXPECT_EQ(grad.getGradientName(1), "gradBuoyancy");
 }
 
-TEST_F(GradientAcousticTest, ConstructorStoresViews)
-{
+TEST_F(GradientAcousticTest, ConstructorStoresViews) {
   GradientAcoustic grad(gradKappaElem, gradBuoyancyElem);
 
   // Verify via public interface
@@ -67,61 +53,50 @@ TEST_F(GradientAcousticTest, ConstructorStoresViews)
   EXPECT_EQ(grad.getGradient(1).extent(0), static_cast<size_t>(numElements));
 }
 
-TEST_F(GradientAcousticTest, GetNumGradientsReturns2)
-{
+TEST_F(GradientAcousticTest, GetNumGradientsReturns2) {
   GradientAcoustic grad(gradKappaElem, gradBuoyancyElem);
   EXPECT_EQ(grad.getNumGradients(), 2);
 }
 
-TEST_F(GradientAcousticTest, GetGradientNameByIndex)
-{
+TEST_F(GradientAcousticTest, GetGradientNameByIndex) {
   GradientAcoustic grad(gradKappaElem, gradBuoyancyElem);
   EXPECT_EQ(grad.getGradientName(0), "gradKappa");
   EXPECT_EQ(grad.getGradientName(1), "gradBuoyancy");
 }
 
-TEST_F(GradientAcousticTest, GetGradientKappaElementBased)
-{
+TEST_F(GradientAcousticTest, GetGradientKappaElementBased) {
   GradientAcoustic grad(gradKappaElem, gradBuoyancyElem);
   auto kappa = grad.getGradient(0);
 
   ASSERT_EQ(kappa.extent(0), static_cast<size_t>(numElements));
-  for (int i = 0; i < numElements; ++i)
-    EXPECT_FLOAT_EQ(kappa(i), static_cast<float>(i) * 1.5f);
+  for (int i = 0; i < numElements; ++i) EXPECT_FLOAT_EQ(kappa(i), static_cast<float>(i) * 1.5f);
 }
 
-TEST_F(GradientAcousticTest, GetGradientBuoyancyElementBased)
-{
+TEST_F(GradientAcousticTest, GetGradientBuoyancyElementBased) {
   GradientAcoustic grad(gradKappaElem, gradBuoyancyElem);
   auto buoyancy = grad.getGradient(1);
 
   ASSERT_EQ(buoyancy.extent(0), static_cast<size_t>(numElements));
-  for (int i = 0; i < numElements; ++i)
-    EXPECT_FLOAT_EQ(buoyancy(i), static_cast<float>(i) * 2.5f);
+  for (int i = 0; i < numElements; ++i) EXPECT_FLOAT_EQ(buoyancy(i), static_cast<float>(i) * 2.5f);
 }
 
-TEST_F(GradientAcousticTest, GetGradientKappaNodeBased)
-{
+TEST_F(GradientAcousticTest, GetGradientKappaNodeBased) {
   GradientAcoustic grad(gradKappaNode, gradBuoyancyNode);
   auto kappa = grad.getGradient(0);
 
   ASSERT_EQ(kappa.extent(0), static_cast<size_t>(numNodes));
-  for (int i = 0; i < numNodes; ++i)
-    EXPECT_FLOAT_EQ(kappa(i), static_cast<float>(i) * 0.5f);
+  for (int i = 0; i < numNodes; ++i) EXPECT_FLOAT_EQ(kappa(i), static_cast<float>(i) * 0.5f);
 }
 
-TEST_F(GradientAcousticTest, GetGradientBuoyancyNodeBased)
-{
+TEST_F(GradientAcousticTest, GetGradientBuoyancyNodeBased) {
   GradientAcoustic grad(gradKappaNode, gradBuoyancyNode);
   auto buoyancy = grad.getGradient(1);
 
   ASSERT_EQ(buoyancy.extent(0), static_cast<size_t>(numNodes));
-  for (int i = 0; i < numNodes; ++i)
-    EXPECT_FLOAT_EQ(buoyancy(i), static_cast<float>(i) * 1.0f);
+  for (int i = 0; i < numNodes; ++i) EXPECT_FLOAT_EQ(buoyancy(i), static_cast<float>(i) * 1.0f);
 }
 
-TEST_F(GradientAcousticTest, GetGradientOutOfBoundsFallsBackToKappa)
-{
+TEST_F(GradientAcousticTest, GetGradientOutOfBoundsFallsBackToKappa) {
   GradientAcoustic grad(gradKappaElem, gradBuoyancyElem);
   auto fallback = grad.getGradient(99);
 
@@ -130,8 +105,7 @@ TEST_F(GradientAcousticTest, GetGradientOutOfBoundsFallsBackToKappa)
   EXPECT_FLOAT_EQ(fallback(0), gradKappaElem(0));
 }
 
-TEST_F(GradientAcousticTest, ViewsAreShallowCopies)
-{
+TEST_F(GradientAcousticTest, ViewsAreShallowCopies) {
   GradientAcoustic grad(gradKappaElem, gradBuoyancyElem);
 
   // Modify through original view — change should be visible through gradient
@@ -139,16 +113,13 @@ TEST_F(GradientAcousticTest, ViewsAreShallowCopies)
   EXPECT_FLOAT_EQ(grad.getGradient(0)(0), 999.0f);
 }
 
-TEST_F(GradientAcousticTest, PrintDoesNotThrow)
-{
+TEST_F(GradientAcousticTest, PrintDoesNotThrow) {
   GradientAcoustic grad(gradKappaElem, gradBuoyancyElem);
   EXPECT_NO_THROW(grad.print());
 }
 
-TEST_F(GradientAcousticTest, PolymorphicInterface)
-{
-  std::unique_ptr<Gradient> grad =
-      std::make_unique<GradientAcoustic>(gradKappaElem, gradBuoyancyElem);
+TEST_F(GradientAcousticTest, PolymorphicInterface) {
+  std::unique_ptr<Gradient> grad = std::make_unique<GradientAcoustic>(gradKappaElem, gradBuoyancyElem);
 
   EXPECT_EQ(grad->getNumGradients(), 2);
   EXPECT_EQ(grad->getGradientName(0), "gradKappa");

--- a/tests/units/gradient/impl/acoustic/test_gradient_data_acoustic.cc
+++ b/tests/units/gradient/impl/acoustic/test_gradient_data_acoustic.cc
@@ -3,16 +3,12 @@
 #include "data_type.h"
 #include "differentiator_data_acoustic.h"
 
-namespace gradient
-{
-namespace test
-{
+namespace gradient {
+namespace test {
 
-class GradientDataAcousticTest : public ::testing::Test
-{
+class GradientDataAcousticTest : public ::testing::Test {
  protected:
-  void SetUp() override
-  {
+  void SetUp() override {
     size = 40;
 
     pn = allocateVector<VECTOR_REAL_VIEW>(size, "pn");
@@ -23,8 +19,7 @@ class GradientDataAcousticTest : public ::testing::Test
     gradKappa = allocateVector<VECTOR_REAL_VIEW>(size, "gradKappa");
     gradBuoyancy = allocateVector<VECTOR_REAL_VIEW>(size, "gradBuoyancy");
 
-    for (int i = 0; i < size; ++i)
-    {
+    for (int i = 0; i < size; ++i) {
       pn(i) = static_cast<float>(i) * 0.1f;
       qn(i) = static_cast<float>(i) * 0.2f;
       qnPrev(i) = static_cast<float>(i) * 0.3f;
@@ -39,8 +34,7 @@ class GradientDataAcousticTest : public ::testing::Test
   VECTOR_REAL_VIEW gradKappa, gradBuoyancy;
 };
 
-TEST_F(GradientDataAcousticTest, Construction)
-{
+TEST_F(GradientDataAcousticTest, Construction) {
   WavefieldViewForwardAcoustic fwd(pn);
   WavefieldViewBackwardAcoustic bwd(qn, qnPrev, qnPrevPrev);
   GradientAcoustic gradient(gradKappa, gradBuoyancy);
@@ -48,8 +42,7 @@ TEST_F(GradientDataAcousticTest, Construction)
   EXPECT_NO_THROW((GradientDataAcoustic{fwd, bwd, gradient}));
 }
 
-TEST_F(GradientDataAcousticTest, GetForwardFieldReturnsPn)
-{
+TEST_F(GradientDataAcousticTest, GetForwardFieldReturnsPn) {
   WavefieldViewForwardAcoustic fwd(pn);
   WavefieldViewBackwardAcoustic bwd(qn, qnPrev, qnPrevPrev);
   GradientAcoustic grad(gradKappa, gradBuoyancy);
@@ -57,12 +50,10 @@ TEST_F(GradientDataAcousticTest, GetForwardFieldReturnsPn)
 
   auto field = data.getForwardField(0);
   ASSERT_EQ(field.extent(0), static_cast<size_t>(size));
-  for (int i = 0; i < size; ++i)
-    EXPECT_FLOAT_EQ(field(i), static_cast<float>(i) * 0.1f);
+  for (int i = 0; i < size; ++i) EXPECT_FLOAT_EQ(field(i), static_cast<float>(i) * 0.1f);
 }
 
-TEST_F(GradientDataAcousticTest, GetBackwardFieldZeroReturnsQn)
-{
+TEST_F(GradientDataAcousticTest, GetBackwardFieldZeroReturnsQn) {
   WavefieldViewForwardAcoustic fwd(pn);
   WavefieldViewBackwardAcoustic bwd(qn, qnPrev, qnPrevPrev);
   GradientAcoustic grad(gradKappa, gradBuoyancy);
@@ -70,12 +61,10 @@ TEST_F(GradientDataAcousticTest, GetBackwardFieldZeroReturnsQn)
 
   auto field = data.getBackwardField(0);
   ASSERT_EQ(field.extent(0), static_cast<size_t>(size));
-  for (int i = 0; i < size; ++i)
-    EXPECT_FLOAT_EQ(field(i), static_cast<float>(i) * 0.2f);
+  for (int i = 0; i < size; ++i) EXPECT_FLOAT_EQ(field(i), static_cast<float>(i) * 0.2f);
 }
 
-TEST_F(GradientDataAcousticTest, GetBackwardFieldOneReturnsQnPrev)
-{
+TEST_F(GradientDataAcousticTest, GetBackwardFieldOneReturnsQnPrev) {
   WavefieldViewForwardAcoustic fwd(pn);
   WavefieldViewBackwardAcoustic bwd(qn, qnPrev, qnPrevPrev);
   GradientAcoustic grad(gradKappa, gradBuoyancy);
@@ -83,12 +72,10 @@ TEST_F(GradientDataAcousticTest, GetBackwardFieldOneReturnsQnPrev)
 
   auto field = data.getBackwardField(1);
   ASSERT_EQ(field.extent(0), static_cast<size_t>(size));
-  for (int i = 0; i < size; ++i)
-    EXPECT_FLOAT_EQ(field(i), static_cast<float>(i) * 0.3f);
+  for (int i = 0; i < size; ++i) EXPECT_FLOAT_EQ(field(i), static_cast<float>(i) * 0.3f);
 }
 
-TEST_F(GradientDataAcousticTest, GetBackwardFieldTwoReturnsQnPrevPrev)
-{
+TEST_F(GradientDataAcousticTest, GetBackwardFieldTwoReturnsQnPrevPrev) {
   WavefieldViewForwardAcoustic fwd(pn);
   WavefieldViewBackwardAcoustic bwd(qn, qnPrev, qnPrevPrev);
   GradientAcoustic grad(gradKappa, gradBuoyancy);
@@ -96,12 +83,10 @@ TEST_F(GradientDataAcousticTest, GetBackwardFieldTwoReturnsQnPrevPrev)
 
   auto field = data.getBackwardField(2);
   ASSERT_EQ(field.extent(0), static_cast<size_t>(size));
-  for (int i = 0; i < size; ++i)
-    EXPECT_FLOAT_EQ(field(i), static_cast<float>(i) * 0.4f);
+  for (int i = 0; i < size; ++i) EXPECT_FLOAT_EQ(field(i), static_cast<float>(i) * 0.4f);
 }
 
-TEST_F(GradientDataAcousticTest, GetGradientZeroReturnsKappa)
-{
+TEST_F(GradientDataAcousticTest, GetGradientZeroReturnsKappa) {
   WavefieldViewForwardAcoustic fwd(pn);
   WavefieldViewBackwardAcoustic bwd(qn, qnPrev, qnPrevPrev);
   GradientAcoustic grad(gradKappa, gradBuoyancy);
@@ -109,12 +94,10 @@ TEST_F(GradientDataAcousticTest, GetGradientZeroReturnsKappa)
 
   auto g = data.getGradient(0);
   ASSERT_EQ(g.extent(0), static_cast<size_t>(size));
-  for (int i = 0; i < size; ++i)
-    EXPECT_FLOAT_EQ(g(i), static_cast<float>(i) * 1.0f);
+  for (int i = 0; i < size; ++i) EXPECT_FLOAT_EQ(g(i), static_cast<float>(i) * 1.0f);
 }
 
-TEST_F(GradientDataAcousticTest, GetGradientOneReturnsBuoyancy)
-{
+TEST_F(GradientDataAcousticTest, GetGradientOneReturnsBuoyancy) {
   WavefieldViewForwardAcoustic fwd(pn);
   WavefieldViewBackwardAcoustic bwd(qn, qnPrev, qnPrevPrev);
   GradientAcoustic grad(gradKappa, gradBuoyancy);
@@ -122,12 +105,10 @@ TEST_F(GradientDataAcousticTest, GetGradientOneReturnsBuoyancy)
 
   auto g = data.getGradient(1);
   ASSERT_EQ(g.extent(0), static_cast<size_t>(size));
-  for (int i = 0; i < size; ++i)
-    EXPECT_FLOAT_EQ(g(i), static_cast<float>(i) * 2.0f);
+  for (int i = 0; i < size; ++i) EXPECT_FLOAT_EQ(g(i), static_cast<float>(i) * 2.0f);
 }
 
-TEST_F(GradientDataAcousticTest, PrintDoesNotThrow)
-{
+TEST_F(GradientDataAcousticTest, PrintDoesNotThrow) {
   WavefieldViewForwardAcoustic fwd(pn);
   WavefieldViewBackwardAcoustic bwd(qn, qnPrev, qnPrevPrev);
   GradientAcoustic grad(gradKappa, gradBuoyancy);

--- a/tests/units/gradient/impl/acoustic/test_wavefield_view_backward_acoustic.cc
+++ b/tests/units/gradient/impl/acoustic/test_wavefield_view_backward_acoustic.cc
@@ -3,24 +3,19 @@
 #include "data_type.h"
 #include "wavefield_view_backward_acoustic.h"
 
-namespace gradient
-{
-namespace test
-{
+namespace gradient {
+namespace test {
 
-class WavefieldViewBackwardAcousticTest : public ::testing::Test
-{
+class WavefieldViewBackwardAcousticTest : public ::testing::Test {
  protected:
-  void SetUp() override
-  {
+  void SetUp() override {
     size = 50;
     qn = allocateVector<VECTOR_REAL_VIEW>(size, "qn");
     qnPrev = allocateVector<VECTOR_REAL_VIEW>(size, "qnPrev");
     qnPrevPrev = allocateVector<VECTOR_REAL_VIEW>(size, "qnPrevPrev");
     dt = 0.001f;
 
-    for (int i = 0; i < size; ++i)
-    {
+    for (int i = 0; i < size; ++i) {
       qn(i) = static_cast<float>(i) * 2.0f;
       qnPrev(i) = static_cast<float>(i) * 3.0f;
       qnPrevPrev(i) = static_cast<float>(i) * 4.0f;
@@ -34,73 +29,61 @@ class WavefieldViewBackwardAcousticTest : public ::testing::Test
   VECTOR_REAL_VIEW qnPrevPrev;
 };
 
-TEST_F(WavefieldViewBackwardAcousticTest, NumFieldsConstant)
-{
+TEST_F(WavefieldViewBackwardAcousticTest, NumFieldsConstant) {
   EXPECT_EQ(WavefieldViewBackwardAcoustic::kNumFields, 3);
 }
 
-TEST_F(WavefieldViewBackwardAcousticTest, GetFieldNamesCorrect)
-{
+TEST_F(WavefieldViewBackwardAcousticTest, GetFieldNamesCorrect) {
   WavefieldViewBackwardAcoustic view(qn, qnPrev, qnPrevPrev);
   EXPECT_EQ(view.getFieldName(0), "qn");
   EXPECT_EQ(view.getFieldName(1), "qnPrev");
   EXPECT_EQ(view.getFieldName(2), "qnPrevPrev");
 }
 
-TEST_F(WavefieldViewBackwardAcousticTest, ConstructorStoresFields)
-{
+TEST_F(WavefieldViewBackwardAcousticTest, ConstructorStoresFields) {
   WavefieldViewBackwardAcoustic view(qn, qnPrev, qnPrevPrev);
   EXPECT_EQ(view.getField(0).extent(0), static_cast<size_t>(size));
   EXPECT_EQ(view.getField(1).extent(0), static_cast<size_t>(size));
   EXPECT_EQ(view.getField(2).extent(0), static_cast<size_t>(size));
 }
 
-TEST_F(WavefieldViewBackwardAcousticTest, GetNumFieldsReturns3)
-{
+TEST_F(WavefieldViewBackwardAcousticTest, GetNumFieldsReturns3) {
   WavefieldViewBackwardAcoustic view(qn, qnPrev, qnPrevPrev);
   EXPECT_EQ(view.getNumFields(), 3);
 }
 
-TEST_F(WavefieldViewBackwardAcousticTest, GetFieldNameByIndex)
-{
+TEST_F(WavefieldViewBackwardAcousticTest, GetFieldNameByIndex) {
   WavefieldViewBackwardAcoustic view(qn, qnPrev, qnPrevPrev);
   EXPECT_EQ(view.getFieldName(0), "qn");
   EXPECT_EQ(view.getFieldName(1), "qnPrev");
   EXPECT_EQ(view.getFieldName(2), "qnPrevPrev");
 }
 
-TEST_F(WavefieldViewBackwardAcousticTest, GetFieldZeroReturnsQn)
-{
+TEST_F(WavefieldViewBackwardAcousticTest, GetFieldZeroReturnsQn) {
   WavefieldViewBackwardAcoustic view(qn, qnPrev, qnPrevPrev);
   auto field = view.getField(0);
 
   ASSERT_EQ(field.extent(0), static_cast<size_t>(size));
-  for (int i = 0; i < size; ++i)
-    EXPECT_FLOAT_EQ(field(i), static_cast<float>(i) * 2.0f);
+  for (int i = 0; i < size; ++i) EXPECT_FLOAT_EQ(field(i), static_cast<float>(i) * 2.0f);
 }
 
-TEST_F(WavefieldViewBackwardAcousticTest, GetFieldOneReturnsQnPrev)
-{
+TEST_F(WavefieldViewBackwardAcousticTest, GetFieldOneReturnsQnPrev) {
   WavefieldViewBackwardAcoustic view(qn, qnPrev, qnPrevPrev);
   auto field = view.getField(1);
 
   ASSERT_EQ(field.extent(0), static_cast<size_t>(size));
-  for (int i = 0; i < size; ++i)
-    EXPECT_FLOAT_EQ(field(i), static_cast<float>(i) * 3.0f);
+  for (int i = 0; i < size; ++i) EXPECT_FLOAT_EQ(field(i), static_cast<float>(i) * 3.0f);
 }
 
-TEST_F(WavefieldViewBackwardAcousticTest, GetFieldTwoReturnsQnPrevPrev)
-{
+TEST_F(WavefieldViewBackwardAcousticTest, GetFieldTwoReturnsQnPrevPrev) {
   WavefieldViewBackwardAcoustic view(qn, qnPrev, qnPrevPrev);
   auto field = view.getField(2);
 
   ASSERT_EQ(field.extent(0), static_cast<size_t>(size));
-  for (int i = 0; i < size; ++i)
-    EXPECT_FLOAT_EQ(field(i), static_cast<float>(i) * 4.0f);
+  for (int i = 0; i < size; ++i) EXPECT_FLOAT_EQ(field(i), static_cast<float>(i) * 4.0f);
 }
 
-TEST_F(WavefieldViewBackwardAcousticTest, GetFieldOutOfBoundsFallsBackToQn)
-{
+TEST_F(WavefieldViewBackwardAcousticTest, GetFieldOutOfBoundsFallsBackToQn) {
   WavefieldViewBackwardAcoustic view(qn, qnPrev, qnPrevPrev);
   auto fallback = view.getField(99);
 
@@ -108,37 +91,31 @@ TEST_F(WavefieldViewBackwardAcousticTest, GetFieldOutOfBoundsFallsBackToQn)
   EXPECT_FLOAT_EQ(fallback(0), qn(0));
 }
 
-TEST_F(WavefieldViewBackwardAcousticTest, QnViewIsShallowCopy)
-{
+TEST_F(WavefieldViewBackwardAcousticTest, QnViewIsShallowCopy) {
   WavefieldViewBackwardAcoustic view(qn, qnPrev, qnPrevPrev);
   qn(1) = 555.0f;
   EXPECT_FLOAT_EQ(view.getField(0)(1), 555.0f);
 }
 
-TEST_F(WavefieldViewBackwardAcousticTest, QnPrevViewIsShallowCopy)
-{
+TEST_F(WavefieldViewBackwardAcousticTest, QnPrevViewIsShallowCopy) {
   WavefieldViewBackwardAcoustic view(qn, qnPrev, qnPrevPrev);
   qnPrev(3) = 666.0f;
   EXPECT_FLOAT_EQ(view.getField(1)(3), 666.0f);
 }
 
-TEST_F(WavefieldViewBackwardAcousticTest, QnPrevPrevViewIsShallowCopy)
-{
+TEST_F(WavefieldViewBackwardAcousticTest, QnPrevPrevViewIsShallowCopy) {
   WavefieldViewBackwardAcoustic view(qn, qnPrev, qnPrevPrev);
   qnPrevPrev(5) = 777.0f;
   EXPECT_FLOAT_EQ(view.getField(2)(5), 777.0f);
 }
 
-TEST_F(WavefieldViewBackwardAcousticTest, PrintDoesNotThrow)
-{
+TEST_F(WavefieldViewBackwardAcousticTest, PrintDoesNotThrow) {
   WavefieldViewBackwardAcoustic view(qn, qnPrev, qnPrevPrev);
   EXPECT_NO_THROW(view.print());
 }
 
-TEST_F(WavefieldViewBackwardAcousticTest, PolymorphicInterface)
-{
-  std::unique_ptr<WavefieldView> view =
-      std::make_unique<WavefieldViewBackwardAcoustic>(qn, qnPrev, qnPrevPrev);
+TEST_F(WavefieldViewBackwardAcousticTest, PolymorphicInterface) {
+  std::unique_ptr<WavefieldView> view = std::make_unique<WavefieldViewBackwardAcoustic>(qn, qnPrev, qnPrevPrev);
 
   EXPECT_EQ(view->getNumFields(), 3);
   EXPECT_EQ(view->getFieldName(0), "qn");

--- a/tests/units/gradient/impl/acoustic/test_wavefield_view_forward_acoustic.cc
+++ b/tests/units/gradient/impl/acoustic/test_wavefield_view_forward_acoustic.cc
@@ -3,16 +3,12 @@
 #include "data_type.h"
 #include "wavefield_view_forward_acoustic.h"
 
-namespace gradient
-{
-namespace test
-{
+namespace gradient {
+namespace test {
 
-class WavefieldViewForwardAcousticTest : public ::testing::Test
-{
+class WavefieldViewForwardAcousticTest : public ::testing::Test {
  protected:
-  void SetUp() override
-  {
+  void SetUp() override {
     size = 50;
     pn = allocateVector<VECTOR_REAL_VIEW>(size, "pn");
 
@@ -23,70 +19,56 @@ class WavefieldViewForwardAcousticTest : public ::testing::Test
   VECTOR_REAL_VIEW pn;
 };
 
-TEST_F(WavefieldViewForwardAcousticTest, NumFieldsConstant)
-{
-  EXPECT_EQ(WavefieldViewForwardAcoustic::kNumFields, 1);
-}
+TEST_F(WavefieldViewForwardAcousticTest, NumFieldsConstant) { EXPECT_EQ(WavefieldViewForwardAcoustic::kNumFields, 1); }
 
-TEST_F(WavefieldViewForwardAcousticTest, GetFieldNameCorrect)
-{
+TEST_F(WavefieldViewForwardAcousticTest, GetFieldNameCorrect) {
   WavefieldViewForwardAcoustic view(pn);
   EXPECT_EQ(view.getFieldName(0), "pn");
 }
 
-TEST_F(WavefieldViewForwardAcousticTest, ConstructorStoresPn)
-{
+TEST_F(WavefieldViewForwardAcousticTest, ConstructorStoresPn) {
   WavefieldViewForwardAcoustic view(pn);
   EXPECT_EQ(view.getField(0).extent(0), static_cast<size_t>(size));
 }
 
-TEST_F(WavefieldViewForwardAcousticTest, GetNumFieldsReturns1)
-{
+TEST_F(WavefieldViewForwardAcousticTest, GetNumFieldsReturns1) {
   WavefieldViewForwardAcoustic view(pn);
   EXPECT_EQ(view.getNumFields(), 1);
 }
 
-TEST_F(WavefieldViewForwardAcousticTest, GetFieldNameReturnsCorrectString)
-{
+TEST_F(WavefieldViewForwardAcousticTest, GetFieldNameReturnsCorrectString) {
   WavefieldViewForwardAcoustic view(pn);
   EXPECT_EQ(view.getFieldName(0), "pn");
 }
 
-TEST_F(WavefieldViewForwardAcousticTest, GetFieldZeroReturnsPn)
-{
+TEST_F(WavefieldViewForwardAcousticTest, GetFieldZeroReturnsPn) {
   WavefieldViewForwardAcoustic view(pn);
   auto field = view.getField(0);
 
   ASSERT_EQ(field.extent(0), static_cast<size_t>(size));
-  for (int i = 0; i < size; ++i)
-    EXPECT_FLOAT_EQ(field(i), static_cast<float>(i) * 0.1f);
+  for (int i = 0; i < size; ++i) EXPECT_FLOAT_EQ(field(i), static_cast<float>(i) * 0.1f);
 }
 
-TEST_F(WavefieldViewForwardAcousticTest, GetFieldOutOfBoundsReturnsPn)
-{
+TEST_F(WavefieldViewForwardAcousticTest, GetFieldOutOfBoundsReturnsPn) {
   // All indices return m_pn (only one field)
   WavefieldViewForwardAcoustic view(pn);
   auto field = view.getField(5);
   EXPECT_EQ(field.extent(0), static_cast<size_t>(size));
 }
 
-TEST_F(WavefieldViewForwardAcousticTest, ViewIsShallowCopy)
-{
+TEST_F(WavefieldViewForwardAcousticTest, ViewIsShallowCopy) {
   WavefieldViewForwardAcoustic view(pn);
   pn(0) = 123.0f;
   EXPECT_FLOAT_EQ(view.getField(0)(0), 123.0f);
 }
 
-TEST_F(WavefieldViewForwardAcousticTest, PrintDoesNotThrow)
-{
+TEST_F(WavefieldViewForwardAcousticTest, PrintDoesNotThrow) {
   WavefieldViewForwardAcoustic view(pn);
   EXPECT_NO_THROW(view.print());
 }
 
-TEST_F(WavefieldViewForwardAcousticTest, PolymorphicInterface)
-{
-  std::unique_ptr<WavefieldView> view =
-      std::make_unique<WavefieldViewForwardAcoustic>(pn);
+TEST_F(WavefieldViewForwardAcousticTest, PolymorphicInterface) {
+  std::unique_ptr<WavefieldView> view = std::make_unique<WavefieldViewForwardAcoustic>(pn);
 
   EXPECT_EQ(view->getNumFields(), 1);
   EXPECT_EQ(view->getFieldName(0), "pn");

--- a/tests/units/gradient/impl/elastic/makutu/test_differentiator_elastic_makutu_struct.cc
+++ b/tests/units/gradient/impl/elastic/makutu/test_differentiator_elastic_makutu_struct.cc
@@ -9,25 +9,20 @@
 #include "differentiator_elastic.h"
 #include "model_struct.h"
 
-namespace gradient
-{
-namespace test
-{
+namespace gradient {
+namespace test {
 
 // =============================================================================
 // Order wrappers
 // =============================================================================
 
-struct Order1
-{
+struct Order1 {
   static constexpr int kOrder = 1;
 };
-struct Order2
-{
+struct Order2 {
   static constexpr int kOrder = 2;
 };
-struct Order3
-{
+struct Order3 {
   static constexpr int kOrder = 3;
 };
 
@@ -45,8 +40,7 @@ using OrderTypes = ::testing::Types<Order1, Order2, Order3>;
 // =============================================================================
 
 template <int ORDER>
-static model::ModelStruct<float, int, ORDER> makeMesh1x1x1()
-{
+static model::ModelStruct<float, int, ORDER> makeMesh1x1x1() {
   model::ModelStructData<float, int> data;
   data.ex_ = 1;
   data.ey_ = 1;
@@ -70,20 +64,17 @@ static model::ModelStruct<float, int, ORDER> makeMesh1x1x1()
 // =============================================================================
 
 template <typename OrderWrapper>
-class DifferentiatorElasticElemTest : public ::testing::Test
-{
+class DifferentiatorElasticElemTest : public ::testing::Test {
  protected:
   static constexpr int kOrder = OrderWrapper::kOrder;
   static constexpr int kNumNodes = (kOrder + 1) * (kOrder + 1) * (kOrder + 1);
   static constexpr int kNumElements = 1;
 
   using Mesh = model::ModelStruct<float, int, kOrder>;
-  using Integral =
-      typename IntegralTypeSelector<kOrder, IntegralType::MAKUTU>::type;
+  using Integral = typename IntegralTypeSelector<kOrder, IntegralType::MAKUTU>::type;
   using Diff = DifferentiatorElastic<kOrder, Integral, Mesh, false>;
 
-  void SetUp() override
-  {
+  void SetUp() override {
     ux_fwd = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "ux_fwd");
     uy_fwd = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uy_fwd");
     uz_fwd = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uz_fwd");
@@ -97,8 +88,7 @@ class DifferentiatorElasticElemTest : public ::testing::Test
     gradLambda = allocateVector<VECTOR_REAL_VIEW>(kNumElements, "gradLambda");
     gradMu = allocateVector<VECTOR_REAL_VIEW>(kNumElements, "gradMu");
 
-    for (int i = 0; i < kNumNodes; ++i)
-    {
+    for (int i = 0; i < kNumNodes; ++i) {
       ux_fwd(i) = 0.0f;
       uy_fwd(i) = 0.0f;
       uz_fwd(i) = 0.0f;
@@ -114,12 +104,10 @@ class DifferentiatorElasticElemTest : public ::testing::Test
     gradMu(0) = 0.0f;
   }
 
-  void makeDataAndCompute(Diff& diff, float dt = 0.001f)
-  {
+  void makeDataAndCompute(Diff& diff, float dt = 0.001f) {
     auto mesh = makeMesh1x1x1<kOrder>();
     WavefieldViewForwardElastic fwd(ux_fwd, uy_fwd, uz_fwd);
-    WavefieldViewBackwardElastic bwd(ux_adj, uy_adj, uz_adj, ux_dt2, uy_dt2,
-                                     uz_dt2);
+    WavefieldViewBackwardElastic bwd(ux_adj, uy_adj, uz_adj, ux_dt2, uy_dt2, uz_dt2);
     GradientElastic grad(gradRho, gradLambda, gradMu);
     GradientDataElastic data(fwd, bwd, grad);
     diff.compute(mesh, data, dt);
@@ -135,47 +123,36 @@ TYPED_TEST_SUITE(DifferentiatorElasticElemTest, OrderTypes);
 
 // --- Static constants ---
 
-TYPED_TEST(DifferentiatorElasticElemTest, OrderConstant)
-{
-  EXPECT_EQ(TestFixture::Diff::kOrder, TestFixture::kOrder);
-}
+TYPED_TEST(DifferentiatorElasticElemTest, OrderConstant) { EXPECT_EQ(TestFixture::Diff::kOrder, TestFixture::kOrder); }
 
-TYPED_TEST(DifferentiatorElasticElemTest, IsModelOnNodesConstant)
-{
-  EXPECT_FALSE(TestFixture::Diff::kIsModelOnNodes);
-}
+TYPED_TEST(DifferentiatorElasticElemTest, IsModelOnNodesConstant) { EXPECT_FALSE(TestFixture::Diff::kIsModelOnNodes); }
 
-TYPED_TEST(DifferentiatorElasticElemTest, PointsPerElementConstant)
-{
+TYPED_TEST(DifferentiatorElasticElemTest, PointsPerElementConstant) {
   EXPECT_EQ(TestFixture::Diff::kPointsPerElement, TestFixture::kNumNodes);
 }
 
 // --- Virtual getters ---
 
-TYPED_TEST(DifferentiatorElasticElemTest, GetOrderReturnsCorrectOrder)
-{
+TYPED_TEST(DifferentiatorElasticElemTest, GetOrderReturnsCorrectOrder) {
   typename TestFixture::Diff diff;
   EXPECT_EQ(diff.getOrder(), TestFixture::kOrder);
 }
 
-TYPED_TEST(DifferentiatorElasticElemTest, IsModelOnNodesReturnsFalse)
-{
+TYPED_TEST(DifferentiatorElasticElemTest, IsModelOnNodesReturnsFalse) {
   typename TestFixture::Diff diff;
   EXPECT_FALSE(diff.isModelOnNodes());
 }
 
 // --- Print ---
 
-TYPED_TEST(DifferentiatorElasticElemTest, PrintDoesNotThrow)
-{
+TYPED_TEST(DifferentiatorElasticElemTest, PrintDoesNotThrow) {
   typename TestFixture::Diff diff;
   EXPECT_NO_THROW(diff.print());
 }
 
 // --- compute() correctness ---
 
-TYPED_TEST(DifferentiatorElasticElemTest, ZeroWavefieldsYieldZeroGradients)
-{
+TYPED_TEST(DifferentiatorElasticElemTest, ZeroWavefieldsYieldZeroGradients) {
   typename TestFixture::Diff diff;
   this->makeDataAndCompute(diff);
 
@@ -184,12 +161,10 @@ TYPED_TEST(DifferentiatorElasticElemTest, ZeroWavefieldsYieldZeroGradients)
   EXPECT_FLOAT_EQ(this->gradMu(0), 0.0f);
 }
 
-TYPED_TEST(DifferentiatorElasticElemTest, UniformFieldGradRhoEqualsVolume)
-{
+TYPED_TEST(DifferentiatorElasticElemTest, UniformFieldGradRhoEqualsVolume) {
   // ux_fwd = 1, ux_dt2 = 1 on all nodes =>
   //   gradRho = ∫_Ω (ü†_x · u_x) dΩ = ∫_Ω 1 dΩ = 1.0 (unit cube)
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->ux_fwd(i) = 1.0f;
     this->ux_dt2(i) = 1.0f;
   }
@@ -200,13 +175,11 @@ TYPED_TEST(DifferentiatorElasticElemTest, UniformFieldGradRhoEqualsVolume)
   EXPECT_NEAR(this->gradRho(0), 1.0f, 1e-5f);
 }
 
-TYPED_TEST(DifferentiatorElasticElemTest, GradRhoAllThreeComponents)
-{
+TYPED_TEST(DifferentiatorElasticElemTest, GradRhoAllThreeComponents) {
   // All forward and dt2 components active:
   //   gradRho = ∫(ü†_x·u_x + ü†_y·u_y + ü†_z·u_z) dΩ
   // u_x=1,u_y=2,u_z=3 with all dt2=1  =>  gradRho = (1+2+3) * volume = 6.0
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->ux_fwd(i) = 1.0f;
     this->uy_fwd(i) = 2.0f;
     this->uz_fwd(i) = 3.0f;
@@ -221,11 +194,9 @@ TYPED_TEST(DifferentiatorElasticElemTest, GradRhoAllThreeComponents)
   EXPECT_NEAR(this->gradRho(0), 6.0f, 1e-4f);
 }
 
-TYPED_TEST(DifferentiatorElasticElemTest, ConstantFieldGradLambdaIsZero)
-{
+TYPED_TEST(DifferentiatorElasticElemTest, ConstantFieldGradLambdaIsZero) {
   // Constant displacement => ∇u = 0 => div(u†) = div(u) = 0 => gradLambda = 0
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->ux_fwd(i) = 1.0f;
     this->uy_fwd(i) = 1.0f;
     this->uz_fwd(i) = 1.0f;
@@ -240,11 +211,9 @@ TYPED_TEST(DifferentiatorElasticElemTest, ConstantFieldGradLambdaIsZero)
   EXPECT_NEAR(this->gradLambda(0), 0.0f, 1e-5f);
 }
 
-TYPED_TEST(DifferentiatorElasticElemTest, ConstantFieldGradMuIsZero)
-{
+TYPED_TEST(DifferentiatorElasticElemTest, ConstantFieldGradMuIsZero) {
   // Constant displacement => ε(u) = 0 => gradMu = 0
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->ux_fwd(i) = 1.0f;
     this->uy_fwd(i) = 1.0f;
     this->uz_fwd(i) = 1.0f;
@@ -259,11 +228,9 @@ TYPED_TEST(DifferentiatorElasticElemTest, ConstantFieldGradMuIsZero)
   EXPECT_NEAR(this->gradMu(0), 0.0f, 1e-5f);
 }
 
-TYPED_TEST(DifferentiatorElasticElemTest, GradRhoScalesWithAmplitude)
-{
+TYPED_TEST(DifferentiatorElasticElemTest, GradRhoScalesWithAmplitude) {
   // Doubling ux_fwd doubles gradRho (linearity)
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->ux_fwd(i) = 1.0f;
     this->ux_dt2(i) = 1.0f;
   }
@@ -281,11 +248,8 @@ TYPED_TEST(DifferentiatorElasticElemTest, GradRhoScalesWithAmplitude)
   EXPECT_NEAR(this->gradRho(0), 2.0f * single, 1e-5f);
 }
 
-TYPED_TEST(DifferentiatorElasticElemTest,
-           ComputeAccumulatesIntoExistingGradient)
-{
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+TYPED_TEST(DifferentiatorElasticElemTest, ComputeAccumulatesIntoExistingGradient) {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->ux_fwd(i) = 1.0f;
     this->ux_dt2(i) = 1.0f;
   }
@@ -298,8 +262,7 @@ TYPED_TEST(DifferentiatorElasticElemTest,
   EXPECT_NEAR(this->gradRho(0), 6.0f, 1e-5f);
 }
 
-TYPED_TEST(DifferentiatorElasticElemTest, GradLambdaNonZeroForLinearField)
-{
+TYPED_TEST(DifferentiatorElasticElemTest, GradLambdaNonZeroForLinearField) {
   // Linear displacement u_x = x => div(u) = ∂u_x/∂x = 1
   // If both forward and adjoint have u_x = x:
   //   gradLambda = ∫ div(u†)·div(u) dΩ = ∫ 1·1 dΩ = 1.0
@@ -309,8 +272,7 @@ TYPED_TEST(DifferentiatorElasticElemTest, GradLambdaNonZeroForLinearField)
   int const dim = TestFixture::kOrder + 1;
   for (int k = 0; k < dim; ++k)
     for (int j = 0; j < dim; ++j)
-      for (int i = 0; i < dim; ++i)
-      {
+      for (int i = 0; i < dim; ++i) {
         int gIdx = mesh.globalNodeIndex(0, i, j, k);
         float x = static_cast<float>(i) / TestFixture::kOrder;
         this->ux_fwd(gIdx) = x;
@@ -320,8 +282,7 @@ TYPED_TEST(DifferentiatorElasticElemTest, GradLambdaNonZeroForLinearField)
   typename TestFixture::Diff diff;
 
   WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
-  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
-                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj, this->ux_dt2, this->uy_dt2, this->uz_dt2);
   GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
   GradientDataElastic data(fwd, bwd, grad);
   diff.compute(mesh, data, 0.001f);
@@ -332,8 +293,7 @@ TYPED_TEST(DifferentiatorElasticElemTest, GradLambdaNonZeroForLinearField)
   EXPECT_NEAR(this->gradLambda(0), 1.0f, 0.2f);
 }
 
-TYPED_TEST(DifferentiatorElasticElemTest, GradMuNonZeroForLinearField)
-{
+TYPED_TEST(DifferentiatorElasticElemTest, GradMuNonZeroForLinearField) {
   // Linear displacement u_x = x => ε_xx = 1, all other ε_ij = 0
   // If both forward and adjoint have u_x = x:
   //   2·ε†:ε = 2·(1·1) = 2
@@ -342,8 +302,7 @@ TYPED_TEST(DifferentiatorElasticElemTest, GradMuNonZeroForLinearField)
   int const dim = TestFixture::kOrder + 1;
   for (int k = 0; k < dim; ++k)
     for (int j = 0; j < dim; ++j)
-      for (int i = 0; i < dim; ++i)
-      {
+      for (int i = 0; i < dim; ++i) {
         int gIdx = mesh.globalNodeIndex(0, i, j, k);
         float x = static_cast<float>(i) / TestFixture::kOrder;
         this->ux_fwd(gIdx) = x;
@@ -353,8 +312,7 @@ TYPED_TEST(DifferentiatorElasticElemTest, GradMuNonZeroForLinearField)
   typename TestFixture::Diff diff;
 
   WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
-  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
-                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj, this->ux_dt2, this->uy_dt2, this->uz_dt2);
   GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
   GradientDataElastic data(fwd, bwd, grad);
   diff.compute(mesh, data, 0.001f);
@@ -363,8 +321,7 @@ TYPED_TEST(DifferentiatorElasticElemTest, GradMuNonZeroForLinearField)
   EXPECT_NEAR(this->gradMu(0), 2.0f, 0.4f);
 }
 
-TYPED_TEST(DifferentiatorElasticElemTest, LinearShearFieldProducesCorrectGradMu)
-{
+TYPED_TEST(DifferentiatorElasticElemTest, LinearShearFieldProducesCorrectGradMu) {
   // Pure shear: u_x = y, u_y = x  => ε_xy = 1, all diagonal ε = 0,
   //   div(u) = 0
   // 2·ε†:ε = 4·(ε_xy†·ε_xy) = 4·1 = 4
@@ -374,8 +331,7 @@ TYPED_TEST(DifferentiatorElasticElemTest, LinearShearFieldProducesCorrectGradMu)
   int const dim = TestFixture::kOrder + 1;
   for (int k = 0; k < dim; ++k)
     for (int j = 0; j < dim; ++j)
-      for (int i = 0; i < dim; ++i)
-      {
+      for (int i = 0; i < dim; ++i) {
         int gIdx = mesh.globalNodeIndex(0, i, j, k);
         float x = static_cast<float>(i) / TestFixture::kOrder;
         float y = static_cast<float>(j) / TestFixture::kOrder;
@@ -388,8 +344,7 @@ TYPED_TEST(DifferentiatorElasticElemTest, LinearShearFieldProducesCorrectGradMu)
   typename TestFixture::Diff diff;
 
   WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
-  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
-                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj, this->ux_dt2, this->uy_dt2, this->uz_dt2);
   GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
   GradientDataElastic data(fwd, bwd, grad);
   diff.compute(mesh, data, 0.001f);
@@ -398,8 +353,7 @@ TYPED_TEST(DifferentiatorElasticElemTest, LinearShearFieldProducesCorrectGradMu)
   EXPECT_NEAR(this->gradMu(0), 4.0f, 0.4f);
 }
 
-TYPED_TEST(DifferentiatorElasticElemTest, PureDilatationLambdaMuConsistency)
-{
+TYPED_TEST(DifferentiatorElasticElemTest, PureDilatationLambdaMuConsistency) {
   // Pure dilatation: u_x = x, u_y = y, u_z = z
   //   div(u) = 3, ε_xx = ε_yy = ε_zz = 1, off-diag = 0
   //   gradLambda = ∫ 3·3 dΩ = 9.0
@@ -409,8 +363,7 @@ TYPED_TEST(DifferentiatorElasticElemTest, PureDilatationLambdaMuConsistency)
   int const dim = TestFixture::kOrder + 1;
   for (int k = 0; k < dim; ++k)
     for (int j = 0; j < dim; ++j)
-      for (int i = 0; i < dim; ++i)
-      {
+      for (int i = 0; i < dim; ++i) {
         int gIdx = mesh.globalNodeIndex(0, i, j, k);
         float x = static_cast<float>(i) / TestFixture::kOrder;
         float y = static_cast<float>(j) / TestFixture::kOrder;
@@ -426,8 +379,7 @@ TYPED_TEST(DifferentiatorElasticElemTest, PureDilatationLambdaMuConsistency)
   typename TestFixture::Diff diff;
 
   WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
-  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
-                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj, this->ux_dt2, this->uy_dt2, this->uz_dt2);
   GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
   GradientDataElastic data(fwd, bwd, grad);
   diff.compute(mesh, data, 0.001f);
@@ -436,8 +388,7 @@ TYPED_TEST(DifferentiatorElasticElemTest, PureDilatationLambdaMuConsistency)
   EXPECT_NEAR(this->gradMu(0), 6.0f, 1.0f);
 }
 
-TYPED_TEST(DifferentiatorElasticElemTest, GradRhoIndependentOfStrainKernels)
-{
+TYPED_TEST(DifferentiatorElasticElemTest, GradRhoIndependentOfStrainKernels) {
   // gradRho depends only on dt2 and fwd, not on adjoint displacement gradients
   // Set ux_fwd=1, ux_dt2=1 but also set non-trivial adjoint displacement
   // => gradRho should still be 1.0
@@ -445,8 +396,7 @@ TYPED_TEST(DifferentiatorElasticElemTest, GradRhoIndependentOfStrainKernels)
   int const dim = TestFixture::kOrder + 1;
   for (int k = 0; k < dim; ++k)
     for (int j = 0; j < dim; ++j)
-      for (int i = 0; i < dim; ++i)
-      {
+      for (int i = 0; i < dim; ++i) {
         int gIdx = mesh.globalNodeIndex(0, i, j, k);
         float x = static_cast<float>(i) / TestFixture::kOrder;
         this->ux_fwd(gIdx) = 1.0f;
@@ -459,8 +409,7 @@ TYPED_TEST(DifferentiatorElasticElemTest, GradRhoIndependentOfStrainKernels)
   typename TestFixture::Diff diff;
 
   WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
-  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
-                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj, this->ux_dt2, this->uy_dt2, this->uz_dt2);
   GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
   GradientDataElastic data(fwd, bwd, grad);
   diff.compute(mesh, data, 0.001f);
@@ -471,24 +420,20 @@ TYPED_TEST(DifferentiatorElasticElemTest, GradRhoIndependentOfStrainKernels)
 
 // --- Polymorphic interface ---
 
-TYPED_TEST(DifferentiatorElasticElemTest, PolymorphicInterface)
-{
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+TYPED_TEST(DifferentiatorElasticElemTest, PolymorphicInterface) {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->ux_fwd(i) = 1.0f;
     this->ux_dt2(i) = 1.0f;
   }
 
-  std::unique_ptr<Differentiator> diff =
-      std::make_unique<typename TestFixture::Diff>();
+  std::unique_ptr<Differentiator> diff = std::make_unique<typename TestFixture::Diff>();
   auto mesh = makeMesh1x1x1<TestFixture::kOrder>();
 
   EXPECT_EQ(diff->getOrder(), TestFixture::kOrder);
   EXPECT_FALSE(diff->isModelOnNodes());
 
   WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
-  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
-                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj, this->ux_dt2, this->uy_dt2, this->uz_dt2);
   GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
   GradientDataElastic data(fwd, bwd, grad);
 
@@ -504,21 +449,18 @@ TYPED_TEST(DifferentiatorElasticElemTest, PolymorphicInterface)
 // =============================================================================
 
 template <typename OrderWrapper>
-class DifferentiatorElasticNodeTest : public ::testing::Test
-{
+class DifferentiatorElasticNodeTest : public ::testing::Test {
  protected:
   static constexpr int kOrder = OrderWrapper::kOrder;
   static constexpr int kNumNodes = (kOrder + 1) * (kOrder + 1) * (kOrder + 1);
   static constexpr int kNumElements = 1;
 
   using Mesh = model::ModelStruct<float, int, kOrder>;
-  using Integral =
-      typename IntegralTypeSelector<kOrder, IntegralType::MAKUTU>::type;
+  using Integral = typename IntegralTypeSelector<kOrder, IntegralType::MAKUTU>::type;
   using DiffNode = DifferentiatorElastic<kOrder, Integral, Mesh, true>;
   using DiffElem = DifferentiatorElastic<kOrder, Integral, Mesh, false>;
 
-  void SetUp() override
-  {
+  void SetUp() override {
     ux_fwd = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "ux_fwd");
     uy_fwd = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uy_fwd");
     uz_fwd = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uz_fwd");
@@ -532,8 +474,7 @@ class DifferentiatorElasticNodeTest : public ::testing::Test
     gradLambda = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "gradLambda");
     gradMu = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "gradMu");
 
-    for (int i = 0; i < kNumNodes; ++i)
-    {
+    for (int i = 0; i < kNumNodes; ++i) {
       ux_fwd(i) = 0.0f;
       uy_fwd(i) = 0.0f;
       uz_fwd(i) = 0.0f;
@@ -549,8 +490,7 @@ class DifferentiatorElasticNodeTest : public ::testing::Test
     }
   }
 
-  float sumGrad(VECTOR_REAL_VIEW const& v) const
-  {
+  float sumGrad(VECTOR_REAL_VIEW const& v) const {
     float s = 0.0f;
     for (int i = 0; i < kNumNodes; ++i) s += v(i);
     return s;
@@ -570,43 +510,37 @@ TYPED_TEST_SUITE(DifferentiatorElasticNodeTest, OrderTypes);
 
 // --- Static constants ---
 
-TYPED_TEST(DifferentiatorElasticNodeTest, IsModelOnNodesConstant)
-{
+TYPED_TEST(DifferentiatorElasticNodeTest, IsModelOnNodesConstant) {
   EXPECT_TRUE(TestFixture::DiffNode::kIsModelOnNodes);
 }
 
 // --- Virtual getters ---
 
-TYPED_TEST(DifferentiatorElasticNodeTest, GetOrderReturnsCorrectOrder)
-{
+TYPED_TEST(DifferentiatorElasticNodeTest, GetOrderReturnsCorrectOrder) {
   typename TestFixture::DiffNode diff;
   EXPECT_EQ(diff.getOrder(), TestFixture::kOrder);
 }
 
-TYPED_TEST(DifferentiatorElasticNodeTest, IsModelOnNodesReturnsTrue)
-{
+TYPED_TEST(DifferentiatorElasticNodeTest, IsModelOnNodesReturnsTrue) {
   typename TestFixture::DiffNode diff;
   EXPECT_TRUE(diff.isModelOnNodes());
 }
 
 // --- Print ---
 
-TYPED_TEST(DifferentiatorElasticNodeTest, PrintDoesNotThrow)
-{
+TYPED_TEST(DifferentiatorElasticNodeTest, PrintDoesNotThrow) {
   typename TestFixture::DiffNode diff;
   EXPECT_NO_THROW(diff.print());
 }
 
 // --- compute() correctness ---
 
-TYPED_TEST(DifferentiatorElasticNodeTest, ZeroWavefieldsYieldZeroGradients)
-{
+TYPED_TEST(DifferentiatorElasticNodeTest, ZeroWavefieldsYieldZeroGradients) {
   typename TestFixture::DiffNode diff;
   auto mesh = makeMesh1x1x1<TestFixture::kOrder>();
 
   WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
-  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
-                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj, this->ux_dt2, this->uy_dt2, this->uz_dt2);
   GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
   GradientDataElastic data(fwd, bwd, grad);
   diff.compute(mesh, data, 0.001f);
@@ -616,10 +550,8 @@ TYPED_TEST(DifferentiatorElasticNodeTest, ZeroWavefieldsYieldZeroGradients)
   EXPECT_FLOAT_EQ(this->sumGradMu(), 0.0f);
 }
 
-TYPED_TEST(DifferentiatorElasticNodeTest, UniformFieldGradRhoSumsToVolume)
-{
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+TYPED_TEST(DifferentiatorElasticNodeTest, UniformFieldGradRhoSumsToVolume) {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->ux_fwd(i) = 1.0f;
     this->ux_dt2(i) = 1.0f;
   }
@@ -628,8 +560,7 @@ TYPED_TEST(DifferentiatorElasticNodeTest, UniformFieldGradRhoSumsToVolume)
   auto mesh = makeMesh1x1x1<TestFixture::kOrder>();
 
   WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
-  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
-                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj, this->ux_dt2, this->uy_dt2, this->uz_dt2);
   GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
   GradientDataElastic data(fwd, bwd, grad);
   diff.compute(mesh, data, 0.001f);
@@ -637,10 +568,8 @@ TYPED_TEST(DifferentiatorElasticNodeTest, UniformFieldGradRhoSumsToVolume)
   EXPECT_NEAR(this->sumGradRho(), 1.0f, 1e-5f);
 }
 
-TYPED_TEST(DifferentiatorElasticNodeTest, ConstantFieldGradLambdaSumsToZero)
-{
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+TYPED_TEST(DifferentiatorElasticNodeTest, ConstantFieldGradLambdaSumsToZero) {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->ux_fwd(i) = 1.0f;
     this->ux_adj(i) = 1.0f;
   }
@@ -649,8 +578,7 @@ TYPED_TEST(DifferentiatorElasticNodeTest, ConstantFieldGradLambdaSumsToZero)
   auto mesh = makeMesh1x1x1<TestFixture::kOrder>();
 
   WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
-  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
-                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj, this->ux_dt2, this->uy_dt2, this->uz_dt2);
   GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
   GradientDataElastic data(fwd, bwd, grad);
   diff.compute(mesh, data, 0.001f);
@@ -658,15 +586,13 @@ TYPED_TEST(DifferentiatorElasticNodeTest, ConstantFieldGradLambdaSumsToZero)
   EXPECT_NEAR(this->sumGradLambda(), 0.0f, 1e-5f);
 }
 
-TYPED_TEST(DifferentiatorElasticNodeTest, NodeBasedSumEqualsElementBasedResult)
-{
+TYPED_TEST(DifferentiatorElasticNodeTest, NodeBasedSumEqualsElementBasedResult) {
   // For single-element mesh, ∑ node_gradients == elem_gradient
   auto mesh = makeMesh1x1x1<TestFixture::kOrder>();
   int const dim = TestFixture::kOrder + 1;
   for (int k = 0; k < dim; ++k)
     for (int j = 0; j < dim; ++j)
-      for (int i = 0; i < dim; ++i)
-      {
+      for (int i = 0; i < dim; ++i) {
         int gIdx = mesh.globalNodeIndex(0, i, j, k);
         float x = static_cast<float>(i) / TestFixture::kOrder;
         float y = static_cast<float>(j) / TestFixture::kOrder;
@@ -681,8 +607,8 @@ TYPED_TEST(DifferentiatorElasticNodeTest, NodeBasedSumEqualsElementBasedResult)
   typename TestFixture::DiffNode diffNode;
   {
     WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
-    WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
-                                     this->ux_dt2, this->uy_dt2, this->uz_dt2);
+    WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj, this->ux_dt2, this->uy_dt2,
+                                     this->uz_dt2);
     GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
     GradientDataElastic data(fwd, bwd, grad);
     diffNode.compute(mesh, data, 0.001f);
@@ -702,8 +628,8 @@ TYPED_TEST(DifferentiatorElasticNodeTest, NodeBasedSumEqualsElementBasedResult)
   typename TestFixture::DiffElem diffElem;
   {
     WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
-    WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
-                                     this->ux_dt2, this->uy_dt2, this->uz_dt2);
+    WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj, this->ux_dt2, this->uy_dt2,
+                                     this->uz_dt2);
     GradientElastic grad(gradRhoElem, gradLambdaElem, gradMuElem);
     GradientDataElastic data(fwd, bwd, grad);
     diffElem.compute(mesh, data, 0.001f);
@@ -716,24 +642,20 @@ TYPED_TEST(DifferentiatorElasticNodeTest, NodeBasedSumEqualsElementBasedResult)
 
 // --- Polymorphic interface ---
 
-TYPED_TEST(DifferentiatorElasticNodeTest, PolymorphicInterface)
-{
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+TYPED_TEST(DifferentiatorElasticNodeTest, PolymorphicInterface) {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->ux_fwd(i) = 1.0f;
     this->ux_dt2(i) = 1.0f;
   }
 
-  std::unique_ptr<Differentiator> diff =
-      std::make_unique<typename TestFixture::DiffNode>();
+  std::unique_ptr<Differentiator> diff = std::make_unique<typename TestFixture::DiffNode>();
   auto mesh = makeMesh1x1x1<TestFixture::kOrder>();
 
   EXPECT_EQ(diff->getOrder(), TestFixture::kOrder);
   EXPECT_TRUE(diff->isModelOnNodes());
 
   WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
-  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
-                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj, this->ux_dt2, this->uy_dt2, this->uz_dt2);
   GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
   GradientDataElastic data(fwd, bwd, grad);
 

--- a/tests/units/gradient/impl/elastic/makutu/test_differentiator_elastic_makutu_unstruct.cc
+++ b/tests/units/gradient/impl/elastic/makutu/test_differentiator_elastic_makutu_unstruct.cc
@@ -9,25 +9,20 @@
 #include "differentiator_elastic.h"
 #include "model_unstruct.h"
 
-namespace gradient
-{
-namespace test
-{
+namespace gradient {
+namespace test {
 
 // =============================================================================
 // Order wrappers
 // =============================================================================
 
-struct Order1U
-{
+struct Order1U {
   static constexpr int kOrder = 1;
 };
-struct Order2U
-{
+struct Order2U {
   static constexpr int kOrder = 2;
 };
-struct Order3U
-{
+struct Order3U {
   static constexpr int kOrder = 3;
 };
 
@@ -49,8 +44,7 @@ using OrderTypesU = ::testing::Types<Order1U, Order2U, Order3U>;
 // =============================================================================
 
 template <int ORDER>
-static model::ModelUnstruct<float, int> makeUnstructMesh1x1x1()
-{
+static model::ModelUnstruct<float, int> makeUnstructMesh1x1x1() {
   constexpr int npe = (ORDER + 1) * (ORDER + 1) * (ORDER + 1);
 
   model::ModelUnstructData<float, int> data;
@@ -66,8 +60,7 @@ static model::ModelUnstruct<float, int> makeUnstructMesh1x1x1()
   data.nodes_coords_y_ = allocateVector<VECTOR_REAL_VIEW>(npe, "cy");
   data.nodes_coords_z_ = allocateVector<VECTOR_REAL_VIEW>(npe, "cz");
 
-  for (int lDof = 0; lDof < npe; ++lDof)
-  {
+  for (int lDof = 0; lDof < npe; ++lDof) {
     data.global_node_index_(0, lDof) = lDof;
 
     int k = lDof / ((ORDER + 1) * (ORDER + 1));
@@ -87,20 +80,17 @@ static model::ModelUnstruct<float, int> makeUnstructMesh1x1x1()
 // =============================================================================
 
 template <typename OrderWrapper>
-class DifferentiatorElasticElemUnstructTest : public ::testing::Test
-{
+class DifferentiatorElasticElemUnstructTest : public ::testing::Test {
  protected:
   static constexpr int kOrder = OrderWrapper::kOrder;
   static constexpr int kNumNodes = (kOrder + 1) * (kOrder + 1) * (kOrder + 1);
   static constexpr int kNumElements = 1;
 
   using Mesh = model::ModelUnstruct<float, int>;
-  using Integral =
-      typename IntegralTypeSelector<kOrder, IntegralType::MAKUTU>::type;
+  using Integral = typename IntegralTypeSelector<kOrder, IntegralType::MAKUTU>::type;
   using Diff = DifferentiatorElastic<kOrder, Integral, Mesh, false>;
 
-  void SetUp() override
-  {
+  void SetUp() override {
     ux_fwd = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "ux_fwd");
     uy_fwd = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uy_fwd");
     uz_fwd = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uz_fwd");
@@ -114,8 +104,7 @@ class DifferentiatorElasticElemUnstructTest : public ::testing::Test
     gradLambda = allocateVector<VECTOR_REAL_VIEW>(kNumElements, "gradLambda");
     gradMu = allocateVector<VECTOR_REAL_VIEW>(kNumElements, "gradMu");
 
-    for (int i = 0; i < kNumNodes; ++i)
-    {
+    for (int i = 0; i < kNumNodes; ++i) {
       ux_fwd(i) = 0.0f;
       uy_fwd(i) = 0.0f;
       uz_fwd(i) = 0.0f;
@@ -141,54 +130,45 @@ TYPED_TEST_SUITE(DifferentiatorElasticElemUnstructTest, OrderTypesU);
 
 // --- Static constants ---
 
-TYPED_TEST(DifferentiatorElasticElemUnstructTest, OrderConstant)
-{
+TYPED_TEST(DifferentiatorElasticElemUnstructTest, OrderConstant) {
   EXPECT_EQ(TestFixture::Diff::kOrder, TestFixture::kOrder);
 }
 
-TYPED_TEST(DifferentiatorElasticElemUnstructTest, IsModelOnNodesConstant)
-{
+TYPED_TEST(DifferentiatorElasticElemUnstructTest, IsModelOnNodesConstant) {
   EXPECT_FALSE(TestFixture::Diff::kIsModelOnNodes);
 }
 
-TYPED_TEST(DifferentiatorElasticElemUnstructTest, PointsPerElementConstant)
-{
+TYPED_TEST(DifferentiatorElasticElemUnstructTest, PointsPerElementConstant) {
   EXPECT_EQ(TestFixture::Diff::kPointsPerElement, TestFixture::kNumNodes);
 }
 
 // --- Virtual getters ---
 
-TYPED_TEST(DifferentiatorElasticElemUnstructTest, GetOrderReturnsCorrectOrder)
-{
+TYPED_TEST(DifferentiatorElasticElemUnstructTest, GetOrderReturnsCorrectOrder) {
   typename TestFixture::Diff diff;
   EXPECT_EQ(diff.getOrder(), TestFixture::kOrder);
 }
 
-TYPED_TEST(DifferentiatorElasticElemUnstructTest, IsModelOnNodesReturnsFalse)
-{
+TYPED_TEST(DifferentiatorElasticElemUnstructTest, IsModelOnNodesReturnsFalse) {
   typename TestFixture::Diff diff;
   EXPECT_FALSE(diff.isModelOnNodes());
 }
 
 // --- Print ---
 
-TYPED_TEST(DifferentiatorElasticElemUnstructTest, PrintDoesNotThrow)
-{
+TYPED_TEST(DifferentiatorElasticElemUnstructTest, PrintDoesNotThrow) {
   typename TestFixture::Diff diff;
   EXPECT_NO_THROW(diff.print());
 }
 
 // --- compute() correctness ---
 
-TYPED_TEST(DifferentiatorElasticElemUnstructTest,
-           ZeroWavefieldsYieldZeroGradients)
-{
+TYPED_TEST(DifferentiatorElasticElemUnstructTest, ZeroWavefieldsYieldZeroGradients) {
   typename TestFixture::Diff diff;
   auto mesh = makeUnstructMesh1x1x1<TestFixture::kOrder>();
 
   WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
-  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
-                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj, this->ux_dt2, this->uy_dt2, this->uz_dt2);
   GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
   GradientDataElastic data(fwd, bwd, grad);
 
@@ -199,11 +179,8 @@ TYPED_TEST(DifferentiatorElasticElemUnstructTest,
   EXPECT_FLOAT_EQ(this->gradMu(0), 0.0f);
 }
 
-TYPED_TEST(DifferentiatorElasticElemUnstructTest,
-           UniformFieldGradRhoEqualsVolume)
-{
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+TYPED_TEST(DifferentiatorElasticElemUnstructTest, UniformFieldGradRhoEqualsVolume) {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->ux_fwd(i) = 1.0f;
     this->ux_dt2(i) = 1.0f;
   }
@@ -212,8 +189,7 @@ TYPED_TEST(DifferentiatorElasticElemUnstructTest,
   auto mesh = makeUnstructMesh1x1x1<TestFixture::kOrder>();
 
   WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
-  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
-                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj, this->ux_dt2, this->uy_dt2, this->uz_dt2);
   GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
   GradientDataElastic data(fwd, bwd, grad);
 
@@ -222,10 +198,8 @@ TYPED_TEST(DifferentiatorElasticElemUnstructTest,
   EXPECT_NEAR(this->gradRho(0), 1.0f, 1e-5f);
 }
 
-TYPED_TEST(DifferentiatorElasticElemUnstructTest, ConstantFieldGradLambdaIsZero)
-{
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+TYPED_TEST(DifferentiatorElasticElemUnstructTest, ConstantFieldGradLambdaIsZero) {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->ux_fwd(i) = 1.0f;
     this->ux_adj(i) = 1.0f;
   }
@@ -234,8 +208,7 @@ TYPED_TEST(DifferentiatorElasticElemUnstructTest, ConstantFieldGradLambdaIsZero)
   auto mesh = makeUnstructMesh1x1x1<TestFixture::kOrder>();
 
   WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
-  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
-                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj, this->ux_dt2, this->uy_dt2, this->uz_dt2);
   GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
   GradientDataElastic data(fwd, bwd, grad);
 
@@ -244,10 +217,8 @@ TYPED_TEST(DifferentiatorElasticElemUnstructTest, ConstantFieldGradLambdaIsZero)
   EXPECT_NEAR(this->gradLambda(0), 0.0f, 1e-5f);
 }
 
-TYPED_TEST(DifferentiatorElasticElemUnstructTest, ConstantFieldGradMuIsZero)
-{
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+TYPED_TEST(DifferentiatorElasticElemUnstructTest, ConstantFieldGradMuIsZero) {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->ux_fwd(i) = 1.0f;
     this->uy_fwd(i) = 1.0f;
     this->uz_fwd(i) = 1.0f;
@@ -260,8 +231,7 @@ TYPED_TEST(DifferentiatorElasticElemUnstructTest, ConstantFieldGradMuIsZero)
   auto mesh = makeUnstructMesh1x1x1<TestFixture::kOrder>();
 
   WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
-  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
-                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj, this->ux_dt2, this->uy_dt2, this->uz_dt2);
   GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
   GradientDataElastic data(fwd, bwd, grad);
 
@@ -270,13 +240,10 @@ TYPED_TEST(DifferentiatorElasticElemUnstructTest, ConstantFieldGradMuIsZero)
   EXPECT_NEAR(this->gradMu(0), 0.0f, 1e-5f);
 }
 
-TYPED_TEST(DifferentiatorElasticElemUnstructTest,
-           GradLambdaNonZeroForLinearField)
-{
+TYPED_TEST(DifferentiatorElasticElemUnstructTest, GradLambdaNonZeroForLinearField) {
   // u_x = x => div(u) = 1 => gradLambda = ∫ 1 dΩ = 1.0
   constexpr int dim = TestFixture::kOrder + 1;
-  for (int lDof = 0; lDof < TestFixture::kNumNodes; ++lDof)
-  {
+  for (int lDof = 0; lDof < TestFixture::kNumNodes; ++lDof) {
     int i = lDof % dim;
     float x = static_cast<float>(i) / TestFixture::kOrder;
     this->ux_fwd(lDof) = x;
@@ -287,8 +254,7 @@ TYPED_TEST(DifferentiatorElasticElemUnstructTest,
   auto mesh = makeUnstructMesh1x1x1<TestFixture::kOrder>();
 
   WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
-  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
-                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj, this->ux_dt2, this->uy_dt2, this->uz_dt2);
   GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
   GradientDataElastic data(fwd, bwd, grad);
 
@@ -297,12 +263,10 @@ TYPED_TEST(DifferentiatorElasticElemUnstructTest,
   EXPECT_NEAR(this->gradLambda(0), 1.0f, 0.2f);
 }
 
-TYPED_TEST(DifferentiatorElasticElemUnstructTest, GradMuNonZeroForLinearField)
-{
+TYPED_TEST(DifferentiatorElasticElemUnstructTest, GradMuNonZeroForLinearField) {
   // u_x = x => ε_xx = 1 => 2·ε†:ε = 2 => gradMu = 2.0
   constexpr int dim = TestFixture::kOrder + 1;
-  for (int lDof = 0; lDof < TestFixture::kNumNodes; ++lDof)
-  {
+  for (int lDof = 0; lDof < TestFixture::kNumNodes; ++lDof) {
     int i = lDof % dim;
     float x = static_cast<float>(i) / TestFixture::kOrder;
     this->ux_fwd(lDof) = x;
@@ -313,8 +277,7 @@ TYPED_TEST(DifferentiatorElasticElemUnstructTest, GradMuNonZeroForLinearField)
   auto mesh = makeUnstructMesh1x1x1<TestFixture::kOrder>();
 
   WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
-  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
-                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj, this->ux_dt2, this->uy_dt2, this->uz_dt2);
   GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
   GradientDataElastic data(fwd, bwd, grad);
 
@@ -323,14 +286,11 @@ TYPED_TEST(DifferentiatorElasticElemUnstructTest, GradMuNonZeroForLinearField)
   EXPECT_NEAR(this->gradMu(0), 2.0f, 0.4f);
 }
 
-TYPED_TEST(DifferentiatorElasticElemUnstructTest,
-           PureDilatationLambdaMuConsistency)
-{
+TYPED_TEST(DifferentiatorElasticElemUnstructTest, PureDilatationLambdaMuConsistency) {
   // u_x=x, u_y=y, u_z=z => div=3, ε_xx=ε_yy=ε_zz=1
   // gradLambda = 9.0, gradMu = 6.0
   constexpr int dim = TestFixture::kOrder + 1;
-  for (int lDof = 0; lDof < TestFixture::kNumNodes; ++lDof)
-  {
+  for (int lDof = 0; lDof < TestFixture::kNumNodes; ++lDof) {
     int k = lDof / (dim * dim);
     int j = (lDof / dim) % dim;
     int i = lDof % dim;
@@ -349,8 +309,7 @@ TYPED_TEST(DifferentiatorElasticElemUnstructTest,
   auto mesh = makeUnstructMesh1x1x1<TestFixture::kOrder>();
 
   WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
-  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
-                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj, this->ux_dt2, this->uy_dt2, this->uz_dt2);
   GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
   GradientDataElastic data(fwd, bwd, grad);
 
@@ -360,14 +319,11 @@ TYPED_TEST(DifferentiatorElasticElemUnstructTest,
   EXPECT_NEAR(this->gradMu(0), 6.0f, 1.0f);
 }
 
-TYPED_TEST(DifferentiatorElasticElemUnstructTest,
-           LinearShearFieldProducesCorrectGradMu)
-{
+TYPED_TEST(DifferentiatorElasticElemUnstructTest, LinearShearFieldProducesCorrectGradMu) {
   // Pure shear: u_x=y, u_y=x => div=0 => gradLambda=0
   // ε_xy = 1 => 2·ε:ε = 4·(ε_xy²) = 4 => gradMu = 4.0
   constexpr int dim = TestFixture::kOrder + 1;
-  for (int lDof = 0; lDof < TestFixture::kNumNodes; ++lDof)
-  {
+  for (int lDof = 0; lDof < TestFixture::kNumNodes; ++lDof) {
     int i = lDof % dim;
     int j = (lDof / dim) % dim;
     float x = static_cast<float>(i) / TestFixture::kOrder;
@@ -382,8 +338,7 @@ TYPED_TEST(DifferentiatorElasticElemUnstructTest,
   auto mesh = makeUnstructMesh1x1x1<TestFixture::kOrder>();
 
   WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
-  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
-                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj, this->ux_dt2, this->uy_dt2, this->uz_dt2);
   GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
   GradientDataElastic data(fwd, bwd, grad);
 
@@ -393,11 +348,8 @@ TYPED_TEST(DifferentiatorElasticElemUnstructTest,
   EXPECT_NEAR(this->gradMu(0), 4.0f, 0.4f);
 }
 
-TYPED_TEST(DifferentiatorElasticElemUnstructTest,
-           ComputeAccumulatesIntoExistingGradient)
-{
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+TYPED_TEST(DifferentiatorElasticElemUnstructTest, ComputeAccumulatesIntoExistingGradient) {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->ux_fwd(i) = 1.0f;
     this->ux_dt2(i) = 1.0f;
   }
@@ -407,8 +359,7 @@ TYPED_TEST(DifferentiatorElasticElemUnstructTest,
   auto mesh = makeUnstructMesh1x1x1<TestFixture::kOrder>();
 
   WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
-  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
-                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj, this->ux_dt2, this->uy_dt2, this->uz_dt2);
   GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
   GradientDataElastic data(fwd, bwd, grad);
 
@@ -420,20 +371,17 @@ TYPED_TEST(DifferentiatorElasticElemUnstructTest,
 // --- Node-based unstructured ---
 
 template <typename OrderWrapper>
-class DifferentiatorElasticNodeUnstructTest : public ::testing::Test
-{
+class DifferentiatorElasticNodeUnstructTest : public ::testing::Test {
  protected:
   static constexpr int kOrder = OrderWrapper::kOrder;
   static constexpr int kNumNodes = (kOrder + 1) * (kOrder + 1) * (kOrder + 1);
 
   using Mesh = model::ModelUnstruct<float, int>;
-  using Integral =
-      typename IntegralTypeSelector<kOrder, IntegralType::MAKUTU>::type;
+  using Integral = typename IntegralTypeSelector<kOrder, IntegralType::MAKUTU>::type;
   using DiffNode = DifferentiatorElastic<kOrder, Integral, Mesh, true>;
   using DiffElem = DifferentiatorElastic<kOrder, Integral, Mesh, false>;
 
-  void SetUp() override
-  {
+  void SetUp() override {
     ux_fwd = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "ux_fwd");
     uy_fwd = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uy_fwd");
     uz_fwd = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "uz_fwd");
@@ -447,8 +395,7 @@ class DifferentiatorElasticNodeUnstructTest : public ::testing::Test
     gradLambda = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "gradLambda");
     gradMu = allocateVector<VECTOR_REAL_VIEW>(kNumNodes, "gradMu");
 
-    for (int i = 0; i < kNumNodes; ++i)
-    {
+    for (int i = 0; i < kNumNodes; ++i) {
       ux_fwd(i) = 0.0f;
       uy_fwd(i) = 0.0f;
       uz_fwd(i) = 0.0f;
@@ -464,8 +411,7 @@ class DifferentiatorElasticNodeUnstructTest : public ::testing::Test
     }
   }
 
-  float sumGrad(VECTOR_REAL_VIEW const& v) const
-  {
+  float sumGrad(VECTOR_REAL_VIEW const& v) const {
     float s = 0.0f;
     for (int i = 0; i < kNumNodes; ++i) s += v(i);
     return s;
@@ -483,15 +429,12 @@ class DifferentiatorElasticNodeUnstructTest : public ::testing::Test
 
 TYPED_TEST_SUITE(DifferentiatorElasticNodeUnstructTest, OrderTypesU);
 
-TYPED_TEST(DifferentiatorElasticNodeUnstructTest,
-           ZeroWavefieldsYieldZeroGradients)
-{
+TYPED_TEST(DifferentiatorElasticNodeUnstructTest, ZeroWavefieldsYieldZeroGradients) {
   typename TestFixture::DiffNode diff;
   auto mesh = makeUnstructMesh1x1x1<TestFixture::kOrder>();
 
   WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
-  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
-                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj, this->ux_dt2, this->uy_dt2, this->uz_dt2);
   GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
   GradientDataElastic data(fwd, bwd, grad);
 
@@ -502,11 +445,8 @@ TYPED_TEST(DifferentiatorElasticNodeUnstructTest,
   EXPECT_FLOAT_EQ(this->sumGradMu(), 0.0f);
 }
 
-TYPED_TEST(DifferentiatorElasticNodeUnstructTest,
-           UniformFieldGradRhoSumsToVolume)
-{
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+TYPED_TEST(DifferentiatorElasticNodeUnstructTest, UniformFieldGradRhoSumsToVolume) {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->ux_fwd(i) = 1.0f;
     this->ux_dt2(i) = 1.0f;
   }
@@ -515,8 +455,7 @@ TYPED_TEST(DifferentiatorElasticNodeUnstructTest,
   auto mesh = makeUnstructMesh1x1x1<TestFixture::kOrder>();
 
   WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
-  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
-                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj, this->ux_dt2, this->uy_dt2, this->uz_dt2);
   GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
   GradientDataElastic data(fwd, bwd, grad);
 
@@ -525,12 +464,9 @@ TYPED_TEST(DifferentiatorElasticNodeUnstructTest,
   EXPECT_NEAR(this->sumGradRho(), 1.0f, 1e-5f);
 }
 
-TYPED_TEST(DifferentiatorElasticNodeUnstructTest,
-           NodeBasedSumEqualsElementBasedResult)
-{
+TYPED_TEST(DifferentiatorElasticNodeUnstructTest, NodeBasedSumEqualsElementBasedResult) {
   constexpr int dim = TestFixture::kOrder + 1;
-  for (int lDof = 0; lDof < TestFixture::kNumNodes; ++lDof)
-  {
+  for (int lDof = 0; lDof < TestFixture::kNumNodes; ++lDof) {
     int i = lDof % dim;
     int j = (lDof / dim) % dim;
     float x = static_cast<float>(i) / TestFixture::kOrder;
@@ -548,8 +484,8 @@ TYPED_TEST(DifferentiatorElasticNodeUnstructTest,
   typename TestFixture::DiffNode diffNode;
   {
     WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
-    WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
-                                     this->ux_dt2, this->uy_dt2, this->uz_dt2);
+    WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj, this->ux_dt2, this->uy_dt2,
+                                     this->uz_dt2);
     GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
     GradientDataElastic data(fwd, bwd, grad);
     diffNode.compute(mesh, data, 0.001f);
@@ -569,8 +505,8 @@ TYPED_TEST(DifferentiatorElasticNodeUnstructTest,
   typename TestFixture::DiffElem diffElem;
   {
     WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
-    WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
-                                     this->ux_dt2, this->uy_dt2, this->uz_dt2);
+    WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj, this->ux_dt2, this->uy_dt2,
+                                     this->uz_dt2);
     GradientElastic grad(gradRhoElem, gradLambdaElem, gradMuElem);
     GradientDataElastic data(fwd, bwd, grad);
     diffElem.compute(mesh, data, 0.001f);
@@ -583,24 +519,20 @@ TYPED_TEST(DifferentiatorElasticNodeUnstructTest,
 
 // --- Polymorphic interface ---
 
-TYPED_TEST(DifferentiatorElasticNodeUnstructTest, PolymorphicInterface)
-{
-  for (int i = 0; i < TestFixture::kNumNodes; ++i)
-  {
+TYPED_TEST(DifferentiatorElasticNodeUnstructTest, PolymorphicInterface) {
+  for (int i = 0; i < TestFixture::kNumNodes; ++i) {
     this->ux_fwd(i) = 1.0f;
     this->ux_dt2(i) = 1.0f;
   }
 
-  std::unique_ptr<Differentiator> diff =
-      std::make_unique<typename TestFixture::DiffNode>();
+  std::unique_ptr<Differentiator> diff = std::make_unique<typename TestFixture::DiffNode>();
   auto mesh = makeUnstructMesh1x1x1<TestFixture::kOrder>();
 
   EXPECT_EQ(diff->getOrder(), TestFixture::kOrder);
   EXPECT_TRUE(diff->isModelOnNodes());
 
   WavefieldViewForwardElastic fwd(this->ux_fwd, this->uy_fwd, this->uz_fwd);
-  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj,
-                                   this->ux_dt2, this->uy_dt2, this->uz_dt2);
+  WavefieldViewBackwardElastic bwd(this->ux_adj, this->uy_adj, this->uz_adj, this->ux_dt2, this->uy_dt2, this->uz_dt2);
   GradientElastic grad(this->gradRho, this->gradLambda, this->gradMu);
   GradientDataElastic data(fwd, bwd, grad);
 

--- a/tests/units/gradient/impl/elastic/test_gradient_data_elastic.cc
+++ b/tests/units/gradient/impl/elastic/test_gradient_data_elastic.cc
@@ -3,16 +3,12 @@
 #include "data_type.h"
 #include "differentiator_data_elastic.h"
 
-namespace gradient
-{
-namespace test
-{
+namespace gradient {
+namespace test {
 
-class GradientDataElasticTest : public ::testing::Test
-{
+class GradientDataElasticTest : public ::testing::Test {
  protected:
-  void SetUp() override
-  {
+  void SetUp() override {
     size = 40;
 
     ux_n = allocateVector<VECTOR_REAL_VIEW>(size, "ux_n");
@@ -26,8 +22,7 @@ class GradientDataElasticTest : public ::testing::Test
     gradLambda = allocateVector<VECTOR_REAL_VIEW>(size, "gradLambda");
     gradMu = allocateVector<VECTOR_REAL_VIEW>(size, "gradMu");
 
-    for (int i = 0; i < size; ++i)
-    {
+    for (int i = 0; i < size; ++i) {
       ux_n(i) = static_cast<float>(i) * 0.1f;
       uy_n(i) = static_cast<float>(i) * 0.2f;
       uz_n(i) = static_cast<float>(i) * 0.3f;
@@ -46,8 +41,7 @@ class GradientDataElasticTest : public ::testing::Test
   VECTOR_REAL_VIEW gradRho, gradLambda, gradMu;
 };
 
-TEST_F(GradientDataElasticTest, Construction)
-{
+TEST_F(GradientDataElasticTest, Construction) {
   WavefieldViewForwardElastic fwd(ux_n, uy_n, uz_n);
   WavefieldViewBackwardElastic bwd(ux_n, uy_n, uz_n, ux_dt2, uy_dt2, uz_dt2);
   GradientElastic grad(gradRho, gradLambda, gradMu);
@@ -55,8 +49,7 @@ TEST_F(GradientDataElasticTest, Construction)
   EXPECT_NO_THROW((GradientDataElastic{fwd, bwd, grad}));
 }
 
-TEST_F(GradientDataElasticTest, GetForwardFieldReturnsUxN)
-{
+TEST_F(GradientDataElasticTest, GetForwardFieldReturnsUxN) {
   WavefieldViewForwardElastic fwd(ux_n, uy_n, uz_n);
   WavefieldViewBackwardElastic bwd(ux_n, uy_n, uz_n, ux_dt2, uy_dt2, uz_dt2);
   GradientElastic grad(gradRho, gradLambda, gradMu);
@@ -64,12 +57,10 @@ TEST_F(GradientDataElasticTest, GetForwardFieldReturnsUxN)
 
   auto field = data.getForwardField(0);
   ASSERT_EQ(field.extent(0), static_cast<size_t>(size));
-  for (int i = 0; i < size; ++i)
-    EXPECT_FLOAT_EQ(field(i), static_cast<float>(i) * 0.1f);
+  for (int i = 0; i < size; ++i) EXPECT_FLOAT_EQ(field(i), static_cast<float>(i) * 0.1f);
 }
 
-TEST_F(GradientDataElasticTest, GetForwardFieldReturnsUyN)
-{
+TEST_F(GradientDataElasticTest, GetForwardFieldReturnsUyN) {
   WavefieldViewForwardElastic fwd(ux_n, uy_n, uz_n);
   WavefieldViewBackwardElastic bwd(ux_n, uy_n, uz_n, ux_dt2, uy_dt2, uz_dt2);
   GradientElastic grad(gradRho, gradLambda, gradMu);
@@ -77,12 +68,10 @@ TEST_F(GradientDataElasticTest, GetForwardFieldReturnsUyN)
 
   auto field = data.getForwardField(1);
   ASSERT_EQ(field.extent(0), static_cast<size_t>(size));
-  for (int i = 0; i < size; ++i)
-    EXPECT_FLOAT_EQ(field(i), static_cast<float>(i) * 0.2f);
+  for (int i = 0; i < size; ++i) EXPECT_FLOAT_EQ(field(i), static_cast<float>(i) * 0.2f);
 }
 
-TEST_F(GradientDataElasticTest, GetBackwardFieldReturnsUxDt2)
-{
+TEST_F(GradientDataElasticTest, GetBackwardFieldReturnsUxDt2) {
   WavefieldViewForwardElastic fwd(ux_n, uy_n, uz_n);
   WavefieldViewBackwardElastic bwd(ux_n, uy_n, uz_n, ux_dt2, uy_dt2, uz_dt2);
   GradientElastic grad(gradRho, gradLambda, gradMu);
@@ -90,12 +79,10 @@ TEST_F(GradientDataElasticTest, GetBackwardFieldReturnsUxDt2)
 
   auto field = data.getBackwardField(3);
   ASSERT_EQ(field.extent(0), static_cast<size_t>(size));
-  for (int i = 0; i < size; ++i)
-    EXPECT_FLOAT_EQ(field(i), static_cast<float>(i) * 0.4f);
+  for (int i = 0; i < size; ++i) EXPECT_FLOAT_EQ(field(i), static_cast<float>(i) * 0.4f);
 }
 
-TEST_F(GradientDataElasticTest, GetGradientZeroReturnsRho)
-{
+TEST_F(GradientDataElasticTest, GetGradientZeroReturnsRho) {
   WavefieldViewForwardElastic fwd(ux_n, uy_n, uz_n);
   WavefieldViewBackwardElastic bwd(ux_n, uy_n, uz_n, ux_dt2, uy_dt2, uz_dt2);
   GradientElastic grad(gradRho, gradLambda, gradMu);
@@ -103,12 +90,10 @@ TEST_F(GradientDataElasticTest, GetGradientZeroReturnsRho)
 
   auto g = data.getGradient(0);
   ASSERT_EQ(g.extent(0), static_cast<size_t>(size));
-  for (int i = 0; i < size; ++i)
-    EXPECT_FLOAT_EQ(g(i), static_cast<float>(i) * 1.0f);
+  for (int i = 0; i < size; ++i) EXPECT_FLOAT_EQ(g(i), static_cast<float>(i) * 1.0f);
 }
 
-TEST_F(GradientDataElasticTest, GetGradientOneReturnsLambda)
-{
+TEST_F(GradientDataElasticTest, GetGradientOneReturnsLambda) {
   WavefieldViewForwardElastic fwd(ux_n, uy_n, uz_n);
   WavefieldViewBackwardElastic bwd(ux_n, uy_n, uz_n, ux_dt2, uy_dt2, uz_dt2);
   GradientElastic grad(gradRho, gradLambda, gradMu);
@@ -116,12 +101,10 @@ TEST_F(GradientDataElasticTest, GetGradientOneReturnsLambda)
 
   auto g = data.getGradient(1);
   ASSERT_EQ(g.extent(0), static_cast<size_t>(size));
-  for (int i = 0; i < size; ++i)
-    EXPECT_FLOAT_EQ(g(i), static_cast<float>(i) * 2.0f);
+  for (int i = 0; i < size; ++i) EXPECT_FLOAT_EQ(g(i), static_cast<float>(i) * 2.0f);
 }
 
-TEST_F(GradientDataElasticTest, GetGradientTwoReturnsMu)
-{
+TEST_F(GradientDataElasticTest, GetGradientTwoReturnsMu) {
   WavefieldViewForwardElastic fwd(ux_n, uy_n, uz_n);
   WavefieldViewBackwardElastic bwd(ux_n, uy_n, uz_n, ux_dt2, uy_dt2, uz_dt2);
   GradientElastic grad(gradRho, gradLambda, gradMu);
@@ -129,12 +112,10 @@ TEST_F(GradientDataElasticTest, GetGradientTwoReturnsMu)
 
   auto g = data.getGradient(2);
   ASSERT_EQ(g.extent(0), static_cast<size_t>(size));
-  for (int i = 0; i < size; ++i)
-    EXPECT_FLOAT_EQ(g(i), static_cast<float>(i) * 3.0f);
+  for (int i = 0; i < size; ++i) EXPECT_FLOAT_EQ(g(i), static_cast<float>(i) * 3.0f);
 }
 
-TEST_F(GradientDataElasticTest, PrintDoesNotThrow)
-{
+TEST_F(GradientDataElasticTest, PrintDoesNotThrow) {
   WavefieldViewForwardElastic fwd(ux_n, uy_n, uz_n);
   WavefieldViewBackwardElastic bwd(ux_n, uy_n, uz_n, ux_dt2, uy_dt2, uz_dt2);
   GradientElastic grad(gradRho, gradLambda, gradMu);

--- a/tests/units/gradient/impl/elastic/test_gradient_elastic.cc
+++ b/tests/units/gradient/impl/elastic/test_gradient_elastic.cc
@@ -3,37 +3,29 @@
 #include "data_type.h"
 #include "gradient_elastic.h"
 
-namespace gradient
-{
-namespace test
-{
+namespace gradient {
+namespace test {
 
-class GradientElasticTest : public ::testing::Test
-{
+class GradientElasticTest : public ::testing::Test {
  protected:
-  void SetUp() override
-  {
+  void SetUp() override {
     numElements = 8;
     numNodes = 27;
 
     gradRhoElem = allocateVector<VECTOR_REAL_VIEW>(numElements, "gradRhoElem");
-    gradLambdaElem =
-        allocateVector<VECTOR_REAL_VIEW>(numElements, "gradLambdaElem");
+    gradLambdaElem = allocateVector<VECTOR_REAL_VIEW>(numElements, "gradLambdaElem");
     gradMuElem = allocateVector<VECTOR_REAL_VIEW>(numElements, "gradMuElem");
 
     gradRhoNode = allocateVector<VECTOR_REAL_VIEW>(numNodes, "gradRhoNode");
-    gradLambdaNode =
-        allocateVector<VECTOR_REAL_VIEW>(numNodes, "gradLambdaNode");
+    gradLambdaNode = allocateVector<VECTOR_REAL_VIEW>(numNodes, "gradLambdaNode");
     gradMuNode = allocateVector<VECTOR_REAL_VIEW>(numNodes, "gradMuNode");
 
-    for (int i = 0; i < numElements; ++i)
-    {
+    for (int i = 0; i < numElements; ++i) {
       gradRhoElem(i) = static_cast<float>(i) * 1.0f;
       gradLambdaElem(i) = static_cast<float>(i) * 2.0f;
       gradMuElem(i) = static_cast<float>(i) * 3.0f;
     }
-    for (int i = 0; i < numNodes; ++i)
-    {
+    for (int i = 0; i < numNodes; ++i) {
       gradRhoNode(i) = static_cast<float>(i) * 0.1f;
       gradLambdaNode(i) = static_cast<float>(i) * 0.2f;
       gradMuNode(i) = static_cast<float>(i) * 0.3f;
@@ -52,13 +44,9 @@ class GradientElasticTest : public ::testing::Test
 
 // --- Static constants ---
 
-TEST_F(GradientElasticTest, NumGradsConstant)
-{
-  EXPECT_EQ(GradientElastic::kNumGrads, 3);
-}
+TEST_F(GradientElasticTest, NumGradsConstant) { EXPECT_EQ(GradientElastic::kNumGrads, 3); }
 
-TEST_F(GradientElasticTest, GetGradientNamesCorrect)
-{
+TEST_F(GradientElasticTest, GetGradientNamesCorrect) {
   GradientElastic grad(gradRhoElem, gradLambdaElem, gradMuElem);
   EXPECT_EQ(grad.getGradientName(0), "gradRho");
   EXPECT_EQ(grad.getGradientName(1), "gradLambda");
@@ -67,8 +55,7 @@ TEST_F(GradientElasticTest, GetGradientNamesCorrect)
 
 // --- Constructor ---
 
-TEST_F(GradientElasticTest, ConstructorStoresViews)
-{
+TEST_F(GradientElasticTest, ConstructorStoresViews) {
   GradientElastic grad(gradRhoElem, gradLambdaElem, gradMuElem);
 
   // Verify via public interface
@@ -79,16 +66,14 @@ TEST_F(GradientElasticTest, ConstructorStoresViews)
 
 // --- Virtual interface: getNumGradients ---
 
-TEST_F(GradientElasticTest, GetNumGradientsReturns3)
-{
+TEST_F(GradientElasticTest, GetNumGradientsReturns3) {
   GradientElastic grad(gradRhoElem, gradLambdaElem, gradMuElem);
   EXPECT_EQ(grad.getNumGradients(), 3);
 }
 
 // --- Virtual interface: getGradientNames ---
 
-TEST_F(GradientElasticTest, GetGradientNameByIndex)
-{
+TEST_F(GradientElasticTest, GetGradientNameByIndex) {
   GradientElastic grad(gradRhoElem, gradLambdaElem, gradMuElem);
   EXPECT_EQ(grad.getGradientName(0), "gradRho");
   EXPECT_EQ(grad.getGradientName(1), "gradLambda");
@@ -97,68 +82,55 @@ TEST_F(GradientElasticTest, GetGradientNameByIndex)
 
 // --- Virtual interface: getGradient ---
 
-TEST_F(GradientElasticTest, GetGradientRhoElementBased)
-{
+TEST_F(GradientElasticTest, GetGradientRhoElementBased) {
   GradientElastic grad(gradRhoElem, gradLambdaElem, gradMuElem);
   auto rho = grad.getGradient(0);
 
   ASSERT_EQ(rho.extent(0), static_cast<size_t>(numElements));
-  for (int i = 0; i < numElements; ++i)
-    EXPECT_FLOAT_EQ(rho(i), static_cast<float>(i) * 1.0f);
+  for (int i = 0; i < numElements; ++i) EXPECT_FLOAT_EQ(rho(i), static_cast<float>(i) * 1.0f);
 }
 
-TEST_F(GradientElasticTest, GetGradientLambdaElementBased)
-{
+TEST_F(GradientElasticTest, GetGradientLambdaElementBased) {
   GradientElastic grad(gradRhoElem, gradLambdaElem, gradMuElem);
   auto lambda = grad.getGradient(1);
 
   ASSERT_EQ(lambda.extent(0), static_cast<size_t>(numElements));
-  for (int i = 0; i < numElements; ++i)
-    EXPECT_FLOAT_EQ(lambda(i), static_cast<float>(i) * 2.0f);
+  for (int i = 0; i < numElements; ++i) EXPECT_FLOAT_EQ(lambda(i), static_cast<float>(i) * 2.0f);
 }
 
-TEST_F(GradientElasticTest, GetGradientMuElementBased)
-{
+TEST_F(GradientElasticTest, GetGradientMuElementBased) {
   GradientElastic grad(gradRhoElem, gradLambdaElem, gradMuElem);
   auto mu = grad.getGradient(2);
 
   ASSERT_EQ(mu.extent(0), static_cast<size_t>(numElements));
-  for (int i = 0; i < numElements; ++i)
-    EXPECT_FLOAT_EQ(mu(i), static_cast<float>(i) * 3.0f);
+  for (int i = 0; i < numElements; ++i) EXPECT_FLOAT_EQ(mu(i), static_cast<float>(i) * 3.0f);
 }
 
-TEST_F(GradientElasticTest, GetGradientRhoNodeBased)
-{
+TEST_F(GradientElasticTest, GetGradientRhoNodeBased) {
   GradientElastic grad(gradRhoNode, gradLambdaNode, gradMuNode);
   auto rho = grad.getGradient(0);
 
   ASSERT_EQ(rho.extent(0), static_cast<size_t>(numNodes));
-  for (int i = 0; i < numNodes; ++i)
-    EXPECT_FLOAT_EQ(rho(i), static_cast<float>(i) * 0.1f);
+  for (int i = 0; i < numNodes; ++i) EXPECT_FLOAT_EQ(rho(i), static_cast<float>(i) * 0.1f);
 }
 
-TEST_F(GradientElasticTest, GetGradientLambdaNodeBased)
-{
+TEST_F(GradientElasticTest, GetGradientLambdaNodeBased) {
   GradientElastic grad(gradRhoNode, gradLambdaNode, gradMuNode);
   auto lambda = grad.getGradient(1);
 
   ASSERT_EQ(lambda.extent(0), static_cast<size_t>(numNodes));
-  for (int i = 0; i < numNodes; ++i)
-    EXPECT_FLOAT_EQ(lambda(i), static_cast<float>(i) * 0.2f);
+  for (int i = 0; i < numNodes; ++i) EXPECT_FLOAT_EQ(lambda(i), static_cast<float>(i) * 0.2f);
 }
 
-TEST_F(GradientElasticTest, GetGradientMuNodeBased)
-{
+TEST_F(GradientElasticTest, GetGradientMuNodeBased) {
   GradientElastic grad(gradRhoNode, gradLambdaNode, gradMuNode);
   auto mu = grad.getGradient(2);
 
   ASSERT_EQ(mu.extent(0), static_cast<size_t>(numNodes));
-  for (int i = 0; i < numNodes; ++i)
-    EXPECT_FLOAT_EQ(mu(i), static_cast<float>(i) * 0.3f);
+  for (int i = 0; i < numNodes; ++i) EXPECT_FLOAT_EQ(mu(i), static_cast<float>(i) * 0.3f);
 }
 
-TEST_F(GradientElasticTest, GetGradientOutOfBoundsFallsBackToRho)
-{
+TEST_F(GradientElasticTest, GetGradientOutOfBoundsFallsBackToRho) {
   GradientElastic grad(gradRhoElem, gradLambdaElem, gradMuElem);
   auto fallback = grad.getGradient(99);
 
@@ -169,15 +141,13 @@ TEST_F(GradientElasticTest, GetGradientOutOfBoundsFallsBackToRho)
 
 // --- Shared-view (shallow copy) semantics ---
 
-TEST_F(GradientElasticTest, RhoViewIsShallowCopy)
-{
+TEST_F(GradientElasticTest, RhoViewIsShallowCopy) {
   GradientElastic grad(gradRhoElem, gradLambdaElem, gradMuElem);
   gradRhoElem(0) = 777.0f;
   EXPECT_FLOAT_EQ(grad.getGradient(0)(0), 777.0f);
 }
 
-TEST_F(GradientElasticTest, LambdaViewIsShallowCopy)
-{
+TEST_F(GradientElasticTest, LambdaViewIsShallowCopy) {
   GradientElastic grad(gradRhoElem, gradLambdaElem, gradMuElem);
   gradLambdaElem(2) = 888.0f;
   EXPECT_FLOAT_EQ(grad.getGradient(1)(2), 888.0f);
@@ -185,18 +155,15 @@ TEST_F(GradientElasticTest, LambdaViewIsShallowCopy)
 
 // --- print() ---
 
-TEST_F(GradientElasticTest, PrintDoesNotThrow)
-{
+TEST_F(GradientElasticTest, PrintDoesNotThrow) {
   GradientElastic grad(gradRhoElem, gradLambdaElem, gradMuElem);
   EXPECT_NO_THROW(grad.print());
 }
 
 // --- Polymorphic usage via base pointer ---
 
-TEST_F(GradientElasticTest, PolymorphicInterface)
-{
-  std::unique_ptr<Gradient> grad = std::make_unique<GradientElastic>(
-      gradRhoElem, gradLambdaElem, gradMuElem);
+TEST_F(GradientElasticTest, PolymorphicInterface) {
+  std::unique_ptr<Gradient> grad = std::make_unique<GradientElastic>(gradRhoElem, gradLambdaElem, gradMuElem);
 
   EXPECT_EQ(grad->getNumGradients(), 3);
   EXPECT_EQ(grad->getGradientName(0), "gradRho");

--- a/tests/units/gradient/impl/elastic/test_wavefield_view_backward_elastic.cc
+++ b/tests/units/gradient/impl/elastic/test_wavefield_view_backward_elastic.cc
@@ -3,20 +3,16 @@
 #include "data_type.h"
 #include "wavefield_view_backward_elastic.h"
 
-namespace gradient
-{
-namespace test
-{
+namespace gradient {
+namespace test {
 
 // =============================================================================
 // WavefieldViewBackwardElastic
 // =============================================================================
 
-class WavefieldViewBackwardElasticTest : public ::testing::Test
-{
+class WavefieldViewBackwardElasticTest : public ::testing::Test {
  protected:
-  void SetUp() override
-  {
+  void SetUp() override {
     size = 45;
     ux_n = allocateVector<VECTOR_REAL_VIEW>(size, "ux_n");
     uy_n = allocateVector<VECTOR_REAL_VIEW>(size, "uy_n");
@@ -25,8 +21,7 @@ class WavefieldViewBackwardElasticTest : public ::testing::Test
     uy_dt2 = allocateVector<VECTOR_REAL_VIEW>(size, "uy_dt2");
     uz_dt2 = allocateVector<VECTOR_REAL_VIEW>(size, "uz_dt2");
 
-    for (int i = 0; i < size; ++i)
-    {
+    for (int i = 0; i < size; ++i) {
       ux_n(i) = static_cast<float>(i) * 1.0f;
       uy_n(i) = static_cast<float>(i) * 2.0f;
       uz_n(i) = static_cast<float>(i) * 3.0f;
@@ -41,13 +36,9 @@ class WavefieldViewBackwardElasticTest : public ::testing::Test
   VECTOR_REAL_VIEW ux_dt2, uy_dt2, uz_dt2;
 };
 
-TEST_F(WavefieldViewBackwardElasticTest, NumFieldsConstant)
-{
-  EXPECT_EQ(WavefieldViewBackwardElastic::kNumFields, 6);
-}
+TEST_F(WavefieldViewBackwardElasticTest, NumFieldsConstant) { EXPECT_EQ(WavefieldViewBackwardElastic::kNumFields, 6); }
 
-TEST_F(WavefieldViewBackwardElasticTest, GetFieldNamesCorrect)
-{
+TEST_F(WavefieldViewBackwardElasticTest, GetFieldNamesCorrect) {
   WavefieldViewBackwardElastic view(ux_n, uy_n, uz_n, ux_dt2, uy_dt2, uz_dt2);
   EXPECT_EQ(view.getFieldName(0), "ux_n");
   EXPECT_EQ(view.getFieldName(1), "uy_n");
@@ -57,8 +48,7 @@ TEST_F(WavefieldViewBackwardElasticTest, GetFieldNamesCorrect)
   EXPECT_EQ(view.getFieldName(5), "uz_dt2");
 }
 
-TEST_F(WavefieldViewBackwardElasticTest, ConstructorStoresAllFields)
-{
+TEST_F(WavefieldViewBackwardElasticTest, ConstructorStoresAllFields) {
   WavefieldViewBackwardElastic view(ux_n, uy_n, uz_n, ux_dt2, uy_dt2, uz_dt2);
   EXPECT_EQ(view.getField(0).extent(0), static_cast<size_t>(size));
   EXPECT_EQ(view.getField(1).extent(0), static_cast<size_t>(size));
@@ -68,14 +58,12 @@ TEST_F(WavefieldViewBackwardElasticTest, ConstructorStoresAllFields)
   EXPECT_EQ(view.getField(5).extent(0), static_cast<size_t>(size));
 }
 
-TEST_F(WavefieldViewBackwardElasticTest, GetNumFieldsReturns6)
-{
+TEST_F(WavefieldViewBackwardElasticTest, GetNumFieldsReturns6) {
   WavefieldViewBackwardElastic view(ux_n, uy_n, uz_n, ux_dt2, uy_dt2, uz_dt2);
   EXPECT_EQ(view.getNumFields(), 6);
 }
 
-TEST_F(WavefieldViewBackwardElasticTest, GetFieldNameByIndex)
-{
+TEST_F(WavefieldViewBackwardElasticTest, GetFieldNameByIndex) {
   WavefieldViewBackwardElastic view(ux_n, uy_n, uz_n, ux_dt2, uy_dt2, uz_dt2);
   EXPECT_EQ(view.getFieldName(0), "ux_n");
   EXPECT_EQ(view.getFieldName(1), "uy_n");
@@ -85,8 +73,7 @@ TEST_F(WavefieldViewBackwardElasticTest, GetFieldNameByIndex)
   EXPECT_EQ(view.getFieldName(5), "uz_dt2");
 }
 
-TEST_F(WavefieldViewBackwardElasticTest, GetFieldReturnsCorrectViews)
-{
+TEST_F(WavefieldViewBackwardElasticTest, GetFieldReturnsCorrectViews) {
   WavefieldViewBackwardElastic view(ux_n, uy_n, uz_n, ux_dt2, uy_dt2, uz_dt2);
 
   auto f0 = view.getField(0);
@@ -96,8 +83,7 @@ TEST_F(WavefieldViewBackwardElasticTest, GetFieldReturnsCorrectViews)
   auto f4 = view.getField(4);
   auto f5 = view.getField(5);
 
-  for (int i = 0; i < size; ++i)
-  {
+  for (int i = 0; i < size; ++i) {
     EXPECT_FLOAT_EQ(f0(i), static_cast<float>(i) * 1.0f);
     EXPECT_FLOAT_EQ(f1(i), static_cast<float>(i) * 2.0f);
     EXPECT_FLOAT_EQ(f2(i), static_cast<float>(i) * 3.0f);
@@ -107,32 +93,27 @@ TEST_F(WavefieldViewBackwardElasticTest, GetFieldReturnsCorrectViews)
   }
 }
 
-TEST_F(WavefieldViewBackwardElasticTest, GetFieldOutOfBoundsFallsBackToUxN)
-{
+TEST_F(WavefieldViewBackwardElasticTest, GetFieldOutOfBoundsFallsBackToUxN) {
   WavefieldViewBackwardElastic view(ux_n, uy_n, uz_n, ux_dt2, uy_dt2, uz_dt2);
   auto fallback = view.getField(99);
   EXPECT_EQ(fallback.extent(0), static_cast<size_t>(size));
   EXPECT_FLOAT_EQ(fallback(0), ux_n(0));
 }
 
-TEST_F(WavefieldViewBackwardElasticTest, ViewsAreShallowCopies)
-{
+TEST_F(WavefieldViewBackwardElasticTest, ViewsAreShallowCopies) {
   WavefieldViewBackwardElastic view(ux_n, uy_n, uz_n, ux_dt2, uy_dt2, uz_dt2);
   ux_dt2(5) = 999.0f;
   EXPECT_FLOAT_EQ(view.getField(3)(5), 999.0f);
 }
 
-TEST_F(WavefieldViewBackwardElasticTest, PrintDoesNotThrow)
-{
+TEST_F(WavefieldViewBackwardElasticTest, PrintDoesNotThrow) {
   WavefieldViewBackwardElastic view(ux_n, uy_n, uz_n, ux_dt2, uy_dt2, uz_dt2);
   EXPECT_NO_THROW(view.print());
 }
 
-TEST_F(WavefieldViewBackwardElasticTest, PolymorphicInterface)
-{
+TEST_F(WavefieldViewBackwardElasticTest, PolymorphicInterface) {
   std::unique_ptr<WavefieldView> view =
-      std::make_unique<WavefieldViewBackwardElastic>(ux_n, uy_n, uz_n, ux_dt2,
-                                                     uy_dt2, uz_dt2);
+      std::make_unique<WavefieldViewBackwardElastic>(ux_n, uy_n, uz_n, ux_dt2, uy_dt2, uz_dt2);
 
   EXPECT_EQ(view->getNumFields(), 6);
   EXPECT_EQ(view->getFieldName(3), "ux_dt2");

--- a/tests/units/gradient/impl/elastic/test_wavefield_view_forward_elastic.cc
+++ b/tests/units/gradient/impl/elastic/test_wavefield_view_forward_elastic.cc
@@ -3,27 +3,22 @@
 #include "data_type.h"
 #include "wavefield_view_forward_elastic.h"
 
-namespace gradient
-{
-namespace test
-{
+namespace gradient {
+namespace test {
 
 // =============================================================================
 // WavefieldViewForwardElastic
 // =============================================================================
 
-class WavefieldViewForwardElasticTest : public ::testing::Test
-{
+class WavefieldViewForwardElasticTest : public ::testing::Test {
  protected:
-  void SetUp() override
-  {
+  void SetUp() override {
     size = 45;
     ux_n = allocateVector<VECTOR_REAL_VIEW>(size, "ux_n");
     uy_n = allocateVector<VECTOR_REAL_VIEW>(size, "uy_n");
     uz_n = allocateVector<VECTOR_REAL_VIEW>(size, "uz_n");
 
-    for (int i = 0; i < size; ++i)
-    {
+    for (int i = 0; i < size; ++i) {
       ux_n(i) = static_cast<float>(i) * 1.0f;
       uy_n(i) = static_cast<float>(i) * 2.0f;
       uz_n(i) = static_cast<float>(i) * 3.0f;
@@ -36,81 +31,66 @@ class WavefieldViewForwardElasticTest : public ::testing::Test
   VECTOR_REAL_VIEW uz_n;
 };
 
-TEST_F(WavefieldViewForwardElasticTest, NumFieldsConstant)
-{
-  EXPECT_EQ(WavefieldViewForwardElastic::kNumFields, 3);
-}
+TEST_F(WavefieldViewForwardElasticTest, NumFieldsConstant) { EXPECT_EQ(WavefieldViewForwardElastic::kNumFields, 3); }
 
-TEST_F(WavefieldViewForwardElasticTest, GetFieldNamesCorrect)
-{
+TEST_F(WavefieldViewForwardElasticTest, GetFieldNamesCorrect) {
   WavefieldViewForwardElastic view(ux_n, uy_n, uz_n);
   EXPECT_EQ(view.getFieldName(0), "ux_n");
   EXPECT_EQ(view.getFieldName(1), "uy_n");
   EXPECT_EQ(view.getFieldName(2), "uz_n");
 }
 
-TEST_F(WavefieldViewForwardElasticTest, ConstructorStoresFields)
-{
+TEST_F(WavefieldViewForwardElasticTest, ConstructorStoresFields) {
   WavefieldViewForwardElastic view(ux_n, uy_n, uz_n);
   EXPECT_EQ(view.getField(0).extent(0), static_cast<size_t>(size));
   EXPECT_EQ(view.getField(1).extent(0), static_cast<size_t>(size));
   EXPECT_EQ(view.getField(2).extent(0), static_cast<size_t>(size));
 }
 
-TEST_F(WavefieldViewForwardElasticTest, GetNumFieldsReturns3)
-{
+TEST_F(WavefieldViewForwardElasticTest, GetNumFieldsReturns3) {
   WavefieldViewForwardElastic view(ux_n, uy_n, uz_n);
   EXPECT_EQ(view.getNumFields(), 3);
 }
 
-TEST_F(WavefieldViewForwardElasticTest, GetFieldNameByIndex)
-{
+TEST_F(WavefieldViewForwardElasticTest, GetFieldNameByIndex) {
   WavefieldViewForwardElastic view(ux_n, uy_n, uz_n);
   EXPECT_EQ(view.getFieldName(0), "ux_n");
   EXPECT_EQ(view.getFieldName(1), "uy_n");
   EXPECT_EQ(view.getFieldName(2), "uz_n");
 }
 
-TEST_F(WavefieldViewForwardElasticTest, GetFieldZeroReturnsUxN)
-{
+TEST_F(WavefieldViewForwardElasticTest, GetFieldZeroReturnsUxN) {
   WavefieldViewForwardElastic view(ux_n, uy_n, uz_n);
   auto field = view.getField(0);
 
   ASSERT_EQ(field.extent(0), static_cast<size_t>(size));
-  for (int i = 0; i < size; ++i)
-    EXPECT_FLOAT_EQ(field(i), static_cast<float>(i) * 1.0f);
+  for (int i = 0; i < size; ++i) EXPECT_FLOAT_EQ(field(i), static_cast<float>(i) * 1.0f);
 }
 
-TEST_F(WavefieldViewForwardElasticTest, GetFieldOneReturnsUyN)
-{
+TEST_F(WavefieldViewForwardElasticTest, GetFieldOneReturnsUyN) {
   WavefieldViewForwardElastic view(ux_n, uy_n, uz_n);
   auto field = view.getField(1);
 
   ASSERT_EQ(field.extent(0), static_cast<size_t>(size));
-  for (int i = 0; i < size; ++i)
-    EXPECT_FLOAT_EQ(field(i), static_cast<float>(i) * 2.0f);
+  for (int i = 0; i < size; ++i) EXPECT_FLOAT_EQ(field(i), static_cast<float>(i) * 2.0f);
 }
 
-TEST_F(WavefieldViewForwardElasticTest, GetFieldTwoReturnsUzN)
-{
+TEST_F(WavefieldViewForwardElasticTest, GetFieldTwoReturnsUzN) {
   WavefieldViewForwardElastic view(ux_n, uy_n, uz_n);
   auto field = view.getField(2);
 
   ASSERT_EQ(field.extent(0), static_cast<size_t>(size));
-  for (int i = 0; i < size; ++i)
-    EXPECT_FLOAT_EQ(field(i), static_cast<float>(i) * 3.0f);
+  for (int i = 0; i < size; ++i) EXPECT_FLOAT_EQ(field(i), static_cast<float>(i) * 3.0f);
 }
 
-TEST_F(WavefieldViewForwardElasticTest, GetFieldOutOfBoundsFallsBackToUxN)
-{
+TEST_F(WavefieldViewForwardElasticTest, GetFieldOutOfBoundsFallsBackToUxN) {
   WavefieldViewForwardElastic view(ux_n, uy_n, uz_n);
   auto fallback = view.getField(99);
   EXPECT_EQ(fallback.extent(0), static_cast<size_t>(size));
   EXPECT_FLOAT_EQ(fallback(0), ux_n(0));
 }
 
-TEST_F(WavefieldViewForwardElasticTest, ViewsAreShallowCopies)
-{
+TEST_F(WavefieldViewForwardElasticTest, ViewsAreShallowCopies) {
   WavefieldViewForwardElastic view(ux_n, uy_n, uz_n);
   ux_n(0) = 100.0f;
   uy_n(0) = 200.0f;
@@ -120,16 +100,13 @@ TEST_F(WavefieldViewForwardElasticTest, ViewsAreShallowCopies)
   EXPECT_FLOAT_EQ(view.getField(2)(0), 300.0f);
 }
 
-TEST_F(WavefieldViewForwardElasticTest, PrintDoesNotThrow)
-{
+TEST_F(WavefieldViewForwardElasticTest, PrintDoesNotThrow) {
   WavefieldViewForwardElastic view(ux_n, uy_n, uz_n);
   EXPECT_NO_THROW(view.print());
 }
 
-TEST_F(WavefieldViewForwardElasticTest, PolymorphicInterface)
-{
-  std::unique_ptr<WavefieldView> view =
-      std::make_unique<WavefieldViewForwardElastic>(ux_n, uy_n, uz_n);
+TEST_F(WavefieldViewForwardElasticTest, PolymorphicInterface) {
+  std::unique_ptr<WavefieldView> view = std::make_unique<WavefieldViewForwardElastic>(ux_n, uy_n, uz_n);
 
   EXPECT_EQ(view->getNumFields(), 3);
   EXPECT_EQ(view->getFieldName(1), "uy_n");

--- a/tests/units/main.cpp
+++ b/tests/units/main.cpp
@@ -9,8 +9,7 @@
 /*
  * Main entry point for the Google Test framework with Kokkos initialization.
  */
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
 #ifdef USE_KOKKOS
   Kokkos::initialize(argc, argv);
 #endif

--- a/tests/units/model/impl/builder/cartesian/test_cartesian_partitioner.cc
+++ b/tests/units/model/impl/builder/cartesian/test_cartesian_partitioner.cc
@@ -7,29 +7,22 @@
 #include "model.h"
 #include "topology_factory.h"
 
-namespace
-{
+namespace {
 
 // Minimal Mock Mesh implementing only what TopologyFactory needs
 template <typename FloatType, typename ScalarType>
-class MockMesh : public model::ModelApi<FloatType, ScalarType>
-{
+class MockMesh : public model::ModelApi<FloatType, ScalarType> {
  public:
-  struct Node
-  {
+  struct Node {
     FloatType x, y, z;
   };
   std::vector<Node> nodes;
   FloatType minSpacing = 1.0;
 
-  void addNode(FloatType x, FloatType y, FloatType z)
-  {
-    nodes.push_back({x, y, z});
-  }
+  void addNode(FloatType x, FloatType y, FloatType z) { nodes.push_back({x, y, z}); }
 
   // Required by TopologyFactory
-  PROXY_HOST_DEVICE FloatType nodeCoord(ScalarType i, int dim) const override
-  {
+  PROXY_HOST_DEVICE FloatType nodeCoord(ScalarType i, int dim) const override {
     if (i < 0 || i >= static_cast<ScalarType>(nodes.size())) return 0.0;
     if (dim == 0) return nodes[i].x;
     if (dim == 1) return nodes[i].y;
@@ -37,150 +30,50 @@ class MockMesh : public model::ModelApi<FloatType, ScalarType>
     return 0.0;
   }
 
-  PROXY_HOST_DEVICE ScalarType getNumberOfNodes() const override
-  {
-    return static_cast<ScalarType>(nodes.size());
-  }
+  PROXY_HOST_DEVICE ScalarType getNumberOfNodes() const override { return static_cast<ScalarType>(nodes.size()); }
 
-  PROXY_HOST_DEVICE FloatType getMinSpacing() const override
-  {
-    return minSpacing;
-  }
+  PROXY_HOST_DEVICE FloatType getMinSpacing() const override { return minSpacing; }
 
   // Stubs for other pure virtual methods (not used by TopologyFactory)
-  PROXY_HOST_DEVICE ScalarType globalNodeIndex(ScalarType, int, int,
-                                               int) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE FloatType getModelVpOnNodes(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE FloatType getModelVpOnElement(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE FloatType getModelRhoOnNodes(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE FloatType getModelRhoOnElement(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE FloatType getModelVsOnNodes(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE FloatType getModelVsOnElement(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE FloatType getModelQpOnNodes(ScalarType) const override
-  {
-    return 1e9;
-  }
-  PROXY_HOST_DEVICE FloatType getModelQpOnElement(ScalarType) const override
-  {
-    return 1e9;
-  }
-  PROXY_HOST_DEVICE FloatType getModelQsOnNodes(ScalarType) const override
-  {
-    return 1e9;
-  }
-  PROXY_HOST_DEVICE FloatType getModelQsOnElement(ScalarType) const override
-  {
-    return 1e9;
-  }
-  PROXY_HOST_DEVICE FloatType getModelDeltaOnNodes(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE FloatType getModelDeltaOnElement(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE FloatType getModelEpsilonOnNodes(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE FloatType
-  getModelEpsilonOnElement(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE FloatType getModelGammaOnNodes(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE FloatType getModelGammaOnElement(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE ScalarType getModelThetaOnNodes(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE ScalarType getModelThetaOnElement(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE ScalarType getModelPhiOnNodes(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE ScalarType getModelPhiOnElement(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE void getCTensorOnElement(ScalarType,
-                                             FloatType[6][6]) const override
-  {
-  }
+  PROXY_HOST_DEVICE ScalarType globalNodeIndex(ScalarType, int, int, int) const override { return 0; }
+  PROXY_HOST_DEVICE FloatType getModelVpOnNodes(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE FloatType getModelVpOnElement(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE FloatType getModelRhoOnNodes(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE FloatType getModelRhoOnElement(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE FloatType getModelVsOnNodes(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE FloatType getModelVsOnElement(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE FloatType getModelQpOnNodes(ScalarType) const override { return 1e9; }
+  PROXY_HOST_DEVICE FloatType getModelQpOnElement(ScalarType) const override { return 1e9; }
+  PROXY_HOST_DEVICE FloatType getModelQsOnNodes(ScalarType) const override { return 1e9; }
+  PROXY_HOST_DEVICE FloatType getModelQsOnElement(ScalarType) const override { return 1e9; }
+  PROXY_HOST_DEVICE FloatType getModelDeltaOnNodes(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE FloatType getModelDeltaOnElement(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE FloatType getModelEpsilonOnNodes(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE FloatType getModelEpsilonOnElement(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE FloatType getModelGammaOnNodes(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE FloatType getModelGammaOnElement(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE ScalarType getModelThetaOnNodes(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE ScalarType getModelThetaOnElement(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE ScalarType getModelPhiOnNodes(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE ScalarType getModelPhiOnElement(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE void getCTensorOnElement(ScalarType, FloatType[6][6]) const override {}
   virtual void initElasticityTensors(model::AnisotropyType a) override {}
-  PROXY_HOST_DEVICE ScalarType getNumberOfElements() const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE int getNumberOfPointsPerElement() const override
-  {
-    return 27;
-  }
+  PROXY_HOST_DEVICE ScalarType getNumberOfElements() const override { return 0; }
+  PROXY_HOST_DEVICE int getNumberOfPointsPerElement() const override { return 27; }
   PROXY_HOST_DEVICE int getOrder() const override { return 1; }
 
-  PROXY_HOST_DEVICE void faceNormal(ScalarType, model::CubicFace,
-                                    FloatType[3]) const override
-  {
-  }
+  PROXY_HOST_DEVICE void faceNormal(ScalarType, model::CubicFace, FloatType[3]) const override {}
 
   PROXY_HOST_DEVICE
-  model::BoundaryFlag boundaryType(ScalarType n) const override
-  {
-    return model::BoundaryFlag::InteriorNode;
-  }
+  model::BoundaryFlag boundaryType(ScalarType n) const override { return model::BoundaryFlag::InteriorNode; }
 
   virtual void buildFaceConnectivity() override {}
 
-  PROXY_HOST_DEVICE bool isFreeSurface(ScalarType n) const override
-  {
-    return 1;
-  }
+  PROXY_HOST_DEVICE bool isFreeSurface(ScalarType n) const override { return 1; }
 
-  PROXY_HOST_DEVICE ScalarType getGlobalNodeFromFace(ScalarType,
-                                                     int) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE ScalarType getGlobalFace(ScalarType,
-                                             model::CubicFace) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE bool isBoundaryFace(ScalarType) const override
-  {
-    return true;
-  }
+  PROXY_HOST_DEVICE ScalarType getGlobalNodeFromFace(ScalarType, int) const override { return 0; }
+  PROXY_HOST_DEVICE ScalarType getGlobalFace(ScalarType, model::CubicFace) const override { return 0; }
+  PROXY_HOST_DEVICE bool isBoundaryFace(ScalarType) const override { return true; }
   PROXY_HOST_DEVICE ScalarType getNumberOfFaces() const override { return 0; }
 
   PROXY_HOST_DEVICE FloatType domainSize(int) const override { return 0; }
@@ -190,14 +83,12 @@ class MockMesh : public model::ModelApi<FloatType, ScalarType>
   void setQualityFactors(FloatType qp, FloatType qs) override {}
 };
 
-class TopologyFactoryTest : public ::testing::Test
-{
+class TopologyFactoryTest : public ::testing::Test {
  protected:
   MockMesh<float, int> mesh;
 };
 
-TEST_F(TopologyFactoryTest, SingleRankReturnsEmptySharedNodes)
-{
+TEST_F(TopologyFactoryTest, SingleRankReturnsEmptySharedNodes) {
   mesh.addNode(0.0, 0.0, 0.0);
   mesh.addNode(1.0, 0.0, 0.0);
 
@@ -207,8 +98,7 @@ TEST_F(TopologyFactoryTest, SingleRankReturnsEmptySharedNodes)
   EXPECT_EQ(topo.sharedNodes.size(), 0);
 }
 
-TEST_F(TopologyFactoryTest, LeftBoundaryDetection)
-{
+TEST_F(TopologyFactoryTest, LeftBoundaryDetection) {
   // Rank 1 of 3 (Middle rank)
   // Left boundary at x=10.0, Right at x=20.0
   // Nodes: 10.0 (Left), 15.0 (Inner), 20.0 (Right)
@@ -235,8 +125,7 @@ TEST_F(TopologyFactoryTest, LeftBoundaryDetection)
   EXPECT_EQ(topo.sharedNodes[2][0], 2);  // Node index 2 is at 20.0
 }
 
-TEST_F(TopologyFactoryTest, AutoToleranceFromSpacing)
-{
+TEST_F(TopologyFactoryTest, AutoToleranceFromSpacing) {
   mesh.minSpacing = 0.1f;
   mesh.addNode(10.000001f, 0.0f, 0.0f);  // Slightly off but within tolerance
 
@@ -250,21 +139,17 @@ TEST_F(TopologyFactoryTest, AutoToleranceFromSpacing)
   EXPECT_FALSE(topo.sharedNodes[0].empty());
 }
 
-TEST_F(TopologyFactoryTest, ThrowsOnMissingBoundaryNodes)
-{
+TEST_F(TopologyFactoryTest, ThrowsOnMissingBoundaryNodes) {
   // Rank 1 expects a left neighbor at x=10.0
   // But mesh only has nodes at 15.0 and 20.0
   mesh.addNode(15.0f, 0.0f, 0.0f);
   mesh.addNode(20.0f, 0.0f, 0.0f);
 
   // CHANGE: Expect logic_error instead of runtime_error
-  EXPECT_THROW(
-      { TopologyFactory::createFromMesh(mesh, 1, 3, 10.0f, 10.0f); },
-      std::logic_error);
+  EXPECT_THROW({ TopologyFactory::createFromMesh(mesh, 1, 3, 10.0f, 10.0f); }, std::logic_error);
 }
 
-TEST_F(TopologyFactoryTest, ThrowsOnAmbiguousBoundary)
-{
+TEST_F(TopologyFactoryTest, ThrowsOnAmbiguousBoundary) {
   // A single node satisfying both left and right conditions
   mesh.addNode(10.0f, 0.0f, 0.0f);
 
@@ -279,8 +164,7 @@ TEST_F(TopologyFactoryTest, ThrowsOnAmbiguousBoundary)
   // (bad input)
   EXPECT_THROW(
 
-      { TopologyFactory::createFromMesh(mesh, 1, 3, 10.0f, width); },
-      std::logic_error);
+      { TopologyFactory::createFromMesh(mesh, 1, 3, 10.0f, width); }, std::logic_error);
 }
 
 }  // namespace

--- a/tests/units/model/impl/builder/cartesian/test_cartesian_struct_boundary_classifier.cc
+++ b/tests/units/model/impl/builder/cartesian/test_cartesian_struct_boundary_classifier.cc
@@ -2,18 +2,13 @@
 
 #include "cartesian_struct_boundary_classifier.h"
 
-namespace model
-{
-namespace test
-{
+namespace model {
+namespace test {
 
 // ---------------------------------------------------------------------------
 // Node index helper: n = k*(nx*ny) + j*nx + i
 // ---------------------------------------------------------------------------
-static int nodeIndex3(int nx, int ny, int i, int j, int k)
-{
-  return k * (nx * ny) + j * nx + i;
-}
+static int nodeIndex3(int nx, int ny, int i, int j, int k) { return k * (nx * ny) + j * nx + i; }
 
 // ---------------------------------------------------------------------------
 // Tests for full-domain classification (all six faces are global boundaries)
@@ -24,72 +19,52 @@ static constexpr int N_NODE = NX * NY * NZ;  // 27
 static constexpr float L = 2.f;
 static constexpr float TOL = L * 1e-4f;
 
-class CartesianStructBoundaryClassifierTest : public ::testing::Test
-{
+class CartesianStructBoundaryClassifierTest : public ::testing::Test {
  protected:
   // All six faces are global boundaries; free surface on top
-  CartesianStructBoundaryClassifier<float, int> classifier{0.f, L, 0.f, L,
-                                                           0.f, L, TOL, true};
+  CartesianStructBoundaryClassifier<float, int> classifier{0.f, L, 0.f, L, 0.f, L, TOL, true};
 
-  VECTOR_INT_VIEW classify() const
-  {
-    return classifier.classify(N_NODE, NX, NY, NZ, 0.f, 0.f, 0.f, L, L, L);
-  }
+  VECTOR_INT_VIEW classify() const { return classifier.classify(N_NODE, NX, NY, NZ, 0.f, 0.f, 0.f, L, L, L); }
 };
 
-TEST_F(CartesianStructBoundaryClassifierTest, InteriorNodeIsInterior)
-{
+TEST_F(CartesianStructBoundaryClassifierTest, InteriorNodeIsInterior) {
   auto flags = classify();
   // Only (1,1,1) is interior in a 3×3×3 grid
-  EXPECT_EQ(flags(nodeIndex3(NX, NY, 1, 1, 1)),
-            static_cast<int>(BoundaryFlag::InteriorNode));
+  EXPECT_EQ(flags(nodeIndex3(NX, NY, 1, 1, 1)), static_cast<int>(BoundaryFlag::InteriorNode));
 }
 
-TEST_F(CartesianStructBoundaryClassifierTest,
-       ZmaxNodesAreSurfaceWhenFreeSurfaceOnTop)
-{
+TEST_F(CartesianStructBoundaryClassifierTest, ZmaxNodesAreSurfaceWhenFreeSurfaceOnTop) {
   auto flags = classify();
   for (int j = 0; j < NY; ++j)
     for (int i = 0; i < NX; ++i)
-      EXPECT_EQ(flags(nodeIndex3(NX, NY, i, j, NZ - 1)),
-                static_cast<int>(BoundaryFlag::Surface))
+      EXPECT_EQ(flags(nodeIndex3(NX, NY, i, j, NZ - 1)), static_cast<int>(BoundaryFlag::Surface))
           << "Node (" << i << "," << j << "," << (NZ - 1) << ")";
 }
 
-TEST_F(CartesianStructBoundaryClassifierTest,
-       ZmaxNodesAreDampingWhenFreeSurfaceOff)
-{
-  CartesianStructBoundaryClassifier<float, int> noSurface{0.f, L, 0.f, L,
-                                                          0.f, L, TOL, false};
+TEST_F(CartesianStructBoundaryClassifierTest, ZmaxNodesAreDampingWhenFreeSurfaceOff) {
+  CartesianStructBoundaryClassifier<float, int> noSurface{0.f, L, 0.f, L, 0.f, L, TOL, false};
   auto flags = noSurface.classify(N_NODE, NX, NY, NZ, 0.f, 0.f, 0.f, L, L, L);
   for (int j = 0; j < NY; ++j)
     for (int i = 0; i < NX; ++i)
-      EXPECT_EQ(flags(nodeIndex3(NX, NY, i, j, NZ - 1)),
-                static_cast<int>(BoundaryFlag::Damping))
+      EXPECT_EQ(flags(nodeIndex3(NX, NY, i, j, NZ - 1)), static_cast<int>(BoundaryFlag::Damping))
           << "Node (" << i << "," << j << "," << (NZ - 1) << ")";
 }
 
-TEST_F(CartesianStructBoundaryClassifierTest, NonZmaxBoundaryNodesAreDamping)
-{
+TEST_F(CartesianStructBoundaryClassifierTest, NonZmaxBoundaryNodesAreDamping) {
   auto flags = classify();
   // xmin face (i=0), k < NZ-1
   for (int k = 0; k < NZ - 1; ++k)
-    for (int j = 0; j < NY; ++j)
-      EXPECT_EQ(flags(nodeIndex3(NX, NY, 0, j, k)),
-                static_cast<int>(BoundaryFlag::Damping));
+    for (int j = 0; j < NY; ++j) EXPECT_EQ(flags(nodeIndex3(NX, NY, 0, j, k)), static_cast<int>(BoundaryFlag::Damping));
   // xmax face (i=NX-1), k < NZ-1
   for (int k = 0; k < NZ - 1; ++k)
     for (int j = 0; j < NY; ++j)
-      EXPECT_EQ(flags(nodeIndex3(NX, NY, NX - 1, j, k)),
-                static_cast<int>(BoundaryFlag::Damping));
+      EXPECT_EQ(flags(nodeIndex3(NX, NY, NX - 1, j, k)), static_cast<int>(BoundaryFlag::Damping));
 }
 
-TEST_F(CartesianStructBoundaryClassifierTest, NodeCountsByFlag)
-{
+TEST_F(CartesianStructBoundaryClassifierTest, NodeCountsByFlag) {
   auto flags = classify();
   int n_interior = 0, n_surface = 0, n_damping = 0;
-  for (int n = 0; n < N_NODE; ++n)
-  {
+  for (int n = 0; n < N_NODE; ++n) {
     if (flags(n) == static_cast<int>(BoundaryFlag::InteriorNode))
       ++n_interior;
     else if (flags(n) == static_cast<int>(BoundaryFlag::Surface))
@@ -107,24 +82,19 @@ TEST_F(CartesianStructBoundaryClassifierTest, NodeCountsByFlag)
 // MPI subdomain: local mesh occupies [0, L]^3 but the global x domain is
 // [0, 2*L], so the local x_max face is an internal MPI edge.
 // ---------------------------------------------------------------------------
-TEST(CartesianStructBoundaryClassifierMpiTest, InternalPartitionFaceIsInterior)
-{
+TEST(CartesianStructBoundaryClassifierMpiTest, InternalPartitionFaceIsInterior) {
   // Global x extends to 2*L; local x_max (= L) is NOT a global boundary
-  CartesianStructBoundaryClassifier<float, int> classifier{
-      0.f, 2 * L, 0.f, L, 0.f, L, TOL, true};
+  CartesianStructBoundaryClassifier<float, int> classifier{0.f, 2 * L, 0.f, L, 0.f, L, TOL, true};
   auto flags = classifier.classify(N_NODE, NX, NY, NZ, 0.f, 0.f, 0.f, L, L, L);
 
   // Node at i=NX-1, j=1, k=1: x_max is internal → interior
-  EXPECT_EQ(flags(nodeIndex3(NX, NY, NX - 1, 1, 1)),
-            static_cast<int>(BoundaryFlag::InteriorNode));
+  EXPECT_EQ(flags(nodeIndex3(NX, NY, NX - 1, 1, 1)), static_cast<int>(BoundaryFlag::InteriorNode));
 
   // Node at i=0, j=1, k=1: x_min is global → damping
-  EXPECT_EQ(flags(nodeIndex3(NX, NY, 0, 1, 1)),
-            static_cast<int>(BoundaryFlag::Damping));
+  EXPECT_EQ(flags(nodeIndex3(NX, NY, 0, 1, 1)), static_cast<int>(BoundaryFlag::Damping));
 
   // Node at i=NX-1, j=1, k=NZ-1: z_max is global → surface
-  EXPECT_EQ(flags(nodeIndex3(NX, NY, NX - 1, 1, NZ - 1)),
-            static_cast<int>(BoundaryFlag::Surface));
+  EXPECT_EQ(flags(nodeIndex3(NX, NY, NX - 1, 1, NZ - 1)), static_cast<int>(BoundaryFlag::Surface));
 }
 
 }  // namespace test

--- a/tests/units/model/impl/builder/cartesian/test_cartesian_struct_builder.cc
+++ b/tests/units/model/impl/builder/cartesian/test_cartesian_struct_builder.cc
@@ -4,14 +4,11 @@
 
 #include "cartesian_struct_builder.h"
 
-namespace model
-{
-namespace test
-{
+namespace model {
+namespace test {
 
 template <typename T>
-class CartesianStructInputs : public ::testing::Test
-{
+class CartesianStructInputs : public ::testing::Test {
  protected:
   static constexpr int ex = 10;
   static constexpr float lx = 1;
@@ -22,8 +19,7 @@ class CartesianStructInputs : public ::testing::Test
 };
 
 template <int Order, bool IsModelOnNodes, bool IsElastic>
-struct BuilderConfig
-{
+struct BuilderConfig {
   using Type = CartesianStructBuilder<float, int, Order>;
   static constexpr int order = Order;
   static constexpr bool isModelOnNodes = IsModelOnNodes;
@@ -32,40 +28,32 @@ struct BuilderConfig
 
 // Define all combinations of Order (1-4) and isModelOnNodes (true/false),
 // isElastic (true/false)
-using BuilderTypes = ::testing::Types<
-    BuilderConfig<1, true, true>, BuilderConfig<1, false, false>,
-    BuilderConfig<1, true, false>, BuilderConfig<1, false, true>,
-    BuilderConfig<2, true, true>, BuilderConfig<2, false, false>,
-    BuilderConfig<2, true, false>, BuilderConfig<2, false, true>,
-    BuilderConfig<3, true, true>, BuilderConfig<3, false, false>,
-    BuilderConfig<3, true, false>, BuilderConfig<3, false, true>,
-    BuilderConfig<4, true, true>, BuilderConfig<4, false, false>,
-    BuilderConfig<4, true, false>, BuilderConfig<4, false, true>,
-    BuilderConfig<5, true, true>, BuilderConfig<5, false, false>,
-    BuilderConfig<5, true, false>, BuilderConfig<5, false, true>,
-    BuilderConfig<6, true, true>, BuilderConfig<6, false, false>,
-    BuilderConfig<6, true, false>, BuilderConfig<6, false, true>,
-    BuilderConfig<7, true, true>, BuilderConfig<7, false, false>,
-    BuilderConfig<7, true, false>, BuilderConfig<7, false, true>,
-    BuilderConfig<8, true, true>, BuilderConfig<8, false, false>,
-    BuilderConfig<8, true, false>, BuilderConfig<8, false, true>,
-    BuilderConfig<9, true, true>, BuilderConfig<9, false, false>,
-    BuilderConfig<9, true, false>, BuilderConfig<9, false, true>>;
+using BuilderTypes =
+    ::testing::Types<BuilderConfig<1, true, true>, BuilderConfig<1, false, false>, BuilderConfig<1, true, false>,
+                     BuilderConfig<1, false, true>, BuilderConfig<2, true, true>, BuilderConfig<2, false, false>,
+                     BuilderConfig<2, true, false>, BuilderConfig<2, false, true>, BuilderConfig<3, true, true>,
+                     BuilderConfig<3, false, false>, BuilderConfig<3, true, false>, BuilderConfig<3, false, true>,
+                     BuilderConfig<4, true, true>, BuilderConfig<4, false, false>, BuilderConfig<4, true, false>,
+                     BuilderConfig<4, false, true>, BuilderConfig<5, true, true>, BuilderConfig<5, false, false>,
+                     BuilderConfig<5, true, false>, BuilderConfig<5, false, true>, BuilderConfig<6, true, true>,
+                     BuilderConfig<6, false, false>, BuilderConfig<6, true, false>, BuilderConfig<6, false, true>,
+                     BuilderConfig<7, true, true>, BuilderConfig<7, false, false>, BuilderConfig<7, true, false>,
+                     BuilderConfig<7, false, true>, BuilderConfig<8, true, true>, BuilderConfig<8, false, false>,
+                     BuilderConfig<8, true, false>, BuilderConfig<8, false, true>, BuilderConfig<9, true, true>,
+                     BuilderConfig<9, false, false>, BuilderConfig<9, true, false>, BuilderConfig<9, false, true>>;
 
 TYPED_TEST_SUITE(CartesianStructInputs, BuilderTypes);
 
 // Test constructor and getModel for all orders and isModelOnNodes values, and
 // check resulting model values
-TYPED_TEST(CartesianStructInputs, GetModelReturnsValidModel)
-{
+TYPED_TEST(CartesianStructInputs, GetModelReturnsValidModel) {
   // Prepare
   constexpr int order = TypeParam::order;
   constexpr bool isModelOnNodes = TypeParam::isModelOnNodes;
   constexpr bool isElastic = TypeParam::isElastic;
 
   // Act
-  typename TypeParam::Type builder(this->ex, this->lx, this->ey, this->ly,
-                                   this->ez, this->lz, isModelOnNodes,
+  typename TypeParam::Type builder(this->ex, this->lx, this->ey, this->ly, this->ez, this->lz, isModelOnNodes,
                                    isElastic);
   auto model = builder.getModel(true);
 
@@ -75,23 +63,20 @@ TYPED_TEST(CartesianStructInputs, GetModelReturnsValidModel)
   EXPECT_EQ(model->isModelOnNodes(), isModelOnNodes);
   EXPECT_EQ(model->isElastic(), isElastic);
   EXPECT_EQ(model->getNumberOfElements(), 10 * 20 * 30);
-  EXPECT_EQ(model->getNumberOfNodes(),
-            (10 * order + 1) * (20 * order + 1) * (30 * order + 1));
+  EXPECT_EQ(model->getNumberOfNodes(), (10 * order + 1) * (20 * order + 1) * (30 * order + 1));
   EXPECT_FLOAT_EQ(model->domainSize(0), 1);
   EXPECT_FLOAT_EQ(model->domainSize(1), 4);
   EXPECT_FLOAT_EQ(model->domainSize(2), 9);
 }
 
 // Test multiple calls return different instances
-TYPED_TEST(CartesianStructInputs, MultipleCallsReturnDifferentInstances)
-{
+TYPED_TEST(CartesianStructInputs, MultipleCallsReturnDifferentInstances) {
   // Prepare
   constexpr bool isModelOnNodes = TypeParam::isModelOnNodes;
   constexpr bool isElastic = TypeParam::isElastic;
 
   // Act
-  typename TypeParam::Type builder(this->ex, this->lx, this->ey, this->ly,
-                                   this->ez, this->lz, isModelOnNodes,
+  typename TypeParam::Type builder(this->ex, this->lx, this->ey, this->ly, this->ez, this->lz, isModelOnNodes,
                                    isElastic);
 
   // Assert
@@ -103,15 +88,13 @@ TYPED_TEST(CartesianStructInputs, MultipleCallsReturnDifferentInstances)
 }
 
 // Test polymorphic behavior
-TYPED_TEST(CartesianStructInputs, PolymorphicBehavior)
-{
+TYPED_TEST(CartesianStructInputs, PolymorphicBehavior) {
   // Prepare
   constexpr bool isModelOnNodes = TypeParam::isModelOnNodes;
   constexpr bool isElastic = TypeParam::isElastic;
 
   // Act
-  typename TypeParam::Type builder(this->ex, this->lx, this->ey, this->ly,
-                                   this->ez, this->lz, isModelOnNodes,
+  typename TypeParam::Type builder(this->ex, this->lx, this->ey, this->ly, this->ez, this->lz, isModelOnNodes,
                                    isElastic);
   ModelBuilderBase<float, int>* base_ptr = &builder;
   auto model = base_ptr->getModel(true);

--- a/tests/units/model/impl/builder/cartesian/test_cartesian_unstruct_boundary_classifier.cc
+++ b/tests/units/model/impl/builder/cartesian/test_cartesian_unstruct_boundary_classifier.cc
@@ -2,18 +2,14 @@
 
 #include "cartesian_unstruct_boundary_classifier.h"
 
-namespace model
-{
-namespace test
-{
+namespace model {
+namespace test {
 
 // ---------------------------------------------------------------------------
 // Helper: fill VECTOR_REAL_VIEW from a std::initializer_list of floats
 // ---------------------------------------------------------------------------
-static VECTOR_REAL_VIEW makeCoords(std::initializer_list<float> vals)
-{
-  auto v = allocateVector<VECTOR_REAL_VIEW>(static_cast<int>(vals.size()),
-                                            "test_coords");
+static VECTOR_REAL_VIEW makeCoords(std::initializer_list<float> vals) {
+  auto v = allocateVector<VECTOR_REAL_VIEW>(static_cast<int>(vals.size()), "test_coords");
   int i = 0;
   for (float val : vals) v(i++) = val;
   return v;
@@ -22,16 +18,13 @@ static VECTOR_REAL_VIEW makeCoords(std::initializer_list<float> vals)
 // domain [0,2]^3, tol = 1e-5
 static constexpr float TOL = 1e-5f;
 
-class CartesianUnstructBoundaryClassifierTest : public ::testing::Test
-{
+class CartesianUnstructBoundaryClassifierTest : public ::testing::Test {
  protected:
   // Full-domain classifier: global == local [0,2]^3
-  CartesianUnstructBoundaryClassifier<float, int> classifier{
-      0.f, 2.f, 0.f, 2.f, 0.f, 2.f, TOL, true};
+  CartesianUnstructBoundaryClassifier<float, int> classifier{0.f, 2.f, 0.f, 2.f, 0.f, 2.f, TOL, true};
 };
 
-TEST_F(CartesianUnstructBoundaryClassifierTest, InteriorNodeIsInterior)
-{
+TEST_F(CartesianUnstructBoundaryClassifierTest, InteriorNodeIsInterior) {
   auto x = makeCoords({1.f});
   auto y = makeCoords({1.f});
   auto z = makeCoords({1.f});
@@ -40,9 +33,7 @@ TEST_F(CartesianUnstructBoundaryClassifierTest, InteriorNodeIsInterior)
   EXPECT_EQ(flags(0), static_cast<int>(BoundaryFlag::InteriorNode));
 }
 
-TEST_F(CartesianUnstructBoundaryClassifierTest,
-       ZmaxNodeIsSurfaceWhenFreeSurfaceOnTop)
-{
+TEST_F(CartesianUnstructBoundaryClassifierTest, ZmaxNodeIsSurfaceWhenFreeSurfaceOnTop) {
   auto x = makeCoords({1.f});
   auto y = makeCoords({1.f});
   auto z = makeCoords({2.f});  // at z_max
@@ -51,11 +42,8 @@ TEST_F(CartesianUnstructBoundaryClassifierTest,
   EXPECT_EQ(flags(0), static_cast<int>(BoundaryFlag::Surface));
 }
 
-TEST_F(CartesianUnstructBoundaryClassifierTest,
-       ZmaxNodeIsDampingWhenFreeSurfaceOff)
-{
-  CartesianUnstructBoundaryClassifier<float, int> noSurface{
-      0.f, 2.f, 0.f, 2.f, 0.f, 2.f, TOL, false};
+TEST_F(CartesianUnstructBoundaryClassifierTest, ZmaxNodeIsDampingWhenFreeSurfaceOff) {
+  CartesianUnstructBoundaryClassifier<float, int> noSurface{0.f, 2.f, 0.f, 2.f, 0.f, 2.f, TOL, false};
 
   auto x = makeCoords({1.f});
   auto y = makeCoords({1.f});
@@ -65,21 +53,17 @@ TEST_F(CartesianUnstructBoundaryClassifierTest,
   EXPECT_EQ(flags(0), static_cast<int>(BoundaryFlag::Damping));
 }
 
-TEST_F(CartesianUnstructBoundaryClassifierTest, AllSixFacesAreDamping)
-{
+TEST_F(CartesianUnstructBoundaryClassifierTest, AllSixFacesAreDamping) {
   // One representative node on each non-zmax face
   auto x = makeCoords({0.f, 2.f, 1.f, 1.f, 1.f});
   auto y = makeCoords({1.f, 1.f, 0.f, 2.f, 1.f});
   auto z = makeCoords({1.f, 1.f, 1.f, 1.f, 0.f});  // last node on z_min
 
   auto flags = classifier.classify(5, x, y, z);
-  for (int n = 0; n < 5; ++n)
-    EXPECT_EQ(flags(n), static_cast<int>(BoundaryFlag::Damping))
-        << "node " << n;
+  for (int n = 0; n < 5; ++n) EXPECT_EQ(flags(n), static_cast<int>(BoundaryFlag::Damping)) << "node " << n;
 }
 
-TEST_F(CartesianUnstructBoundaryClassifierTest, MixedNodeTypes)
-{
+TEST_F(CartesianUnstructBoundaryClassifierTest, MixedNodeTypes) {
   // Layout: interior, zmax (surface), xmin (damping), zmin (damping)
   auto x = makeCoords({1.f, 1.f, 0.f, 1.f});
   auto y = makeCoords({1.f, 1.f, 1.f, 1.f});
@@ -96,14 +80,11 @@ TEST_F(CartesianUnstructBoundaryClassifierTest, MixedNodeTypes)
 // MPI subdomain test: local mesh in [0,2] x [0,2] x [0,2] with global x in
 // [0,4] → node at x=2 is an internal MPI edge, not a physical boundary.
 // ---------------------------------------------------------------------------
-TEST(CartesianUnstructBoundaryClassifierMpiTest,
-     InternalPartitionFaceIsInterior)
-{
-  CartesianUnstructBoundaryClassifier<float, int> classifier{
-      0.f, 4.f,  // global x: local covers only half
-      0.f, 2.f,  // global y
-      0.f, 2.f,  // global z
-      TOL, true};
+TEST(CartesianUnstructBoundaryClassifierMpiTest, InternalPartitionFaceIsInterior) {
+  CartesianUnstructBoundaryClassifier<float, int> classifier{0.f, 4.f,  // global x: local covers only half
+                                                             0.f, 2.f,  // global y
+                                                             0.f, 2.f,  // global z
+                                                             TOL, true};
 
   // Node at x=2 (local xmax), y=1, z=1 — NOT on any global face
   auto x = makeCoords({2.f});
@@ -114,11 +95,8 @@ TEST(CartesianUnstructBoundaryClassifierMpiTest,
   EXPECT_EQ(flags(0), static_cast<int>(BoundaryFlag::InteriorNode));
 }
 
-TEST(CartesianUnstructBoundaryClassifierMpiTest,
-     GlobalXminIsStillDampingInSubdomain)
-{
-  CartesianUnstructBoundaryClassifier<float, int> classifier{
-      0.f, 4.f, 0.f, 2.f, 0.f, 2.f, TOL, true};
+TEST(CartesianUnstructBoundaryClassifierMpiTest, GlobalXminIsStillDampingInSubdomain) {
+  CartesianUnstructBoundaryClassifier<float, int> classifier{0.f, 4.f, 0.f, 2.f, 0.f, 2.f, TOL, true};
 
   auto x = makeCoords({0.f});
   auto y = makeCoords({1.f});

--- a/tests/units/model/impl/mesh/faceconnectivity/test_face_connectivity_helpers.h
+++ b/tests/units/model/impl/mesh/faceconnectivity/test_face_connectivity_helpers.h
@@ -5,27 +5,22 @@
 
 #include "face_connectivity.h"
 
-namespace model
-{
+namespace model {
 
 template <typename FloatType, typename ScalarType, typename FCType>
-void testSingleCubeFaceCount(const FCType& fc)
-{
+void testSingleCubeFaceCount(const FCType& fc) {
   EXPECT_EQ(fc.getNumberOfFaces(), 6);
   EXPECT_EQ(fc.getDofsPerFace(), 4);
 }
 
 template <typename FloatType, typename ScalarType, typename FCType>
-void testTwoAdjacentCubesFaceCount(const FCType& fc)
-{
+void testTwoAdjacentCubesFaceCount(const FCType& fc) {
   EXPECT_EQ(fc.getNumberOfFaces(), 11);
 }
 
 template <typename FloatType, typename ScalarType, typename FCType>
-void testGlobalFaceIds(const FCType& fc)
-{
-  for (int lf = 0; lf < 6; ++lf)
-  {
+void testGlobalFaceIds(const FCType& fc) {
+  for (int lf = 0; lf < 6; ++lf) {
     auto face_id = fc.getGlobalFace(0, static_cast<CubicFace>(lf));
     EXPECT_GE(face_id, 0);
     EXPECT_LT(face_id, 6);
@@ -33,24 +28,19 @@ void testGlobalFaceIds(const FCType& fc)
 }
 
 template <typename FloatType, typename ScalarType, typename FCType>
-void testGlobalFaceUniqueness(const FCType& fc)
-{
+void testGlobalFaceUniqueness(const FCType& fc) {
   std::set<ScalarType> face_ids;
-  for (int lf = 0; lf < 6; ++lf)
-    face_ids.insert(fc.getGlobalFace(0, static_cast<CubicFace>(lf)));
+  for (int lf = 0; lf < 6; ++lf) face_ids.insert(fc.getGlobalFace(0, static_cast<CubicFace>(lf)));
   EXPECT_EQ(face_ids.size(), 6);
 }
 
 template <typename FloatType, typename ScalarType, typename FCType>
-void testSingleCubeAllBoundary(const FCType& fc)
-{
-  for (ScalarType f = 0; f < fc.getNumberOfFaces(); ++f)
-    EXPECT_TRUE(fc.isBoundaryFace(f));
+void testSingleCubeAllBoundary(const FCType& fc) {
+  for (ScalarType f = 0; f < fc.getNumberOfFaces(); ++f) EXPECT_TRUE(fc.isBoundaryFace(f));
 }
 
 template <typename FloatType, typename ScalarType, typename FCType>
-void testSharedFaceNotBoundary(const FCType& fc)
-{
+void testSharedFaceNotBoundary(const FCType& fc) {
   auto face_elem0_xplus = fc.getGlobalFace(0, CubicFace::kXPlus);
   auto face_elem1_xminus = fc.getGlobalFace(1, CubicFace::kXMinus);
   EXPECT_EQ(face_elem0_xplus, face_elem1_xminus);
@@ -58,8 +48,7 @@ void testSharedFaceNotBoundary(const FCType& fc)
 }
 
 template <typename FloatType, typename ScalarType, typename FCType>
-void testBoundaryFaceCount(const FCType& fc)
-{
+void testBoundaryFaceCount(const FCType& fc) {
   int boundary_count = 0;
   for (ScalarType f = 0; f < fc.getNumberOfFaces(); ++f)
     if (fc.isBoundaryFace(f)) boundary_count++;
@@ -67,11 +56,9 @@ void testBoundaryFaceCount(const FCType& fc)
 }
 
 template <typename FloatType, typename ScalarType, typename FCType>
-void testFaceNodes(const FCType& fc, int n_nodes)
-{
+void testFaceNodes(const FCType& fc, int n_nodes) {
   auto face0 = fc.getGlobalFace(0, CubicFace::kXMinus);
-  for (int dof = 0; dof < 4; ++dof)
-  {
+  for (int dof = 0; dof < 4; ++dof) {
     auto node = fc.getGlobalNodeFromFace(face0, dof);
     EXPECT_GE(node, 0);
     EXPECT_LT(node, n_nodes);
@@ -79,18 +66,15 @@ void testFaceNodes(const FCType& fc, int n_nodes)
 }
 
 template <typename FloatType, typename ScalarType, typename FCType>
-void testFaceNodesUnique(const FCType& fc)
-{
+void testFaceNodesUnique(const FCType& fc) {
   auto face0 = fc.getGlobalFace(0, CubicFace::kXMinus);
   std::set<ScalarType> nodes;
-  for (int dof = 0; dof < 4; ++dof)
-    nodes.insert(fc.getGlobalNodeFromFace(face0, dof));
+  for (int dof = 0; dof < 4; ++dof) nodes.insert(fc.getGlobalNodeFromFace(face0, dof));
   EXPECT_EQ(nodes.size(), 4);
 }
 
 template <typename FloatType, typename ScalarType, typename FCType>
-void testInternalFaceOwners(const FCType& fc)
-{
+void testInternalFaceOwners(const FCType& fc) {
   auto shared_face = fc.getGlobalFace(0, CubicFace::kXPlus);
   EXPECT_GE(fc.elemOwner(shared_face), 0);
   EXPECT_GE(fc.elemNeighbor(shared_face), 0);
@@ -98,8 +82,7 @@ void testInternalFaceOwners(const FCType& fc)
 }
 
 template <typename FloatType, typename ScalarType, typename FCType>
-void testBoundaryFaceNoNeighbor(const FCType& fc)
-{
+void testBoundaryFaceNoNeighbor(const FCType& fc) {
   auto boundary_face = fc.getGlobalFace(0, CubicFace::kXMinus);
   EXPECT_GE(fc.elemOwner(boundary_face), 0);
   EXPECT_EQ(fc.elemNeighbor(boundary_face), -1);

--- a/tests/units/model/impl/mesh/faceconnectivity/test_face_connectivity_struct.cpp
+++ b/tests/units/model/impl/mesh/faceconnectivity/test_face_connectivity_struct.cpp
@@ -4,14 +4,11 @@
 #include "model_struct.h"
 #include "test_face_connectivity_helpers.h"
 
-namespace model
-{
-namespace
-{
+namespace model {
+namespace {
 
 template <typename FloatType, typename ScalarType>
-ModelStruct<FloatType, ScalarType, 1> createSingleCube()
-{
+ModelStruct<FloatType, ScalarType, 1> createSingleCube() {
   ModelStructData<FloatType, ScalarType> data;
   data.ex_ = 1;
   data.ey_ = 1;
@@ -28,8 +25,7 @@ ModelStruct<FloatType, ScalarType, 1> createSingleCube()
 }
 
 template <typename FloatType, typename ScalarType>
-ModelStruct<FloatType, ScalarType, 1> createTwoAdjacentCubes()
-{
+ModelStruct<FloatType, ScalarType, 1> createTwoAdjacentCubes() {
   ModelStructData<FloatType, ScalarType> data;
   data.ex_ = 2;
   data.ey_ = 1;
@@ -46,108 +42,94 @@ ModelStruct<FloatType, ScalarType, 1> createTwoAdjacentCubes()
 }
 
 template <typename T>
-class FaceConnectivityStructTest : public ::testing::Test
-{
+class FaceConnectivityStructTest : public ::testing::Test {
  protected:
   using FloatType = typename T::FloatType;
   using ScalarType = typename T::ScalarType;
 };
 
-struct FloatInt
-{
+struct FloatInt {
   using FloatType = float;
   using ScalarType = int;
 };
-struct DoubleInt
-{
+struct DoubleInt {
   using FloatType = double;
   using ScalarType = int;
 };
 using TestTypes = ::testing::Types<FloatInt, DoubleInt>;
 TYPED_TEST_SUITE(FaceConnectivityStructTest, TestTypes);
 
-TYPED_TEST(FaceConnectivityStructTest, BuildFromSingleCube)
-{
+TYPED_TEST(FaceConnectivityStructTest, BuildFromSingleCube) {
   using F = typename TestFixture::FloatType;
   using S = typename TestFixture::ScalarType;
   FaceConnectivityStruct<F, S> fc(1, 1, 1, 1);
   testSingleCubeFaceCount<F, S>(fc);
 }
 
-TYPED_TEST(FaceConnectivityStructTest, BuildFromTwoAdjacentCubes)
-{
+TYPED_TEST(FaceConnectivityStructTest, BuildFromTwoAdjacentCubes) {
   using F = typename TestFixture::FloatType;
   using S = typename TestFixture::ScalarType;
   FaceConnectivityStruct<F, S> fc(2, 1, 1, 1);
   testTwoAdjacentCubesFaceCount<F, S>(fc);
 }
 
-TYPED_TEST(FaceConnectivityStructTest, GetGlobalFaceReturnsValidIds)
-{
+TYPED_TEST(FaceConnectivityStructTest, GetGlobalFaceReturnsValidIds) {
   using F = typename TestFixture::FloatType;
   using S = typename TestFixture::ScalarType;
   FaceConnectivityStruct<F, S> fc(1, 1, 1, 1);
   testGlobalFaceIds<F, S>(fc);
 }
 
-TYPED_TEST(FaceConnectivityStructTest, GetGlobalFaceUniqueness)
-{
+TYPED_TEST(FaceConnectivityStructTest, GetGlobalFaceUniqueness) {
   using F = typename TestFixture::FloatType;
   using S = typename TestFixture::ScalarType;
   FaceConnectivityStruct<F, S> fc(1, 1, 1, 1);
   testGlobalFaceUniqueness<F, S>(fc);
 }
 
-TYPED_TEST(FaceConnectivityStructTest, SingleCubeAllFacesAreBoundary)
-{
+TYPED_TEST(FaceConnectivityStructTest, SingleCubeAllFacesAreBoundary) {
   using F = typename TestFixture::FloatType;
   using S = typename TestFixture::ScalarType;
   FaceConnectivityStruct<F, S> fc(1, 1, 1, 1);
   testSingleCubeAllBoundary<F, S>(fc);
 }
 
-TYPED_TEST(FaceConnectivityStructTest, TwoCubesSharedFaceNotBoundary)
-{
+TYPED_TEST(FaceConnectivityStructTest, TwoCubesSharedFaceNotBoundary) {
   using F = typename TestFixture::FloatType;
   using S = typename TestFixture::ScalarType;
   FaceConnectivityStruct<F, S> fc(2, 1, 1, 1);
   testSharedFaceNotBoundary<F, S>(fc);
 }
 
-TYPED_TEST(FaceConnectivityStructTest, TwoCubesCountBoundaryFaces)
-{
+TYPED_TEST(FaceConnectivityStructTest, TwoCubesCountBoundaryFaces) {
   using F = typename TestFixture::FloatType;
   using S = typename TestFixture::ScalarType;
   FaceConnectivityStruct<F, S> fc(2, 1, 1, 1);
   testBoundaryFaceCount<F, S>(fc);
 }
 
-TYPED_TEST(FaceConnectivityStructTest, FaceNodesValid)
-{
+TYPED_TEST(FaceConnectivityStructTest, FaceNodesValid) {
   using F = typename TestFixture::FloatType;
   using S = typename TestFixture::ScalarType;
   FaceConnectivityStruct<F, S> fc(1, 1, 1, 1);
   testFaceNodes<F, S>(fc, 8);
 }
 
-TYPED_TEST(FaceConnectivityStructTest, FaceNodesUnique)
-{
+TYPED_TEST(FaceConnectivityStructTest, FaceNodesUnique) {
   using F = typename TestFixture::FloatType;
   using S = typename TestFixture::ScalarType;
   FaceConnectivityStruct<F, S> fc(1, 1, 1, 1);
   testFaceNodesUnique<F, S>(fc);
 }
 
-TYPED_TEST(FaceConnectivityStructTest, InternalFaceHasTwoOwners)
-{
+TYPED_TEST(FaceConnectivityStructTest, InternalFaceHasTwoOwners) {
   using F = typename TestFixture::FloatType;
   using S = typename TestFixture::ScalarType;
   FaceConnectivityStruct<F, S> fc(2, 1, 1, 1);
   testInternalFaceOwners<F, S>(fc);
 }
 
-TYPED_TEST(FaceConnectivityStructTest, BoundaryFaceHasNoNeighbor)
-{
+TYPED_TEST(FaceConnectivityStructTest, BoundaryFaceHasNoNeighbor) {
   using F = typename TestFixture::FloatType;
   using S = typename TestFixture::ScalarType;
   FaceConnectivityStruct<F, S> fc(1, 1, 1, 1);

--- a/tests/units/model/impl/mesh/faceconnectivity/test_face_connectivity_unstruct.cpp
+++ b/tests/units/model/impl/mesh/faceconnectivity/test_face_connectivity_unstruct.cpp
@@ -4,14 +4,11 @@
 #include "model_unstruct.h"
 #include "test_face_connectivity_helpers.h"
 
-namespace model
-{
-namespace
-{
+namespace model {
+namespace {
 
 template <typename FloatType, typename ScalarType>
-ModelUnstruct<FloatType, ScalarType> createSingleCube()
-{
+ModelUnstruct<FloatType, ScalarType> createSingleCube() {
   ModelUnstructData<FloatType, ScalarType> data;
   data.order_ = 1;
   data.n_element_ = 1;
@@ -28,8 +25,7 @@ ModelUnstruct<FloatType, ScalarType> createSingleCube()
   data.model_vp_element_ = allocateVector<VECTOR_REAL_VIEW>(1);
   data.model_rho_element_ = allocateVector<VECTOR_REAL_VIEW>(1);
   data.boundaries_t_ = allocateVector<VECTOR_INT_VIEW>(8);
-  for (int i = 0; i < 8; ++i)
-  {
+  for (int i = 0; i < 8; ++i) {
     data.global_node_index_(0, i) = i;
     data.nodes_coords_x_[i] = (i & 1) ? 1.0 : 0.0;
     data.nodes_coords_y_[i] = (i & 2) ? 1.0 : 0.0;
@@ -41,8 +37,7 @@ ModelUnstruct<FloatType, ScalarType> createSingleCube()
 }
 
 template <typename FloatType, typename ScalarType>
-ModelUnstruct<FloatType, ScalarType> createTwoAdjacentCubes()
-{
+ModelUnstruct<FloatType, ScalarType> createTwoAdjacentCubes() {
   ModelUnstructData<FloatType, ScalarType> data;
   data.order_ = 1;
   data.n_element_ = 2;
@@ -59,8 +54,7 @@ ModelUnstruct<FloatType, ScalarType> createTwoAdjacentCubes()
   data.model_vp_element_ = allocateVector<VECTOR_REAL_VIEW>(2);
   data.model_rho_element_ = allocateVector<VECTOR_REAL_VIEW>(2);
   data.boundaries_t_ = allocateVector<VECTOR_INT_VIEW>(12);
-  for (int i = 0; i < 8; ++i)
-  {
+  for (int i = 0; i < 8; ++i) {
     data.global_node_index_(0, i) = i;
     data.nodes_coords_x_[i] = (i & 1) ? 1.0 : 0.0;
     data.nodes_coords_y_[i] = (i & 2) ? 1.0 : 0.0;
@@ -74,8 +68,7 @@ ModelUnstruct<FloatType, ScalarType> createTwoAdjacentCubes()
   data.global_node_index_(1, 5) = 10;
   data.global_node_index_(1, 6) = 7;
   data.global_node_index_(1, 7) = 11;
-  for (int i = 8; i < 12; ++i)
-  {
+  for (int i = 8; i < 12; ++i) {
     data.nodes_coords_x_[i] = 2.0;
     data.nodes_coords_y_[i] = (i & 2) ? 1.0 : 0.0;
     data.nodes_coords_z_[i] = (i & 4) ? 1.0 : 0.0;
@@ -86,28 +79,24 @@ ModelUnstruct<FloatType, ScalarType> createTwoAdjacentCubes()
 }
 
 template <typename T>
-class FaceConnectivityUnstructTest : public ::testing::Test
-{
+class FaceConnectivityUnstructTest : public ::testing::Test {
  protected:
   using FloatType = typename T::FloatType;
   using ScalarType = typename T::ScalarType;
 };
 
-struct FloatInt
-{
+struct FloatInt {
   using FloatType = float;
   using ScalarType = int;
 };
-struct DoubleInt
-{
+struct DoubleInt {
   using FloatType = double;
   using ScalarType = int;
 };
 using TestTypes = ::testing::Types<FloatInt, DoubleInt>;
 TYPED_TEST_SUITE(FaceConnectivityUnstructTest, TestTypes);
 
-TYPED_TEST(FaceConnectivityUnstructTest, BuildFromSingleCube)
-{
+TYPED_TEST(FaceConnectivityUnstructTest, BuildFromSingleCube) {
   using F = typename TestFixture::FloatType;
   using S = typename TestFixture::ScalarType;
   FaceConnectivityUnstruct<F, S> fc;
@@ -115,8 +104,7 @@ TYPED_TEST(FaceConnectivityUnstructTest, BuildFromSingleCube)
   testSingleCubeFaceCount<F, S>(fc);
 }
 
-TYPED_TEST(FaceConnectivityUnstructTest, BuildFromTwoAdjacentCubes)
-{
+TYPED_TEST(FaceConnectivityUnstructTest, BuildFromTwoAdjacentCubes) {
   using F = typename TestFixture::FloatType;
   using S = typename TestFixture::ScalarType;
   FaceConnectivityUnstruct<F, S> fc;
@@ -124,8 +112,7 @@ TYPED_TEST(FaceConnectivityUnstructTest, BuildFromTwoAdjacentCubes)
   testTwoAdjacentCubesFaceCount<F, S>(fc);
 }
 
-TYPED_TEST(FaceConnectivityUnstructTest, GetGlobalFaceReturnsValidIds)
-{
+TYPED_TEST(FaceConnectivityUnstructTest, GetGlobalFaceReturnsValidIds) {
   using F = typename TestFixture::FloatType;
   using S = typename TestFixture::ScalarType;
   FaceConnectivityUnstruct<F, S> fc;
@@ -133,8 +120,7 @@ TYPED_TEST(FaceConnectivityUnstructTest, GetGlobalFaceReturnsValidIds)
   testGlobalFaceIds<F, S>(fc);
 }
 
-TYPED_TEST(FaceConnectivityUnstructTest, GetGlobalFaceUniqueness)
-{
+TYPED_TEST(FaceConnectivityUnstructTest, GetGlobalFaceUniqueness) {
   using F = typename TestFixture::FloatType;
   using S = typename TestFixture::ScalarType;
   FaceConnectivityUnstruct<F, S> fc;
@@ -142,8 +128,7 @@ TYPED_TEST(FaceConnectivityUnstructTest, GetGlobalFaceUniqueness)
   testGlobalFaceUniqueness<F, S>(fc);
 }
 
-TYPED_TEST(FaceConnectivityUnstructTest, SingleCubeAllFacesAreBoundary)
-{
+TYPED_TEST(FaceConnectivityUnstructTest, SingleCubeAllFacesAreBoundary) {
   using F = typename TestFixture::FloatType;
   using S = typename TestFixture::ScalarType;
   FaceConnectivityUnstruct<F, S> fc;
@@ -151,8 +136,7 @@ TYPED_TEST(FaceConnectivityUnstructTest, SingleCubeAllFacesAreBoundary)
   testSingleCubeAllBoundary<F, S>(fc);
 }
 
-TYPED_TEST(FaceConnectivityUnstructTest, TwoCubesSharedFaceNotBoundary)
-{
+TYPED_TEST(FaceConnectivityUnstructTest, TwoCubesSharedFaceNotBoundary) {
   using F = typename TestFixture::FloatType;
   using S = typename TestFixture::ScalarType;
   FaceConnectivityUnstruct<F, S> fc;
@@ -160,8 +144,7 @@ TYPED_TEST(FaceConnectivityUnstructTest, TwoCubesSharedFaceNotBoundary)
   testSharedFaceNotBoundary<F, S>(fc);
 }
 
-TYPED_TEST(FaceConnectivityUnstructTest, TwoCubesCountBoundaryFaces)
-{
+TYPED_TEST(FaceConnectivityUnstructTest, TwoCubesCountBoundaryFaces) {
   using F = typename TestFixture::FloatType;
   using S = typename TestFixture::ScalarType;
   FaceConnectivityUnstruct<F, S> fc;
@@ -169,8 +152,7 @@ TYPED_TEST(FaceConnectivityUnstructTest, TwoCubesCountBoundaryFaces)
   testBoundaryFaceCount<F, S>(fc);
 }
 
-TYPED_TEST(FaceConnectivityUnstructTest, FaceNodesValid)
-{
+TYPED_TEST(FaceConnectivityUnstructTest, FaceNodesValid) {
   using F = typename TestFixture::FloatType;
   using S = typename TestFixture::ScalarType;
   FaceConnectivityUnstruct<F, S> fc;
@@ -178,8 +160,7 @@ TYPED_TEST(FaceConnectivityUnstructTest, FaceNodesValid)
   testFaceNodes<F, S>(fc, 8);
 }
 
-TYPED_TEST(FaceConnectivityUnstructTest, FaceNodesUnique)
-{
+TYPED_TEST(FaceConnectivityUnstructTest, FaceNodesUnique) {
   using F = typename TestFixture::FloatType;
   using S = typename TestFixture::ScalarType;
   FaceConnectivityUnstruct<F, S> fc;
@@ -187,8 +168,7 @@ TYPED_TEST(FaceConnectivityUnstructTest, FaceNodesUnique)
   testFaceNodesUnique<F, S>(fc);
 }
 
-TYPED_TEST(FaceConnectivityUnstructTest, InternalFaceHasTwoOwners)
-{
+TYPED_TEST(FaceConnectivityUnstructTest, InternalFaceHasTwoOwners) {
   using F = typename TestFixture::FloatType;
   using S = typename TestFixture::ScalarType;
   FaceConnectivityUnstruct<F, S> fc;
@@ -196,8 +176,7 @@ TYPED_TEST(FaceConnectivityUnstructTest, InternalFaceHasTwoOwners)
   testInternalFaceOwners<F, S>(fc);
 }
 
-TYPED_TEST(FaceConnectivityUnstructTest, BoundaryFaceHasNoNeighbor)
-{
+TYPED_TEST(FaceConnectivityUnstructTest, BoundaryFaceHasNoNeighbor) {
   using F = typename TestFixture::FloatType;
   using S = typename TestFixture::ScalarType;
   FaceConnectivityUnstruct<F, S> fc;

--- a/tests/units/model/impl/mesh/struct/test_struct_mesh.cc
+++ b/tests/units/model/impl/mesh/struct/test_struct_mesh.cc
@@ -7,10 +7,8 @@
 
 #include "model_struct.h"
 
-namespace model
-{
-namespace
-{
+namespace model {
+namespace {
 
 // ============================================================================
 // Type Wrapper Classes for Non-Type Template Parameters
@@ -19,75 +17,65 @@ namespace
 // We wrap template instantiations in structs to make them compatible.
 
 // Order 1 wrappers
-struct FloatOrder1
-{
+struct FloatOrder1 {
   using FloatType = float;
   using ScalarType = int;
   static constexpr int Order = 1;
 };
 
-struct DoubleOrder1
-{
+struct DoubleOrder1 {
   using FloatType = double;
   using ScalarType = int;
   static constexpr int Order = 1;
 };
 
 // Order 2 wrappers
-struct FloatOrder2
-{
+struct FloatOrder2 {
   using FloatType = float;
   using ScalarType = int;
   static constexpr int Order = 2;
 };
 
-struct DoubleOrder2
-{
+struct DoubleOrder2 {
   using FloatType = double;
   using ScalarType = int;
   static constexpr int Order = 2;
 };
 
 // Order 3 wrappers
-struct FloatOrder3
-{
+struct FloatOrder3 {
   using FloatType = float;
   using ScalarType = int;
   static constexpr int Order = 3;
 };
 
-struct DoubleOrder3
-{
+struct DoubleOrder3 {
   using FloatType = double;
   using ScalarType = int;
   static constexpr int Order = 3;
 };
 
 // Order 4 wrappers
-struct FloatOrder4
-{
+struct FloatOrder4 {
   using FloatType = float;
   using ScalarType = int;
   static constexpr int Order = 4;
 };
 
-struct DoubleOrder4
-{
+struct DoubleOrder4 {
   using FloatType = double;
   using ScalarType = int;
   static constexpr int Order = 4;
 };
 
 // Order 5 wrappers
-struct FloatOrder5
-{
+struct FloatOrder5 {
   using FloatType = float;
   using ScalarType = int;
   static constexpr int Order = 5;
 };
 
-struct DoubleOrder5
-{
+struct DoubleOrder5 {
   using FloatType = double;
   using ScalarType = int;
   static constexpr int Order = 5;
@@ -98,8 +86,7 @@ struct DoubleOrder5
 // ============================================================================
 
 template <typename TypeWrapper>
-class ModelStructTest : public ::testing::Test
-{
+class ModelStructTest : public ::testing::Test {
  protected:
   using FloatType = typename TypeWrapper::FloatType;
   using ScalarType = typename TypeWrapper::ScalarType;
@@ -108,8 +95,7 @@ class ModelStructTest : public ::testing::Test
   using ModelStructType = ModelStruct<FloatType, ScalarType, Order>;
   using ModelStructDataType = ModelStructData<FloatType, ScalarType>;
 
-  void SetUp() override
-  {
+  void SetUp() override {
     // Standard structured mesh: 10x10x10 elements
     // With Order=1: 11x11x11 nodes
     // With Order=2: 21x21x21 nodes
@@ -134,10 +120,8 @@ class ModelStructTest : public ::testing::Test
 };
 
 // Register type wrappers for typed tests
-using TypeWrappers =
-    ::testing::Types<FloatOrder1, FloatOrder2, FloatOrder3, FloatOrder4,
-                     FloatOrder5, DoubleOrder1, DoubleOrder2, DoubleOrder3,
-                     DoubleOrder4, DoubleOrder5>;
+using TypeWrappers = ::testing::Types<FloatOrder1, FloatOrder2, FloatOrder3, FloatOrder4, FloatOrder5, DoubleOrder1,
+                                      DoubleOrder2, DoubleOrder3, DoubleOrder4, DoubleOrder5>;
 
 TYPED_TEST_SUITE(ModelStructTest, TypeWrappers);
 
@@ -145,30 +129,26 @@ TYPED_TEST_SUITE(ModelStructTest, TypeWrappers);
 // Constructor and Initialization Tests
 // ============================================================================
 
-TYPED_TEST(ModelStructTest, DefaultConstructor)
-{
+TYPED_TEST(ModelStructTest, DefaultConstructor) {
   using ModelStructType = typename TestFixture::ModelStructType;
   ModelStructType model;
   // Default constructor should compile and not crash
   SUCCEED();
 }
 
-TYPED_TEST(ModelStructTest, ConstructorFromData)
-{
+TYPED_TEST(ModelStructTest, ConstructorFromData) {
   auto& model = *this->model_;
   EXPECT_EQ(model.getNumberOfElements(), 1000);  // 10*10*10
 }
 
-TYPED_TEST(ModelStructTest, CopyConstructor)
-{
+TYPED_TEST(ModelStructTest, CopyConstructor) {
   auto& original = *this->model_;
   auto copy = original;
   EXPECT_EQ(copy.getNumberOfElements(), original.getNumberOfElements());
   EXPECT_EQ(copy.getNumberOfNodes(), original.getNumberOfNodes());
 }
 
-TYPED_TEST(ModelStructTest, AssignmentOperator)
-{
+TYPED_TEST(ModelStructTest, AssignmentOperator) {
   auto original = *this->model_;
   auto assigned = original;
   EXPECT_EQ(assigned.getNumberOfElements(), original.getNumberOfElements());
@@ -178,13 +158,11 @@ TYPED_TEST(ModelStructTest, AssignmentOperator)
 // Mesh Topology Tests
 // ============================================================================
 
-TYPED_TEST(ModelStructTest, ElementIndexConversion)
-{
+TYPED_TEST(ModelStructTest, ElementIndexConversion) {
   auto& model = *this->model_;
 
   // Test conversion from linear to 3D indices and back
-  for (int linear = 0; linear < 1000; ++linear)
-  {
+  for (int linear = 0; linear < 1000; ++linear) {
     auto idx = model.elementIndex(linear);
     EXPECT_GE(idx[0], 0);
     EXPECT_LT(idx[0], 10);
@@ -195,8 +173,7 @@ TYPED_TEST(ModelStructTest, ElementIndexConversion)
   }
 }
 
-TYPED_TEST(ModelStructTest, ElementIndexBoundaries)
-{
+TYPED_TEST(ModelStructTest, ElementIndexBoundaries) {
   auto& model = *this->model_;
 
   // First element
@@ -212,17 +189,13 @@ TYPED_TEST(ModelStructTest, ElementIndexBoundaries)
   EXPECT_EQ(last[2], 9);
 }
 
-TYPED_TEST(ModelStructTest, GlobalVertexIndex)
-{
+TYPED_TEST(ModelStructTest, GlobalVertexIndex) {
   auto& model = *this->model_;
 
   auto elem_idx = std::array<int, 3>{5, 5, 5};
-  for (int i = 0; i <= 1; ++i)
-  {
-    for (int j = 0; j <= 1; ++j)
-    {
-      for (int k = 0; k <= 1; ++k)
-      {
+  for (int i = 0; i <= 1; ++i) {
+    for (int j = 0; j <= 1; ++j) {
+      for (int k = 0; k <= 1; ++k) {
         auto vertex = model.globalVertexIndex(elem_idx, i, j, k);
         EXPECT_GE(vertex[0], 5);
         EXPECT_LE(vertex[0], 6);
@@ -239,8 +212,7 @@ TYPED_TEST(ModelStructTest, GlobalVertexIndex)
 // Coordinate System Tests
 // ============================================================================
 
-TYPED_TEST(ModelStructTest, VertexCoordinates)
-{
+TYPED_TEST(ModelStructTest, VertexCoordinates) {
   auto& model = *this->model_;
   typename TestFixture::FloatType coords[3];
 
@@ -305,8 +277,7 @@ TYPED_TEST(ModelStructTest, VertexCoordinates)
   EXPECT_EQ(coords[2], 10.0);
 }
 
-TYPED_TEST(ModelStructTest, NodeCoordAtOrigin)
-{
+TYPED_TEST(ModelStructTest, NodeCoordAtOrigin) {
   auto& model = *this->model_;
 
   auto x = model.nodeCoord(0, 0);
@@ -318,8 +289,7 @@ TYPED_TEST(ModelStructTest, NodeCoordAtOrigin)
   EXPECT_NEAR(z, 0.0, 1e-6);
 }
 
-TYPED_TEST(ModelStructTest, NodeCoordBoundaryX)
-{
+TYPED_TEST(ModelStructTest, NodeCoordBoundaryX) {
   auto& model = *this->model_;
   constexpr int Order = TestFixture::Order;
 
@@ -333,8 +303,7 @@ TYPED_TEST(ModelStructTest, NodeCoordBoundaryX)
   EXPECT_NEAR(x, 100.0, 1e-6);
 }
 
-TYPED_TEST(ModelStructTest, NodeCoordMonotonicallyIncreasing)
-{
+TYPED_TEST(ModelStructTest, NodeCoordMonotonicallyIncreasing) {
   auto& model = *this->model_;
   constexpr int Order = TestFixture::Order;
 
@@ -342,8 +311,7 @@ TYPED_TEST(ModelStructTest, NodeCoordMonotonicallyIncreasing)
 
   // Sample nodes along x-direction
   auto prev_x = model.nodeCoord(0, 0);
-  for (auto i = 1; i < nx; ++i)
-  {
+  for (auto i = 1; i < nx; ++i) {
     auto curr_x = model.nodeCoord(i, 0);
     EXPECT_GT(curr_x, prev_x);
     prev_x = curr_x;
@@ -354,8 +322,7 @@ TYPED_TEST(ModelStructTest, NodeCoordMonotonicallyIncreasing)
 // Global Node Index Tests
 // ============================================================================
 
-TYPED_TEST(ModelStructTest, GlobalNodeIndexFirstElement)
-{
+TYPED_TEST(ModelStructTest, GlobalNodeIndexFirstElement) {
   auto& model = *this->model_;
 
   // First element at origin
@@ -363,18 +330,14 @@ TYPED_TEST(ModelStructTest, GlobalNodeIndexFirstElement)
   EXPECT_EQ(node_idx, 0);
 }
 
-TYPED_TEST(ModelStructTest, GlobalNodeIndexConsistency)
-{
+TYPED_TEST(ModelStructTest, GlobalNodeIndexConsistency) {
   auto& model = *this->model_;
   constexpr int Order = TestFixture::Order;
 
   // All nodes in first element should be within valid range
-  for (int i = 0; i <= Order; ++i)
-  {
-    for (int j = 0; j <= Order; ++j)
-    {
-      for (int k = 0; k <= Order; ++k)
-      {
+  for (int i = 0; i <= Order; ++i) {
+    for (int j = 0; j <= Order; ++j) {
+      for (int k = 0; k <= Order; ++k) {
         auto node_idx = model.globalNodeIndex(0, i, j, k);
         EXPECT_GE(node_idx, 0);
         EXPECT_LT(node_idx, model.getNumberOfNodes());
@@ -387,14 +350,12 @@ TYPED_TEST(ModelStructTest, GlobalNodeIndexConsistency)
 // Element and Node Count Tests
 // ============================================================================
 
-TYPED_TEST(ModelStructTest, NumberOfElements)
-{
+TYPED_TEST(ModelStructTest, NumberOfElements) {
   auto& model = *this->model_;
   EXPECT_EQ(model.getNumberOfElements(), 1000);
 }
 
-TYPED_TEST(ModelStructTest, NumberOfNodes)
-{
+TYPED_TEST(ModelStructTest, NumberOfNodes) {
   auto& model = *this->model_;
   constexpr int Order = TestFixture::Order;
 
@@ -402,8 +363,7 @@ TYPED_TEST(ModelStructTest, NumberOfNodes)
   EXPECT_EQ(model.getNumberOfNodes(), expected_nodes);
 }
 
-TYPED_TEST(ModelStructTest, NumberOfPointsPerElement)
-{
+TYPED_TEST(ModelStructTest, NumberOfPointsPerElement) {
   auto& model = *this->model_;
   constexpr int Order = TestFixture::Order;
 
@@ -411,8 +371,7 @@ TYPED_TEST(ModelStructTest, NumberOfPointsPerElement)
   EXPECT_EQ(model.getNumberOfPointsPerElement(), expected_points);
 }
 
-TYPED_TEST(ModelStructTest, GetOrder)
-{
+TYPED_TEST(ModelStructTest, GetOrder) {
   auto& model = *this->model_;
   constexpr int Order = TestFixture::Order;
 
@@ -423,25 +382,21 @@ TYPED_TEST(ModelStructTest, GetOrder)
 // Material Property Tests
 // ============================================================================
 
-TYPED_TEST(ModelStructTest, VelocityPropertiesOnNodes)
-{
+TYPED_TEST(ModelStructTest, VelocityPropertiesOnNodes) {
   auto& model = *this->model_;
 
   // Test Vp on first few nodes
-  for (int i = 0; i < 10; ++i)
-  {
+  for (int i = 0; i < 10; ++i) {
     auto vp = model.getModelVpOnNodes(i);
     EXPECT_EQ(vp, 1500.0);
   }
 }
 
-TYPED_TEST(ModelStructTest, VelocityPropertiesOnElements)
-{
+TYPED_TEST(ModelStructTest, VelocityPropertiesOnElements) {
   auto& model = *this->model_;
 
   // Test on first few elements
-  for (int i = 0; i < 10; ++i)
-  {
+  for (int i = 0; i < 10; ++i) {
     auto vp = model.getModelVpOnElement(i);
     auto vs = model.getModelVsOnElement(i);
     auto rho = model.getModelRhoOnElement(i);
@@ -452,8 +407,7 @@ TYPED_TEST(ModelStructTest, VelocityPropertiesOnElements)
   }
 }
 
-TYPED_TEST(ModelStructTest, AnisotropicAnglesOnElements)
-{
+TYPED_TEST(ModelStructTest, AnisotropicAnglesOnElements) {
   auto& model = *this->model_;
 
   // Test on first element
@@ -464,8 +418,7 @@ TYPED_TEST(ModelStructTest, AnisotropicAnglesOnElements)
   EXPECT_EQ(phi, 0.0);
 }
 
-TYPED_TEST(ModelStructTest, DensityPropertiesConsistent)
-{
+TYPED_TEST(ModelStructTest, DensityPropertiesConsistent) {
   auto& model = *this->model_;
 
   auto rho_node = model.getModelRhoOnNodes(0);
@@ -479,8 +432,7 @@ TYPED_TEST(ModelStructTest, DensityPropertiesConsistent)
 // Domain Properties Tests
 // ============================================================================
 
-TYPED_TEST(ModelStructTest, DomainSize)
-{
+TYPED_TEST(ModelStructTest, DomainSize) {
   auto& model = *this->model_;
 
   auto lx = model.domainSize(0);
@@ -492,8 +444,7 @@ TYPED_TEST(ModelStructTest, DomainSize)
   EXPECT_EQ(lz, 100.0);
 }
 
-TYPED_TEST(ModelStructTest, DomainSizeInvalidDimension)
-{
+TYPED_TEST(ModelStructTest, DomainSizeInvalidDimension) {
   auto& model = *this->model_;
 
   // Invalid dimension should return -1
@@ -501,34 +452,28 @@ TYPED_TEST(ModelStructTest, DomainSizeInvalidDimension)
   EXPECT_EQ(model.domainSize(-1), -1);
 }
 
-TYPED_TEST(ModelStructTest, MinSpacingPositive)
-{
+TYPED_TEST(ModelStructTest, MinSpacingPositive) {
   auto& model = *this->model_;
 
   auto min_spacing = model.getMinSpacing();
   EXPECT_GT(min_spacing, 0.0);
 }
 
-TYPED_TEST(ModelStructTest, MinSpacingDependsOnOrder)
-{
+TYPED_TEST(ModelStructTest, MinSpacingDependsOnOrder) {
   auto& model = *this->model_;
   constexpr int Order = TestFixture::Order;
 
   auto min_spacing = model.getMinSpacing();
 
-  if constexpr (Order == 1)
-  {
+  if constexpr (Order == 1) {
     EXPECT_EQ(min_spacing, 10.0);  // min(10, 10, 10)
-  }
-  else if constexpr (Order == 2)
-  {
+  } else if constexpr (Order == 2) {
     EXPECT_EQ(min_spacing, 5.0);  // min(10, 10, 10) / 2
   }
   // Higher orders have specific coefficients
 }
 
-TYPED_TEST(ModelStructTest, MaxSpeedPositive)
-{
+TYPED_TEST(ModelStructTest, MaxSpeedPositive) {
   auto& model = *this->model_;
 
   auto max_speed = model.getMaxSpeed();
@@ -539,20 +484,17 @@ TYPED_TEST(ModelStructTest, MaxSpeedPositive)
 // Model Configuration Tests
 // ============================================================================
 
-TYPED_TEST(ModelStructTest, IsModelOnNodes)
-{
+TYPED_TEST(ModelStructTest, IsModelOnNodes) {
   auto& model = *this->model_;
   EXPECT_TRUE(model.isModelOnNodes());
 }
 
-TYPED_TEST(ModelStructTest, IsElastic)
-{
+TYPED_TEST(ModelStructTest, IsElastic) {
   auto& model = *this->model_;
   EXPECT_FALSE(model.isElastic());
 }
 
-TYPED_TEST(ModelStructTest, IsElasticInitialization)
-{
+TYPED_TEST(ModelStructTest, IsElasticInitialization) {
   using ModelStructDataType = typename TestFixture::ModelStructDataType;
   using ModelStructType = typename TestFixture::ModelStructType;
 
@@ -574,8 +516,7 @@ TYPED_TEST(ModelStructTest, IsElasticInitialization)
 // Boundary Tests
 // ============================================================================
 
-TYPED_TEST(ModelStructTest, FaceNormal)
-{
+TYPED_TEST(ModelStructTest, FaceNormal) {
   auto& model = *this->model_;
   typename TestFixture::FloatType normal[3] = {0.0, 0.0, 0.0};
 
@@ -620,8 +561,7 @@ TYPED_TEST(ModelStructTest, FaceNormal)
 // Elasticity Tensor Tests - UPDATED
 // ============================================================================
 
-TYPED_TEST(ModelStructTest, InitElasticityTensorsNonElastic)
-{
+TYPED_TEST(ModelStructTest, InitElasticityTensorsNonElastic) {
   auto& model = *this->model_;
 
   // Should return early if not elastic
@@ -629,8 +569,7 @@ TYPED_TEST(ModelStructTest, InitElasticityTensorsNonElastic)
   SUCCEED();
 }
 
-TYPED_TEST(ModelStructTest, InitElasticityTensorsElastic)
-{
+TYPED_TEST(ModelStructTest, InitElasticityTensorsElastic) {
   using ModelStructDataType = typename TestFixture::ModelStructDataType;
   using ModelStructType = typename TestFixture::ModelStructType;
   using FloatType = typename TestFixture::FloatType;
@@ -646,26 +585,22 @@ TYPED_TEST(ModelStructTest, InitElasticityTensorsElastic)
   elastic_data.isModelOnNodes_ = false;  // CHANGED: Use elements for TTI
 
   ModelStructType elastic_model(elastic_data);
-  elastic_model.initElasticityTensors(
-      model::kTTI);  // CHANGED: Use TTI instead of kIso
+  elastic_model.initElasticityTensors(model::kTTI);  // CHANGED: Use TTI instead of kIso
 
   // Verify tensors were created
   FloatType C[6][6];
   elastic_model.getCTensorOnElement(0, C);
 
   // Verify symmetry of C tensor (Voigt notation)
-  for (int i = 0; i < 6; ++i)
-  {
-    for (int j = 0; j < 6; ++j)
-    {
+  for (int i = 0; i < 6; ++i) {
+    for (int j = 0; j < 6; ++j) {
       EXPECT_NEAR(C[i][j], C[j][i],
                   1e-6);  // CHANGED: Relaxed tolerance for float
     }
   }
 }
 
-TYPED_TEST(ModelStructTest, GetCTensorOnElement)
-{
+TYPED_TEST(ModelStructTest, GetCTensorOnElement) {
   using ModelStructDataType = typename TestFixture::ModelStructDataType;
   using ModelStructType = typename TestFixture::ModelStructType;
   using FloatType = typename TestFixture::FloatType;
@@ -681,20 +616,16 @@ TYPED_TEST(ModelStructTest, GetCTensorOnElement)
   elastic_data.isModelOnNodes_ = false;  // CHANGED: Use elements for TTI
 
   ModelStructType elastic_model(elastic_data);
-  elastic_model.initElasticityTensors(
-      model::kTTI);  // CHANGED: Use TTI instead of kIso
+  elastic_model.initElasticityTensors(model::kTTI);  // CHANGED: Use TTI instead of kIso
 
   FloatType C[6][6];
   elastic_model.getCTensorOnElement(0, C);
 
   // Verify tensor values are reasonable (non-zero)
   bool has_nonzero = false;
-  for (int i = 0; i < 6; ++i)
-  {
-    for (int j = 0; j < 6; ++j)
-    {
-      if (C[i][j] != 0.0)
-      {
+  for (int i = 0; i < 6; ++i) {
+    for (int j = 0; j < 6; ++j) {
+      if (C[i][j] != 0.0) {
         has_nonzero = true;
       }
     }
@@ -706,8 +637,7 @@ TYPED_TEST(ModelStructTest, GetCTensorOnElement)
 // Large Mesh Tests
 // ============================================================================
 
-TYPED_TEST(ModelStructTest, LargeMeshHandling)
-{
+TYPED_TEST(ModelStructTest, LargeMeshHandling) {
   using ModelStructDataType = typename TestFixture::ModelStructDataType;
   using ModelStructType = typename TestFixture::ModelStructType;
 
@@ -727,8 +657,7 @@ TYPED_TEST(ModelStructTest, LargeMeshHandling)
   EXPECT_GT(large_model.getNumberOfNodes(), 125000);
 }
 
-TYPED_TEST(ModelStructTest, UniformMeshProperties)
-{
+TYPED_TEST(ModelStructTest, UniformMeshProperties) {
   auto& model = *this->model_;
 
   // In a uniform mesh, element spacing should be consistent
@@ -741,8 +670,7 @@ TYPED_TEST(ModelStructTest, UniformMeshProperties)
 // Documentation Tests
 // ============================================================================
 
-TYPED_TEST(ModelStructTest, StructuredVsUnstructuredComparison)
-{
+TYPED_TEST(ModelStructTest, StructuredVsUnstructuredComparison) {
   // ModelStruct: Structured Cartesian mesh
   // - Regular grid topology
   // - Face connectivity computed on-the-fly via formulas

--- a/tests/units/model/impl/mesh/test_topology_factory.cc
+++ b/tests/units/model/impl/mesh/test_topology_factory.cc
@@ -7,29 +7,22 @@
 #include "model.h"
 #include "topology_factory.h"
 
-namespace
-{
+namespace {
 
 // Minimal Mock Mesh implementing only what TopologyFactory needs
 template <typename FloatType, typename ScalarType>
-class MockMesh : public model::ModelApi<FloatType, ScalarType>
-{
+class MockMesh : public model::ModelApi<FloatType, ScalarType> {
  public:
-  struct Node
-  {
+  struct Node {
     FloatType x, y, z;
   };
 
   std::vector<Node> nodes;
   FloatType minSpacing = 1.0;
 
-  void addNode(FloatType x, FloatType y, FloatType z)
-  {
-    nodes.push_back({x, y, z});
-  }
+  void addNode(FloatType x, FloatType y, FloatType z) { nodes.push_back({x, y, z}); }
 
-  PROXY_HOST_DEVICE FloatType nodeCoord(ScalarType i, int dim) const override
-  {
+  PROXY_HOST_DEVICE FloatType nodeCoord(ScalarType i, int dim) const override {
 #if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
     if (i < 0 || i >= static_cast<ScalarType>(nodes.size())) return 0.0;
     if (dim == 0) return nodes[i].x;
@@ -39,8 +32,7 @@ class MockMesh : public model::ModelApi<FloatType, ScalarType>
     return 0.0;
   }
 
-  PROXY_HOST_DEVICE ScalarType getNumberOfNodes() const override
-  {
+  PROXY_HOST_DEVICE ScalarType getNumberOfNodes() const override {
 #if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
     return static_cast<ScalarType>(nodes.size());
 #else
@@ -48,147 +40,49 @@ class MockMesh : public model::ModelApi<FloatType, ScalarType>
 #endif
   }
 
-  PROXY_HOST_DEVICE FloatType getMinSpacing() const override
-  {
-    return minSpacing;
-  }
+  PROXY_HOST_DEVICE FloatType getMinSpacing() const override { return minSpacing; }
 
   // Stubs for other pure virtual methods (not used by TopologyFactory)
-  PROXY_HOST_DEVICE ScalarType globalNodeIndex(ScalarType, int, int,
-                                               int) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE FloatType getModelVpOnNodes(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE FloatType getModelVpOnElement(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE FloatType getModelRhoOnNodes(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE FloatType getModelRhoOnElement(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE FloatType getModelVsOnNodes(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE FloatType getModelVsOnElement(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE FloatType getModelQpOnNodes(ScalarType) const override
-  {
-    return 1e9;
-  }
-  PROXY_HOST_DEVICE FloatType getModelQpOnElement(ScalarType) const override
-  {
-    return 1e9;
-  }
-  PROXY_HOST_DEVICE FloatType getModelQsOnNodes(ScalarType) const override
-  {
-    return 1e9;
-  }
-  PROXY_HOST_DEVICE FloatType getModelQsOnElement(ScalarType) const override
-  {
-    return 1e9;
-  }
-  PROXY_HOST_DEVICE FloatType getModelDeltaOnNodes(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE FloatType getModelDeltaOnElement(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE FloatType getModelEpsilonOnNodes(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE FloatType
-  getModelEpsilonOnElement(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE FloatType getModelGammaOnNodes(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE FloatType getModelGammaOnElement(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE ScalarType getModelThetaOnNodes(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE ScalarType getModelThetaOnElement(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE ScalarType getModelPhiOnNodes(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE ScalarType getModelPhiOnElement(ScalarType) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE void getCTensorOnElement(ScalarType,
-                                             FloatType[6][6]) const override
-  {
-  }
-  virtual void initElasticityTensors(
-      model::AnisotropyType anisotropy_type) override
-  {
-  }
-  PROXY_HOST_DEVICE ScalarType getNumberOfElements() const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE int getNumberOfPointsPerElement() const override
-  {
-    return 27;
-  }
+  PROXY_HOST_DEVICE ScalarType globalNodeIndex(ScalarType, int, int, int) const override { return 0; }
+  PROXY_HOST_DEVICE FloatType getModelVpOnNodes(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE FloatType getModelVpOnElement(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE FloatType getModelRhoOnNodes(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE FloatType getModelRhoOnElement(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE FloatType getModelVsOnNodes(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE FloatType getModelVsOnElement(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE FloatType getModelQpOnNodes(ScalarType) const override { return 1e9; }
+  PROXY_HOST_DEVICE FloatType getModelQpOnElement(ScalarType) const override { return 1e9; }
+  PROXY_HOST_DEVICE FloatType getModelQsOnNodes(ScalarType) const override { return 1e9; }
+  PROXY_HOST_DEVICE FloatType getModelQsOnElement(ScalarType) const override { return 1e9; }
+  PROXY_HOST_DEVICE FloatType getModelDeltaOnNodes(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE FloatType getModelDeltaOnElement(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE FloatType getModelEpsilonOnNodes(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE FloatType getModelEpsilonOnElement(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE FloatType getModelGammaOnNodes(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE FloatType getModelGammaOnElement(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE ScalarType getModelThetaOnNodes(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE ScalarType getModelThetaOnElement(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE ScalarType getModelPhiOnNodes(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE ScalarType getModelPhiOnElement(ScalarType) const override { return 0; }
+  PROXY_HOST_DEVICE void getCTensorOnElement(ScalarType, FloatType[6][6]) const override {}
+  virtual void initElasticityTensors(model::AnisotropyType anisotropy_type) override {}
+  PROXY_HOST_DEVICE ScalarType getNumberOfElements() const override { return 0; }
+  PROXY_HOST_DEVICE int getNumberOfPointsPerElement() const override { return 27; }
   PROXY_HOST_DEVICE int getOrder() const override { return 1; }
 
-  PROXY_HOST_DEVICE model::BoundaryFlag boundaryType(ScalarType) const override
-  {
+  PROXY_HOST_DEVICE model::BoundaryFlag boundaryType(ScalarType) const override {
     return model::BoundaryFlag::InteriorNode;
   }
 
-  PROXY_HOST_DEVICE void faceNormal(ScalarType, model::CubicFace,
-                                    FloatType[3]) const override
-  {
-  }
+  PROXY_HOST_DEVICE void faceNormal(ScalarType, model::CubicFace, FloatType[3]) const override {}
 
   virtual void buildFaceConnectivity() override {}
 
-  PROXY_HOST_DEVICE bool isFreeSurface(ScalarType n) const override
-  {
-    return true;
-  }
+  PROXY_HOST_DEVICE bool isFreeSurface(ScalarType n) const override { return true; }
 
-  PROXY_HOST_DEVICE ScalarType getGlobalNodeFromFace(ScalarType,
-                                                     int) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE ScalarType getGlobalFace(ScalarType,
-                                             model::CubicFace) const override
-  {
-    return 0;
-  }
-  PROXY_HOST_DEVICE bool isBoundaryFace(ScalarType) const override
-  {
-    return true;
-  }
+  PROXY_HOST_DEVICE ScalarType getGlobalNodeFromFace(ScalarType, int) const override { return 0; }
+  PROXY_HOST_DEVICE ScalarType getGlobalFace(ScalarType, model::CubicFace) const override { return 0; }
+  PROXY_HOST_DEVICE bool isBoundaryFace(ScalarType) const override { return true; }
   PROXY_HOST_DEVICE ScalarType getNumberOfFaces() const override { return 0; }
 
   PROXY_HOST_DEVICE FloatType domainSize(int) const override { return 0; }
@@ -198,14 +92,12 @@ class MockMesh : public model::ModelApi<FloatType, ScalarType>
   void setQualityFactors(FloatType qp, FloatType qs) override {}
 };
 
-class TopologyFactoryTest : public ::testing::Test
-{
+class TopologyFactoryTest : public ::testing::Test {
  protected:
   MockMesh<float, int> mesh;
 };
 
-TEST_F(TopologyFactoryTest, SingleRankReturnsEmptySharedNodes)
-{
+TEST_F(TopologyFactoryTest, SingleRankReturnsEmptySharedNodes) {
   mesh.addNode(0.0, 0.0, 0.0);
   mesh.addNode(1.0, 0.0, 0.0);
 
@@ -215,8 +107,7 @@ TEST_F(TopologyFactoryTest, SingleRankReturnsEmptySharedNodes)
   EXPECT_EQ(topo.sharedNodes.size(), 0);
 }
 
-TEST_F(TopologyFactoryTest, LeftBoundaryDetection)
-{
+TEST_F(TopologyFactoryTest, LeftBoundaryDetection) {
   mesh.addNode(10.0f, 0.0f, 0.0f);  // Left
   mesh.addNode(15.0f, 0.0f, 0.0f);
   mesh.addNode(20.0f, 0.0f, 0.0f);  // Right
@@ -233,8 +124,7 @@ TEST_F(TopologyFactoryTest, LeftBoundaryDetection)
   EXPECT_EQ(topo.sharedNodes[2][0], 2);
 }
 
-TEST_F(TopologyFactoryTest, AutoToleranceFromSpacing)
-{
+TEST_F(TopologyFactoryTest, AutoToleranceFromSpacing) {
   mesh.minSpacing = 0.1f;
   mesh.addNode(10.000001f, 0.0f, 0.0f);  // Slightly off but within tolerance
 
@@ -248,27 +138,21 @@ TEST_F(TopologyFactoryTest, AutoToleranceFromSpacing)
   EXPECT_FALSE(topo.sharedNodes[0].empty());
 }
 
-TEST_F(TopologyFactoryTest, ThrowsOnMissingBoundaryNodes)
-{
+TEST_F(TopologyFactoryTest, ThrowsOnMissingBoundaryNodes) {
   mesh.addNode(15.0f, 0.0f, 0.0f);
   mesh.addNode(20.0f, 0.0f, 0.0f);
 
   // Expect logic_error (topology inconsistency)
-  EXPECT_THROW(
-      { TopologyFactory::createFromMesh(mesh, 1, 3, 10.0f, 10.0f); },
-      std::logic_error);
+  EXPECT_THROW({ TopologyFactory::createFromMesh(mesh, 1, 3, 10.0f, 10.0f); }, std::logic_error);
 }
 
-TEST_F(TopologyFactoryTest, ThrowsOnAmbiguousBoundary)
-{
+TEST_F(TopologyFactoryTest, ThrowsOnAmbiguousBoundary) {
   mesh.addNode(10.0f, 0.0f, 0.0f);
 
   // Width 1e-7 is < tolerance 1e-6, so node is detected on BOTH boundaries
   float width = 1e-7f;
 
-  EXPECT_THROW(
-      { TopologyFactory::createFromMesh(mesh, 1, 3, 10.0f, width); },
-      std::logic_error);
+  EXPECT_THROW({ TopologyFactory::createFromMesh(mesh, 1, 3, 10.0f, width); }, std::logic_error);
 }
 
 }  // namespace

--- a/tests/units/model/impl/mesh/unstruct/test_unstruct_mesh.cc
+++ b/tests/units/model/impl/mesh/unstruct/test_unstruct_mesh.cc
@@ -2,26 +2,22 @@
 
 #include "model_unstruct.h"
 
-namespace model
-{
-namespace
-{
+namespace model {
+namespace {
 
 // ============================================================================
 // Test Fixture
 // ============================================================================
 
 template <typename T>
-class ModelUnstructTest : public ::testing::Test
-{
+class ModelUnstructTest : public ::testing::Test {
  protected:
   using FloatType = typename T::FloatType;
   using ScalarType = typename T::ScalarType;
   using ModelType = ModelUnstruct<FloatType, ScalarType>;
 
   // Helper to create minimal test mesh
-  ModelType createTestMesh()
-  {
+  ModelType createTestMesh() {
     ModelUnstructData<FloatType, ScalarType> data;
     data.order_ = 1;
     data.n_element_ = 1;
@@ -38,8 +34,7 @@ class ModelUnstructTest : public ::testing::Test
     data.model_rho_element_ = allocateVector<VECTOR_REAL_VIEW>(1);
     data.boundaries_t_ = allocateVector<VECTOR_INT_VIEW>(8);
 
-    for (int i = 0; i < 8; ++i)
-    {
+    for (int i = 0; i < 8; ++i) {
       data.global_node_index_(0, i) = i;
       data.nodes_coords_x_[i] = (i & 1) ? 1.0 : 0.0;
       data.nodes_coords_y_[i] = (i & 2) ? 1.0 : 0.0;
@@ -52,13 +47,11 @@ class ModelUnstructTest : public ::testing::Test
   }
 };
 
-struct FloatInt
-{
+struct FloatInt {
   using FloatType = float;
   using ScalarType = int;
 };
-struct DoubleInt
-{
+struct DoubleInt {
   using FloatType = double;
   using ScalarType = int;
 };
@@ -70,14 +63,12 @@ TYPED_TEST_SUITE(ModelUnstructTest, TestTypes);
 // Construction Tests
 // ============================================================================
 
-TYPED_TEST(ModelUnstructTest, DefaultConstructor)
-{
+TYPED_TEST(ModelUnstructTest, DefaultConstructor) {
   typename TestFixture::ModelType model;
   SUCCEED();
 }
 
-TYPED_TEST(ModelUnstructTest, ConstructFromData)
-{
+TYPED_TEST(ModelUnstructTest, ConstructFromData) {
   auto model = this->createTestMesh();
   EXPECT_EQ(model.getNumberOfElements(), 1);
   EXPECT_EQ(model.getNumberOfNodes(), 8);
@@ -88,26 +79,22 @@ TYPED_TEST(ModelUnstructTest, ConstructFromData)
 // Indexing Tests
 // ============================================================================
 
-TYPED_TEST(ModelUnstructTest, GlobalNodeIndexInRange)
-{
+TYPED_TEST(ModelUnstructTest, GlobalNodeIndexInRange) {
   auto model = this->createTestMesh();
 
   for (int k = 0; k <= 1; ++k)
     for (int j = 0; j <= 1; ++j)
-      for (int i = 0; i <= 1; ++i)
-      {
+      for (int i = 0; i <= 1; ++i) {
         auto node = model.globalNodeIndex(0, i, j, k);
         EXPECT_GE(node, 0);
         EXPECT_LT(node, 8);
       }
 }
 
-TYPED_TEST(ModelUnstructTest, VertexCoordsInUnitCube)
-{
+TYPED_TEST(ModelUnstructTest, VertexCoordsInUnitCube) {
   auto model = this->createTestMesh();
 
-  for (int i = 0; i < 8; ++i)
-  {
+  for (int i = 0; i < 8; ++i) {
     typename TestFixture::FloatType coords[3];
     model.vertexCoords(i, coords);
 
@@ -124,22 +111,19 @@ TYPED_TEST(ModelUnstructTest, VertexCoordsInUnitCube)
 // Material Property Tests
 // ============================================================================
 
-TYPED_TEST(ModelUnstructTest, VelocityAndDensityPositive)
-{
+TYPED_TEST(ModelUnstructTest, VelocityAndDensityPositive) {
   auto model = this->createTestMesh();
 
   EXPECT_GT(model.getModelVpOnElement(0), 0.0);
   EXPECT_GT(model.getModelRhoOnElement(0), 0.0);
 }
 
-TYPED_TEST(ModelUnstructTest, IsModelOnNodesConfig)
-{
+TYPED_TEST(ModelUnstructTest, IsModelOnNodesConfig) {
   auto model = this->createTestMesh();
   EXPECT_FALSE(model.isModelOnNodes());
 }
 
-TYPED_TEST(ModelUnstructTest, IsElasticConfig)
-{
+TYPED_TEST(ModelUnstructTest, IsElasticConfig) {
   auto model = this->createTestMesh();
   EXPECT_FALSE(model.isElastic());
 }
@@ -148,8 +132,7 @@ TYPED_TEST(ModelUnstructTest, IsElasticConfig)
 // Geometry Tests
 // ============================================================================
 
-TYPED_TEST(ModelUnstructTest, DomainSizeCorrect)
-{
+TYPED_TEST(ModelUnstructTest, DomainSizeCorrect) {
   auto model = this->createTestMesh();
 
   EXPECT_FLOAT_EQ(model.domainSize(0), 1.0);
@@ -157,14 +140,12 @@ TYPED_TEST(ModelUnstructTest, DomainSizeCorrect)
   EXPECT_FLOAT_EQ(model.domainSize(2), 1.0);
 }
 
-TYPED_TEST(ModelUnstructTest, MinSpacingPositive)
-{
+TYPED_TEST(ModelUnstructTest, MinSpacingPositive) {
   auto model = this->createTestMesh();
   EXPECT_GT(model.getMinSpacing(), 0.0);
 }
 
-TYPED_TEST(ModelUnstructTest, MaxSpeedPositive)
-{
+TYPED_TEST(ModelUnstructTest, MaxSpeedPositive) {
   auto model = this->createTestMesh();
   EXPECT_GT(model.getMaxSpeed(), 0.0);
 }
@@ -173,21 +154,19 @@ TYPED_TEST(ModelUnstructTest, MaxSpeedPositive)
 // Face Normal Tests
 // ============================================================================
 
-TYPED_TEST(ModelUnstructTest, FaceNormalNormalized)
-{
+TYPED_TEST(ModelUnstructTest, FaceNormalNormalized) {
   auto model = this->createTestMesh();
 
   typename TestFixture::FloatType normal[3];
   model.faceNormal(0, CubicFace::kXMinus, normal);
 
-  typename TestFixture::FloatType norm = std::sqrt(
-      normal[0] * normal[0] + normal[1] * normal[1] + normal[2] * normal[2]);
+  typename TestFixture::FloatType norm =
+      std::sqrt(normal[0] * normal[0] + normal[1] * normal[1] + normal[2] * normal[2]);
 
   EXPECT_NEAR(norm, 1.0, 1e-5);
 }
 
-TYPED_TEST(ModelUnstructTest, OppositeFacesHaveOppositeNormals)
-{
+TYPED_TEST(ModelUnstructTest, OppositeFacesHaveOppositeNormals) {
   auto model = this->createTestMesh();
 
   typename TestFixture::FloatType n_xminus[3], n_xplus[3];
@@ -195,9 +174,7 @@ TYPED_TEST(ModelUnstructTest, OppositeFacesHaveOppositeNormals)
   model.faceNormal(0, CubicFace::kXPlus, n_xplus);
 
   // Should be opposite (dot product ≈ -1)
-  typename TestFixture::FloatType dot = n_xminus[0] * n_xplus[0] +
-                                        n_xminus[1] * n_xplus[1] +
-                                        n_xminus[2] * n_xplus[2];
+  typename TestFixture::FloatType dot = n_xminus[0] * n_xplus[0] + n_xminus[1] * n_xplus[1] + n_xminus[2] * n_xplus[2];
 
   EXPECT_NEAR(dot, -1.0, 1e-5);
 }

--- a/tests/units/solver/impl/test_attenuation.cc
+++ b/tests/units/solver/impl/test_attenuation.cc
@@ -29,14 +29,10 @@
 #include "wavefield_acoustic.h"
 #include "wavefield_elastic.h"
 
-namespace solver
-{
-namespace fe
-{
-namespace test
-{
-static VECTOR_REAL_VIEW toView(const std::vector<float>& v, const char* name)
-{
+namespace solver {
+namespace fe {
+namespace test {
+static VECTOR_REAL_VIEW toView(const std::vector<float>& v, const char* name) {
   if (v.empty()) return VECTOR_REAL_VIEW();
   auto view = allocateVector<VECTOR_REAL_VIEW>(v.size(), name);
   for (size_t i = 0; i < v.size(); ++i) view[i] = v[i];
@@ -46,34 +42,27 @@ static VECTOR_REAL_VIEW toView(const std::vector<float>& v, const char* name)
 // ======================================================================
 // Helper: build a small structured mesh and return the model pointer
 // ======================================================================
-static std::shared_ptr<model::ModelApi<float, int>> buildSmallMesh(
-    int order, bool isElastic)
-{
+static std::shared_ptr<model::ModelApi<float, int>> buildSmallMesh(int order, bool isElastic) {
   // 3x3x3 elements, 300m x 300m x 300m domain => element size = 100m
   constexpr int EX = 3, EY = 3, EZ = 3;
   constexpr float LX = 300.0f, LY = 300.0f, LZ = 300.0f;
   const bool isModelOnNodes = false;
 
-  switch (order)
-  {
+  switch (order) {
     case 1: {
-      model::CartesianStructBuilder<float, int, 1> builder(
-          EX, LX, EY, LY, EZ, LZ, isModelOnNodes, isElastic);
+      model::CartesianStructBuilder<float, int, 1> builder(EX, LX, EY, LY, EZ, LZ, isModelOnNodes, isElastic);
       return builder.getModel(false);
     }
     case 2: {
-      model::CartesianStructBuilder<float, int, 2> builder(
-          EX, LX, EY, LY, EZ, LZ, isModelOnNodes, isElastic);
+      model::CartesianStructBuilder<float, int, 2> builder(EX, LX, EY, LY, EZ, LZ, isModelOnNodes, isElastic);
       return builder.getModel(false);
     }
     case 3: {
-      model::CartesianStructBuilder<float, int, 3> builder(
-          EX, LX, EY, LY, EZ, LZ, isModelOnNodes, isElastic);
+      model::CartesianStructBuilder<float, int, 3> builder(EX, LX, EY, LY, EZ, LZ, isModelOnNodes, isElastic);
       return builder.getModel(false);
     }
     default: {
-      model::CartesianStructBuilder<float, int, 1> builder(
-          EX, LX, EY, LY, EZ, LZ, isModelOnNodes, isElastic);
+      model::CartesianStructBuilder<float, int, 1> builder(EX, LX, EY, LY, EZ, LZ, isModelOnNodes, isElastic);
       return builder.getModel(false);
     }
   }
@@ -82,11 +71,9 @@ static std::shared_ptr<model::ModelApi<float, int>> buildSmallMesh(
 // ======================================================================
 // Helper: compute L2-norm of a wavefield across all nodes
 // ======================================================================
-static float fieldL2Norm(const VECTOR_REAL_VIEW& field, int numNodes)
-{
+static float fieldL2Norm(const VECTOR_REAL_VIEW& field, int numNodes) {
   float sum = 0.0f;
-  for (int i = 0; i < numNodes; ++i)
-  {
+  for (int i = 0; i < numNodes; ++i) {
     sum += field(i) * field(i);
   }
   return std::sqrt(sum);
@@ -95,9 +82,7 @@ static float fieldL2Norm(const VECTOR_REAL_VIEW& field, int numNodes)
 // ======================================================================
 // Helper: set an impulsive source at the center node of a pressure field
 // ======================================================================
-static void setImpulseSource(VECTOR_REAL_VIEW& field, int numNodes,
-                             float amplitude)
-{
+static void setImpulseSource(VECTOR_REAL_VIEW& field, int numNodes, float amplitude) {
   int centerNode = numNodes / 2;
   field(centerNode) = amplitude;
 }
@@ -105,13 +90,10 @@ static void setImpulseSource(VECTOR_REAL_VIEW& field, int numNodes,
 // ======================================================================
 // TEST: setSLSAttenuation stores parameters correctly
 // ======================================================================
-TEST(AttenuationSetup, SetSLSAttenuationStoresParameters)
-{
+TEST(AttenuationSetup, SetSLSAttenuationStoresParameters) {
   auto solver = solver_factory::createSolver(
-      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu,
-      utils::enums::meshType::kStruct,
-      utils::enums::modelLocationType::kOnElements,
-      utils::enums::physicType::kAcoustic, 1);
+      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu, utils::enums::meshType::kStruct,
+      utils::enums::modelLocationType::kOnElements, utils::enums::physicType::kAcoustic, 1);
 
   // Set 2 SLS mechanisms with explicit coefficients
   std::vector<float> freqs = {2.0f * M_PI * 1.0f, 2.0f * M_PI * 10.0f};
@@ -125,13 +107,10 @@ TEST(AttenuationSetup, SetSLSAttenuationStoresParameters)
 // ======================================================================
 // TEST: setSLSAttenuation with empty frequencies disables attenuation
 // ======================================================================
-TEST(AttenuationSetup, EmptyFrequenciesDisablesAttenuation)
-{
+TEST(AttenuationSetup, EmptyFrequenciesDisablesAttenuation) {
   auto solver = solver_factory::createSolver(
-      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu,
-      utils::enums::meshType::kStruct,
-      utils::enums::modelLocationType::kOnElements,
-      utils::enums::physicType::kAcoustic, 1);
+      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu, utils::enums::meshType::kStruct,
+      utils::enums::modelLocationType::kOnElements, utils::enums::physicType::kAcoustic, 1);
 
   // First enable
   std::vector<float> freqs = {2.0f * M_PI * 5.0f};
@@ -149,32 +128,24 @@ TEST(AttenuationSetup, EmptyFrequenciesDisablesAttenuation)
 // ======================================================================
 // TEST: setSLSAttenuation rejects mismatched coefficient sizes
 // ======================================================================
-TEST(AttenuationSetup, MismatchedCoefficientsThrows)
-{
+TEST(AttenuationSetup, MismatchedCoefficientsThrows) {
   auto solver = solver_factory::createSolver(
-      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu,
-      utils::enums::meshType::kStruct,
-      utils::enums::modelLocationType::kOnElements,
-      utils::enums::physicType::kAcoustic, 1);
+      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu, utils::enums::meshType::kStruct,
+      utils::enums::modelLocationType::kOnElements, utils::enums::physicType::kAcoustic, 1);
 
   std::vector<float> freqs = {1.0f, 2.0f, 3.0f};
   std::vector<float> coeffs = {0.5f};  // Wrong size: 1 vs 3
 
-  EXPECT_THROW(
-      solver->setSLSAttenuation(toView(freqs, "f"), toView(coeffs, "c")),
-      std::runtime_error);
+  EXPECT_THROW(solver->setSLSAttenuation(toView(freqs, "f"), toView(coeffs, "c")), std::runtime_error);
 }
 
 // ======================================================================
 // TEST: computeFEInit with attenuation allocates arrays and runs
 // ======================================================================
-TEST(AttenuationInit, ComputeFEInitWithAttenuationRuns)
-{
+TEST(AttenuationInit, ComputeFEInitWithAttenuationRuns) {
   auto solver = solver_factory::createSolver(
-      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu,
-      utils::enums::meshType::kStruct,
-      utils::enums::modelLocationType::kOnElements,
-      utils::enums::physicType::kAcoustic, 1);
+      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu, utils::enums::meshType::kStruct,
+      utils::enums::modelLocationType::kOnElements, utils::enums::physicType::kAcoustic, 1);
 
   std::vector<float> freqs = {2.0f * M_PI * 5.0f};
   solver->setSLSAttenuation(toView(freqs, "f"));
@@ -188,30 +159,24 @@ TEST(AttenuationInit, ComputeFEInitWithAttenuationRuns)
 // ======================================================================
 // Helper: run a generic acoustic simulation and return L2 norm at the end
 // ======================================================================
-static float runAcousticSimulation(
-    std::shared_ptr<model::ModelApi<float, int>> mesh,
-    const std::vector<float>& slsFreqs, int numTimeSteps, float dt, int order)
-{
+static float runAcousticSimulation(std::shared_ptr<model::ModelApi<float, int>> mesh,
+                                   const std::vector<float>& slsFreqs, int numTimeSteps, float dt, int order) {
   int numNodes = mesh->getNumberOfNodes();
   int npp = (order + 1) * (order + 1) * (order + 1);
 
   auto solver = solver_factory::createSolver(
-      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu,
-      utils::enums::meshType::kStruct,
-      utils::enums::modelLocationType::kOnElements,
-      utils::enums::physicType::kAcoustic, order);
+      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu, utils::enums::meshType::kStruct,
+      utils::enums::modelLocationType::kOnElements, utils::enums::physicType::kAcoustic, order);
   solver->setAnisotropyType(model::AnisotropyType::kIso);
 
-  if (!slsFreqs.empty())
-  {
+  if (!slsFreqs.empty()) {
     solver->setSLSAttenuation(toView(slsFreqs, "f"));
   }
   solver->computeFEInit(*mesh, {0, 0, 0}, false, 0.0f);
 
   auto pPrev = allocateVector<VECTOR_REAL_VIEW>(numNodes, "pPrev");
   auto pCurr = allocateVector<VECTOR_REAL_VIEW>(numNodes, "pCurr");
-  for (int i = 0; i < numNodes; ++i)
-  {
+  for (int i = 0; i < numNodes; ++i) {
     pPrev(i) = 0.0f;
     pCurr(i) = 0.0f;
   }
@@ -221,8 +186,7 @@ static float runAcousticSimulation(
   auto rhsElem = allocateVector<VECTOR_INT_VIEW>(1, "rhsElem");
   auto rhsWeights = allocateArray2D<ARRAY_REAL_VIEW>(1, npp, "rhsWeights");
   rhsElem(0) = 0;
-  for (int j = 0; j < npp; ++j)
-  {
+  for (int j = 0; j < npp; ++j) {
     rhsTerm(0, j) = 0.0f;
     rhsWeights(0, j) = 0.0f;
   }
@@ -231,8 +195,7 @@ static float runAcousticSimulation(
   RhsAcoustic rhs(rhsTerm, rhsElem, rhsWeights);
   SEMsolverDataAcoustic data(wf, rhs);
 
-  for (int t = 0; t < numTimeSteps; ++t)
-  {
+  for (int t = 0; t < numTimeSteps; ++t) {
     solver->computeForces(dt, t, data);
     solver->updateSolution(dt, data);
     data.swapWavefields();
@@ -245,8 +208,7 @@ static float runAcousticSimulation(
 // Uses Q=10, 1 SLS mechanism, 500 time steps (matching the elastic test
 // that passes with these parameters).
 // ======================================================================
-TEST(AttenuationAcoustic, AttenuationDecaysAmplitude)
-{
+TEST(AttenuationAcoustic, AttenuationDecaysAmplitude) {
   const int order = 1;
   const int numTimeSteps = 500;
   const float dt = 0.001f;
@@ -259,10 +221,8 @@ TEST(AttenuationAcoustic, AttenuationDecaysAmplitude)
   auto mesh_att = buildSmallMesh(order, false);
   mesh_att->setQualityFactors(10.0f, 10.0f);
 
-  float norm_no_att =
-      runAcousticSimulation(mesh_no_att, {}, numTimeSteps, dt, order);
-  float norm_att =
-      runAcousticSimulation(mesh_att, freqs, numTimeSteps, dt, order);
+  float norm_no_att = runAcousticSimulation(mesh_no_att, {}, numTimeSteps, dt, order);
+  float norm_att = runAcousticSimulation(mesh_att, freqs, numTimeSteps, dt, order);
 
   EXPECT_GT(norm_no_att, 0.0f) << "Non-attenuated simulation should propagate";
   // If the wavefield differs and both are finite, the implementation works.
@@ -272,27 +232,22 @@ TEST(AttenuationAcoustic, AttenuationDecaysAmplitude)
   // We verify the wavefield is meaningfully different (attenuation is active).
   float ratio = norm_att / norm_no_att;
   EXPECT_NE(ratio, 1.0f) << "Attenuation should change the wavefield. "
-                         << "norm_no_att=" << norm_no_att
-                         << ", norm_att=" << norm_att;
-  EXPECT_TRUE(std::isfinite(norm_att))
-      << "Attenuated simulation should remain stable";
+                         << "norm_no_att=" << norm_no_att << ", norm_att=" << norm_att;
+  EXPECT_TRUE(std::isfinite(norm_att)) << "Attenuated simulation should remain stable";
 }
 
 // ======================================================================
 // TEST: Wavefield remains finite (no NaN/Inf) with attenuation
 // ======================================================================
-TEST(AttenuationAcoustic, NoNanOrInfWithAttenuation)
-{
+TEST(AttenuationAcoustic, NoNanOrInfWithAttenuation) {
   const int order = 1;
   auto mesh = buildSmallMesh(order, false);
   mesh->setQualityFactors(50.0f, 50.0f);
   int numNodes = mesh->getNumberOfNodes();
 
   auto solver = solver_factory::createSolver(
-      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu,
-      utils::enums::meshType::kStruct,
-      utils::enums::modelLocationType::kOnElements,
-      utils::enums::physicType::kAcoustic, order);
+      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu, utils::enums::meshType::kStruct,
+      utils::enums::modelLocationType::kOnElements, utils::enums::physicType::kAcoustic, order);
   solver->setAnisotropyType(model::AnisotropyType::kIso);
 
   std::vector<float> freqs = {2.0f * static_cast<float>(M_PI) * 5.0f};
@@ -301,8 +256,7 @@ TEST(AttenuationAcoustic, NoNanOrInfWithAttenuation)
 
   auto pPrev = allocateVector<VECTOR_REAL_VIEW>(numNodes, "pPrev_nan");
   auto pCurr = allocateVector<VECTOR_REAL_VIEW>(numNodes, "pCurr_nan");
-  for (int i = 0; i < numNodes; ++i)
-  {
+  for (int i = 0; i < numNodes; ++i) {
     pPrev(i) = 0.0f;
     pCurr(i) = 0.0f;
   }
@@ -310,14 +264,11 @@ TEST(AttenuationAcoustic, NoNanOrInfWithAttenuation)
 
   int npp = (order + 1) * (order + 1) * (order + 1);
   const int numSteps = 100;
-  auto rhsTerm =
-      allocateArray2D<ARRAY_REAL_VIEW>(1, numSteps, "rhsTerm_nantest");
+  auto rhsTerm = allocateArray2D<ARRAY_REAL_VIEW>(1, numSteps, "rhsTerm_nantest");
   auto rhsElem = allocateVector<VECTOR_INT_VIEW>(1, "rhsElem_nantest");
-  auto rhsWeights =
-      allocateArray2D<ARRAY_REAL_VIEW>(1, npp, "rhsWeights_nantest");
+  auto rhsWeights = allocateArray2D<ARRAY_REAL_VIEW>(1, npp, "rhsWeights_nantest");
   rhsElem(0) = 0;
-  for (int j = 0; j < npp; ++j)
-  {
+  for (int j = 0; j < npp; ++j) {
     rhsTerm(0, j) = 0.0f;
     rhsWeights(0, j) = 0.0f;
   }
@@ -327,26 +278,22 @@ TEST(AttenuationAcoustic, NoNanOrInfWithAttenuation)
   SEMsolverDataAcoustic data(wf, rhs);
 
   float dt = 0.001f;
-  for (int t = 0; t < numSteps; ++t)
-  {
+  for (int t = 0; t < numSteps; ++t) {
     solver->computeForces(dt, t, data);
     solver->updateSolution(dt, data);
     data.swapWavefields();
   }
 
   // Check no NaN or Inf
-  for (int i = 0; i < numNodes; ++i)
-  {
-    EXPECT_TRUE(std::isfinite(data.getCurrentField(0)(i)))
-        << "NaN/Inf detected at node " << i;
+  for (int i = 0; i < numNodes; ++i) {
+    EXPECT_TRUE(std::isfinite(data.getCurrentField(0)(i))) << "NaN/Inf detected at node " << i;
   }
 }
 
 // ======================================================================
 // TEST: Elastic simulation with attenuation decays amplitude
 // ======================================================================
-TEST(AttenuationElastic, AttenuationDecaysAmplitude)
-{
+TEST(AttenuationElastic, AttenuationDecaysAmplitude) {
   const int order = 1;
   const int numTimeSteps = 1000;
 
@@ -361,10 +308,8 @@ TEST(AttenuationElastic, AttenuationDecaysAmplitude)
 
   // ----- Run 1: No attenuation -----
   auto solver_no_att = solver_factory::createSolver(
-      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu,
-      utils::enums::meshType::kStruct,
-      utils::enums::modelLocationType::kOnElements,
-      utils::enums::physicType::kElastic, order);
+      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu, utils::enums::meshType::kStruct,
+      utils::enums::modelLocationType::kOnElements, utils::enums::physicType::kElastic, order);
   solver_no_att->setAnisotropyType(model::AnisotropyType::kIso);
   solver_no_att->computeFEInit(*mesh_no_att, {0, 0, 0}, false, 0.0f);
 
@@ -374,8 +319,7 @@ TEST(AttenuationElastic, AttenuationDecaysAmplitude)
   auto uyCurr_na = allocateVector<VECTOR_REAL_VIEW>(numNodes, "uyCurr_na");
   auto uzPrev_na = allocateVector<VECTOR_REAL_VIEW>(numNodes, "uzPrev_na");
   auto uzCurr_na = allocateVector<VECTOR_REAL_VIEW>(numNodes, "uzCurr_na");
-  for (int i = 0; i < numNodes; ++i)
-  {
+  for (int i = 0; i < numNodes; ++i) {
     uxPrev_na(i) = 0.0f;
     uxCurr_na(i) = 0.0f;
     uyPrev_na(i) = 0.0f;
@@ -385,31 +329,25 @@ TEST(AttenuationElastic, AttenuationDecaysAmplitude)
   }
   setImpulseSource(uzCurr_na, numNodes, 1.0f);
 
-  auto rhsTermx_na =
-      allocateArray2D<ARRAY_REAL_VIEW>(1, numTimeSteps, "rtx_na");
-  auto rhsTermy_na =
-      allocateArray2D<ARRAY_REAL_VIEW>(1, numTimeSteps, "rty_na");
-  auto rhsTermz_na =
-      allocateArray2D<ARRAY_REAL_VIEW>(1, numTimeSteps, "rtz_na");
+  auto rhsTermx_na = allocateArray2D<ARRAY_REAL_VIEW>(1, numTimeSteps, "rtx_na");
+  auto rhsTermy_na = allocateArray2D<ARRAY_REAL_VIEW>(1, numTimeSteps, "rty_na");
+  auto rhsTermz_na = allocateArray2D<ARRAY_REAL_VIEW>(1, numTimeSteps, "rtz_na");
   auto rhsElem_na = allocateVector<VECTOR_INT_VIEW>(1, "re_na");
   auto rhsW_na = allocateArray2D<ARRAY_REAL_VIEW>(1, npp, "rw_na");
   rhsElem_na(0) = 0;
-  for (int j = 0; j < npp; ++j)
-  {
+  for (int j = 0; j < npp; ++j) {
     rhsTermx_na(0, j) = 0.0f;
     rhsTermy_na(0, j) = 0.0f;
     rhsTermz_na(0, j) = 0.0f;
     rhsW_na(0, j) = 0.0f;
   }
 
-  WavefieldElastic wf_na(uxPrev_na, uxCurr_na, uyPrev_na, uyCurr_na, uzPrev_na,
-                         uzCurr_na);
+  WavefieldElastic wf_na(uxPrev_na, uxCurr_na, uyPrev_na, uyCurr_na, uzPrev_na, uzCurr_na);
   RhsElastic rhs_na(rhsTermx_na, rhsTermy_na, rhsTermz_na, rhsElem_na, rhsW_na);
   SEMsolverDataElastic data_na(wf_na, rhs_na);
 
   float dt = 0.001f;
-  for (int t = 0; t < numTimeSteps; ++t)
-  {
+  for (int t = 0; t < numTimeSteps; ++t) {
     solver_no_att->computeForces(dt, t, data_na);
     solver_no_att->updateSolution(dt, data_na);
     data_na.swapWavefields();
@@ -420,14 +358,11 @@ TEST(AttenuationElastic, AttenuationDecaysAmplitude)
 
   // ----- Run 2: With attenuation -----
   auto solver_att = solver_factory::createSolver(
-      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu,
-      utils::enums::meshType::kStruct,
-      utils::enums::modelLocationType::kOnElements,
-      utils::enums::physicType::kElastic, order);
+      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu, utils::enums::meshType::kStruct,
+      utils::enums::modelLocationType::kOnElements, utils::enums::physicType::kElastic, order);
   solver_att->setAnisotropyType(model::AnisotropyType::kIso);
 
-  std::vector<float> freqs = {2.0f * static_cast<float>(M_PI) * 5.0f,
-                              2.0f * static_cast<float>(M_PI) * 50.0f};
+  std::vector<float> freqs = {2.0f * static_cast<float>(M_PI) * 5.0f, 2.0f * static_cast<float>(M_PI) * 50.0f};
   solver_att->setSLSAttenuation(toView(freqs, "f"));
   solver_att->computeFEInit(*mesh_att, {0, 0, 0}, false, 0.0f);
 
@@ -437,8 +372,7 @@ TEST(AttenuationElastic, AttenuationDecaysAmplitude)
   auto uyCurr_a = allocateVector<VECTOR_REAL_VIEW>(numNodes, "uyCurr_a");
   auto uzPrev_a = allocateVector<VECTOR_REAL_VIEW>(numNodes, "uzPrev_a");
   auto uzCurr_a = allocateVector<VECTOR_REAL_VIEW>(numNodes, "uzCurr_a");
-  for (int i = 0; i < numNodes; ++i)
-  {
+  for (int i = 0; i < numNodes; ++i) {
     uxPrev_a(i) = 0.0f;
     uxCurr_a(i) = 0.0f;
     uyPrev_a(i) = 0.0f;
@@ -454,40 +388,34 @@ TEST(AttenuationElastic, AttenuationDecaysAmplitude)
   auto rhsElem_a = allocateVector<VECTOR_INT_VIEW>(1, "re_a");
   auto rhsW_a = allocateArray2D<ARRAY_REAL_VIEW>(1, npp, "rw_a");
   rhsElem_a(0) = 0;
-  for (int j = 0; j < npp; ++j)
-  {
+  for (int j = 0; j < npp; ++j) {
     rhsTermx_a(0, j) = 0.0f;
     rhsTermy_a(0, j) = 0.0f;
     rhsTermz_a(0, j) = 0.0f;
     rhsW_a(0, j) = 0.0f;
   }
 
-  WavefieldElastic wf_a(uxPrev_a, uxCurr_a, uyPrev_a, uyCurr_a, uzPrev_a,
-                        uzCurr_a);
+  WavefieldElastic wf_a(uxPrev_a, uxCurr_a, uyPrev_a, uyCurr_a, uzPrev_a, uzCurr_a);
   RhsElastic rhs_a(rhsTermx_a, rhsTermy_a, rhsTermz_a, rhsElem_a, rhsW_a);
   SEMsolverDataElastic data_a(wf_a, rhs_a);
 
-  for (int t = 0; t < numTimeSteps; ++t)
-  {
+  for (int t = 0; t < numTimeSteps; ++t) {
     solver_att->computeForces(dt, t, data_a);
     solver_att->updateSolution(dt, data_a);
     data_a.swapWavefields();
   }
-  float norm_att = fieldL2Norm(data_a.getCurrentField(0), numNodes) +
-                   fieldL2Norm(data_a.getCurrentField(1), numNodes) +
+  float norm_att = fieldL2Norm(data_a.getCurrentField(0), numNodes) + fieldL2Norm(data_a.getCurrentField(1), numNodes) +
                    fieldL2Norm(data_a.getCurrentField(2), numNodes);
 
   EXPECT_GT(norm_no_att, 0.0f) << "Non-attenuated elastic should propagate";
-  EXPECT_LT(norm_att, norm_no_att)
-      << "Elastic attenuation should reduce amplitude. "
-      << "norm_no_att=" << norm_no_att << ", norm_att=" << norm_att;
+  EXPECT_LT(norm_att, norm_no_att) << "Elastic attenuation should reduce amplitude. "
+                                   << "norm_no_att=" << norm_no_att << ", norm_att=" << norm_att;
 }
 
 // ======================================================================
 // TEST: Elastic wavefield remains finite with attenuation
 // ======================================================================
-TEST(AttenuationElastic, NoNanOrInfWithAttenuation)
-{
+TEST(AttenuationElastic, NoNanOrInfWithAttenuation) {
   const int order = 1;
   auto mesh = buildSmallMesh(order, true);
   mesh->setQualityFactors(50.0f, 30.0f);
@@ -495,10 +423,8 @@ TEST(AttenuationElastic, NoNanOrInfWithAttenuation)
   int npp = (order + 1) * (order + 1) * (order + 1);
 
   auto solver = solver_factory::createSolver(
-      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu,
-      utils::enums::meshType::kStruct,
-      utils::enums::modelLocationType::kOnElements,
-      utils::enums::physicType::kElastic, order);
+      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu, utils::enums::meshType::kStruct,
+      utils::enums::modelLocationType::kOnElements, utils::enums::physicType::kElastic, order);
   solver->setAnisotropyType(model::AnisotropyType::kIso);
 
   std::vector<float> freqs = {2.0f * static_cast<float>(M_PI) * 5.0f};
@@ -511,8 +437,7 @@ TEST(AttenuationElastic, NoNanOrInfWithAttenuation)
   auto uyC = allocateVector<VECTOR_REAL_VIEW>(numNodes, "uy_c_e");
   auto uzP = allocateVector<VECTOR_REAL_VIEW>(numNodes, "uz_p_e");
   auto uzC = allocateVector<VECTOR_REAL_VIEW>(numNodes, "uz_c_e");
-  for (int i = 0; i < numNodes; ++i)
-  {
+  for (int i = 0; i < numNodes; ++i) {
     uxP(i) = 0.0f;
     uxC(i) = 0.0f;
     uyP(i) = 0.0f;
@@ -529,8 +454,7 @@ TEST(AttenuationElastic, NoNanOrInfWithAttenuation)
   auto re = allocateVector<VECTOR_INT_VIEW>(1, "re_ef");
   auto rw = allocateArray2D<ARRAY_REAL_VIEW>(1, npp, "rw_ef");
   re(0) = 0;
-  for (int j = 0; j < npp; ++j)
-  {
+  for (int j = 0; j < npp; ++j) {
     rtx(0, j) = 0.0f;
     rty(0, j) = 0.0f;
     rtz(0, j) = 0.0f;
@@ -542,19 +466,15 @@ TEST(AttenuationElastic, NoNanOrInfWithAttenuation)
   SEMsolverDataElastic data(wf, rhs);
 
   float dt = 0.001f;
-  for (int t = 0; t < numSteps; ++t)
-  {
+  for (int t = 0; t < numSteps; ++t) {
     solver->computeForces(dt, t, data);
     solver->updateSolution(dt, data);
     data.swapWavefields();
   }
 
-  for (int f = 0; f < 3; ++f)
-  {
-    for (int i = 0; i < numNodes; ++i)
-    {
-      EXPECT_TRUE(std::isfinite(data.getCurrentField(f)(i)))
-          << "NaN/Inf on elastic field " << f << " at node " << i;
+  for (int f = 0; f < 3; ++f) {
+    for (int i = 0; i < numNodes; ++i) {
+      EXPECT_TRUE(std::isfinite(data.getCurrentField(f)(i))) << "NaN/Inf on elastic field " << f << " at node " << i;
     }
   }
 }
@@ -562,8 +482,7 @@ TEST(AttenuationElastic, NoNanOrInfWithAttenuation)
 // ======================================================================
 // TEST: computeOneStep also works with attenuation (acoustic)
 // ======================================================================
-TEST(AttenuationAcoustic, ComputeOneStepWithAttenuation)
-{
+TEST(AttenuationAcoustic, ComputeOneStepWithAttenuation) {
   const int order = 1;
   auto mesh = buildSmallMesh(order, false);
   mesh->setQualityFactors(50.0f, 50.0f);
@@ -571,10 +490,8 @@ TEST(AttenuationAcoustic, ComputeOneStepWithAttenuation)
   int npp = (order + 1) * (order + 1) * (order + 1);
 
   auto solver = solver_factory::createSolver(
-      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu,
-      utils::enums::meshType::kStruct,
-      utils::enums::modelLocationType::kOnElements,
-      utils::enums::physicType::kAcoustic, order);
+      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu, utils::enums::meshType::kStruct,
+      utils::enums::modelLocationType::kOnElements, utils::enums::physicType::kAcoustic, order);
   solver->setAnisotropyType(model::AnisotropyType::kIso);
 
   std::vector<float> freqs = {2.0f * static_cast<float>(M_PI) * 10.0f};
@@ -583,8 +500,7 @@ TEST(AttenuationAcoustic, ComputeOneStepWithAttenuation)
 
   auto pP = allocateVector<VECTOR_REAL_VIEW>(numNodes, "pP_os");
   auto pC = allocateVector<VECTOR_REAL_VIEW>(numNodes, "pC_os");
-  for (int i = 0; i < numNodes; ++i)
-  {
+  for (int i = 0; i < numNodes; ++i) {
     pP(i) = 0.0f;
     pC(i) = 0.0f;
   }
@@ -595,8 +511,7 @@ TEST(AttenuationAcoustic, ComputeOneStepWithAttenuation)
   auto re = allocateVector<VECTOR_INT_VIEW>(1, "re_os");
   auto rw = allocateArray2D<ARRAY_REAL_VIEW>(1, npp, "rw_os");
   re(0) = 0;
-  for (int j = 0; j < npp; ++j)
-  {
+  for (int j = 0; j < npp; ++j) {
     rt(0, j) = 0.0f;
     rw(0, j) = 0.0f;
   }
@@ -606,15 +521,13 @@ TEST(AttenuationAcoustic, ComputeOneStepWithAttenuation)
   SEMsolverDataAcoustic data(wf, rhs);
 
   float dt = 0.001f;
-  for (int t = 0; t < numSteps; ++t)
-  {
+  for (int t = 0; t < numSteps; ++t) {
     solver->computeOneStep(dt, t, data);
     data.swapWavefields();
   }
 
   // Verify finite values
-  for (int i = 0; i < numNodes; ++i)
-  {
+  for (int i = 0; i < numNodes; ++i) {
     EXPECT_TRUE(std::isfinite(data.getCurrentField(0)(i)));
   }
 }
@@ -624,8 +537,7 @@ TEST(AttenuationAcoustic, ComputeOneStepWithAttenuation)
 // Verifies that adding more SLS mechanisms produces a measurably
 // different wavefield, confirming attenuation parameters are active.
 // ======================================================================
-TEST(AttenuationAcoustic, MoreMechanismsChangeWavefield)
-{
+TEST(AttenuationAcoustic, MoreMechanismsChangeWavefield) {
   const int order = 1;
   const int numTimeSteps = 200;
   const float dt = 0.001f;
@@ -633,16 +545,14 @@ TEST(AttenuationAcoustic, MoreMechanismsChangeWavefield)
   float norm_1sls = [&]() {
     auto mesh = buildSmallMesh(order, false);
     mesh->setQualityFactors(50.0f, 50.0f);
-    return runAcousticSimulation(mesh, {2.0f * static_cast<float>(M_PI) * 5.0f},
-                                 numTimeSteps, dt, order);
+    return runAcousticSimulation(mesh, {2.0f * static_cast<float>(M_PI) * 5.0f}, numTimeSteps, dt, order);
   }();
 
   float norm_3sls = [&]() {
     auto mesh = buildSmallMesh(order, false);
     mesh->setQualityFactors(50.0f, 50.0f);
     return runAcousticSimulation(mesh,
-                                 {2.0f * static_cast<float>(M_PI) * 1.0f,
-                                  2.0f * static_cast<float>(M_PI) * 5.0f,
+                                 {2.0f * static_cast<float>(M_PI) * 1.0f, 2.0f * static_cast<float>(M_PI) * 5.0f,
                                   2.0f * static_cast<float>(M_PI) * 25.0f},
                                  numTimeSteps, dt, order);
   }();
@@ -652,17 +562,15 @@ TEST(AttenuationAcoustic, MoreMechanismsChangeWavefield)
   EXPECT_TRUE(std::isfinite(norm_1sls)) << "1 SLS should be stable";
   EXPECT_TRUE(std::isfinite(norm_3sls)) << "3 SLS should be stable";
   // Verify that different numbers of SLS mechanisms produce different results
-  EXPECT_NE(norm_1sls, norm_3sls)
-      << "Different numbers of SLS mechanisms should produce different "
-         "wavefields. norm_1sls="
-      << norm_1sls << ", norm_3sls=" << norm_3sls;
+  EXPECT_NE(norm_1sls, norm_3sls) << "Different numbers of SLS mechanisms should produce different "
+                                     "wavefields. norm_1sls="
+                                  << norm_1sls << ", norm_3sls=" << norm_3sls;
 }
 
 // ======================================================================
 // TEST: Acoustic attenuation at order 2
 // ======================================================================
-TEST(AttenuationAcousticHighOrder, Order2DecaysAmplitude)
-{
+TEST(AttenuationAcousticHighOrder, Order2DecaysAmplitude) {
   const int order = 2;
   const int numTimeSteps = 500;
   const float dt = 0.0005f;  // smaller dt for higher order stability
@@ -674,24 +582,20 @@ TEST(AttenuationAcousticHighOrder, Order2DecaysAmplitude)
   auto mesh_att = buildSmallMesh(order, false);
   mesh_att->setQualityFactors(10.0f, 10.0f);
 
-  float norm_no_att =
-      runAcousticSimulation(mesh_no_att, {}, numTimeSteps, dt, order);
-  float norm_att =
-      runAcousticSimulation(mesh_att, freqs, numTimeSteps, dt, order);
+  float norm_no_att = runAcousticSimulation(mesh_no_att, {}, numTimeSteps, dt, order);
+  float norm_att = runAcousticSimulation(mesh_att, freqs, numTimeSteps, dt, order);
 
   EXPECT_GT(norm_no_att, 0.0f);
   EXPECT_TRUE(std::isfinite(norm_att));
   float ratio = norm_att / norm_no_att;
   EXPECT_NE(ratio, 1.0f) << "Order-2 attenuation should change the wavefield. "
-                         << "norm_no_att=" << norm_no_att
-                         << ", norm_att=" << norm_att;
+                         << "norm_no_att=" << norm_no_att << ", norm_att=" << norm_att;
 }
 
 // ======================================================================
 // TEST: Elastic attenuation at order 2
 // ======================================================================
-TEST(AttenuationElasticHighOrder, Order2DecaysAmplitude)
-{
+TEST(AttenuationElasticHighOrder, Order2DecaysAmplitude) {
   const int order = 2;
   const int numTimeSteps = 500;
   const float dt = 0.0005f;
@@ -705,10 +609,8 @@ TEST(AttenuationElasticHighOrder, Order2DecaysAmplitude)
 
   // ----- No attenuation -----
   auto solver_na = solver_factory::createSolver(
-      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu,
-      utils::enums::meshType::kStruct,
-      utils::enums::modelLocationType::kOnElements,
-      utils::enums::physicType::kElastic, order);
+      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu, utils::enums::meshType::kStruct,
+      utils::enums::modelLocationType::kOnElements, utils::enums::physicType::kElastic, order);
   solver_na->setAnisotropyType(model::AnisotropyType::kIso);
   solver_na->computeFEInit(*mesh_no_att, {0, 0, 0}, false, 0.0f);
 
@@ -718,8 +620,7 @@ TEST(AttenuationElasticHighOrder, Order2DecaysAmplitude)
   auto uyC_na = allocateVector<VECTOR_REAL_VIEW>(numNodes, "uyC_na2");
   auto uzP_na = allocateVector<VECTOR_REAL_VIEW>(numNodes, "uzP_na2");
   auto uzC_na = allocateVector<VECTOR_REAL_VIEW>(numNodes, "uzC_na2");
-  for (int i = 0; i < numNodes; ++i)
-  {
+  for (int i = 0; i < numNodes; ++i) {
     uxP_na(i) = uxC_na(i) = uyP_na(i) = uyC_na(i) = 0.0f;
     uzP_na(i) = uzC_na(i) = 0.0f;
   }
@@ -731,8 +632,7 @@ TEST(AttenuationElasticHighOrder, Order2DecaysAmplitude)
   auto re_na = allocateVector<VECTOR_INT_VIEW>(1, "re_na2");
   auto rw_na = allocateArray2D<ARRAY_REAL_VIEW>(1, npp, "rw_na2");
   re_na(0) = 0;
-  for (int j = 0; j < npp; ++j)
-  {
+  for (int j = 0; j < npp; ++j) {
     rtx_na(0, j) = rty_na(0, j) = rtz_na(0, j) = rw_na(0, j) = 0.0f;
   }
 
@@ -740,25 +640,20 @@ TEST(AttenuationElasticHighOrder, Order2DecaysAmplitude)
   RhsElastic rhs_na(rtx_na, rty_na, rtz_na, re_na, rw_na);
   SEMsolverDataElastic data_na(wf_na, rhs_na);
 
-  for (int t = 0; t < numTimeSteps; ++t)
-  {
+  for (int t = 0; t < numTimeSteps; ++t) {
     solver_na->computeForces(dt, t, data_na);
     solver_na->updateSolution(dt, data_na);
     data_na.swapWavefields();
   }
   float norm_na = fieldL2Norm(data_na.getCurrentField(0), numNodes) +
-                  fieldL2Norm(data_na.getCurrentField(1), numNodes) +
-                  fieldL2Norm(data_na.getCurrentField(2), numNodes);
+                  fieldL2Norm(data_na.getCurrentField(1), numNodes) + fieldL2Norm(data_na.getCurrentField(2), numNodes);
 
   // ----- With attenuation -----
   auto solver_a = solver_factory::createSolver(
-      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu,
-      utils::enums::meshType::kStruct,
-      utils::enums::modelLocationType::kOnElements,
-      utils::enums::physicType::kElastic, order);
+      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu, utils::enums::meshType::kStruct,
+      utils::enums::modelLocationType::kOnElements, utils::enums::physicType::kElastic, order);
   solver_a->setAnisotropyType(model::AnisotropyType::kIso);
-  std::vector<float> freqs = {2.0f * static_cast<float>(M_PI) * 5.0f,
-                              2.0f * static_cast<float>(M_PI) * 50.0f};
+  std::vector<float> freqs = {2.0f * static_cast<float>(M_PI) * 5.0f, 2.0f * static_cast<float>(M_PI) * 50.0f};
   solver_a->setSLSAttenuation(toView(freqs, "f"));
   solver_a->computeFEInit(*mesh_att, {0, 0, 0}, false, 0.0f);
 
@@ -768,8 +663,7 @@ TEST(AttenuationElasticHighOrder, Order2DecaysAmplitude)
   auto uyC_a = allocateVector<VECTOR_REAL_VIEW>(numNodes, "uyC_a2");
   auto uzP_a = allocateVector<VECTOR_REAL_VIEW>(numNodes, "uzP_a2");
   auto uzC_a = allocateVector<VECTOR_REAL_VIEW>(numNodes, "uzC_a2");
-  for (int i = 0; i < numNodes; ++i)
-  {
+  for (int i = 0; i < numNodes; ++i) {
     uxP_a(i) = uxC_a(i) = uyP_a(i) = uyC_a(i) = 0.0f;
     uzP_a(i) = uzC_a(i) = 0.0f;
   }
@@ -781,8 +675,7 @@ TEST(AttenuationElasticHighOrder, Order2DecaysAmplitude)
   auto re_a = allocateVector<VECTOR_INT_VIEW>(1, "re_a2");
   auto rw_a = allocateArray2D<ARRAY_REAL_VIEW>(1, npp, "rw_a2");
   re_a(0) = 0;
-  for (int j = 0; j < npp; ++j)
-  {
+  for (int j = 0; j < npp; ++j) {
     rtx_a(0, j) = rty_a(0, j) = rtz_a(0, j) = rw_a(0, j) = 0.0f;
   }
 
@@ -790,14 +683,12 @@ TEST(AttenuationElasticHighOrder, Order2DecaysAmplitude)
   RhsElastic rhs_a(rtx_a, rty_a, rtz_a, re_a, rw_a);
   SEMsolverDataElastic data_a(wf_a, rhs_a);
 
-  for (int t = 0; t < numTimeSteps; ++t)
-  {
+  for (int t = 0; t < numTimeSteps; ++t) {
     solver_a->computeForces(dt, t, data_a);
     solver_a->updateSolution(dt, data_a);
     data_a.swapWavefields();
   }
-  float norm_a = fieldL2Norm(data_a.getCurrentField(0), numNodes) +
-                 fieldL2Norm(data_a.getCurrentField(1), numNodes) +
+  float norm_a = fieldL2Norm(data_a.getCurrentField(0), numNodes) + fieldL2Norm(data_a.getCurrentField(1), numNodes) +
                  fieldL2Norm(data_a.getCurrentField(2), numNodes);
 
   EXPECT_GT(norm_na, 0.0f);
@@ -805,18 +696,15 @@ TEST(AttenuationElasticHighOrder, Order2DecaysAmplitude)
   // arrival pattern, so we verify the wavefield is meaningfully modified
   // rather than strictly checking amplitude reduction.
   float ratio = norm_a / norm_na;
-  EXPECT_NE(ratio, 1.0f)
-      << "Order-2 elastic attenuation should change the wavefield. "
-      << "norm_na=" << norm_na << ", norm_a=" << norm_a;
-  EXPECT_TRUE(std::isfinite(norm_a))
-      << "Order-2 elastic attenuation should remain stable";
+  EXPECT_NE(ratio, 1.0f) << "Order-2 elastic attenuation should change the wavefield. "
+                         << "norm_na=" << norm_na << ", norm_a=" << norm_a;
+  EXPECT_TRUE(std::isfinite(norm_a)) << "Order-2 elastic attenuation should remain stable";
 }
 
 // ======================================================================
 // TEST: Acoustic attenuation at order 3
 // ======================================================================
-TEST(AttenuationAcousticHighOrder, Order3DecaysAmplitude)
-{
+TEST(AttenuationAcousticHighOrder, Order3DecaysAmplitude) {
   const int order = 3;
   const int numTimeSteps = 500;
   const float dt = 0.001f;  // CFL-safe (dt_max ~ 0.018 for order 3)
@@ -828,34 +716,28 @@ TEST(AttenuationAcousticHighOrder, Order3DecaysAmplitude)
   auto mesh_att = buildSmallMesh(order, false);
   mesh_att->setQualityFactors(10.0f, 10.0f);
 
-  float norm_no_att =
-      runAcousticSimulation(mesh_no_att, {}, numTimeSteps, dt, order);
-  float norm_att =
-      runAcousticSimulation(mesh_att, freqs, numTimeSteps, dt, order);
+  float norm_no_att = runAcousticSimulation(mesh_no_att, {}, numTimeSteps, dt, order);
+  float norm_att = runAcousticSimulation(mesh_att, freqs, numTimeSteps, dt, order);
 
   EXPECT_GT(norm_no_att, 0.0f);
   EXPECT_TRUE(std::isfinite(norm_att));
   float ratio = norm_att / norm_no_att;
   EXPECT_NE(ratio, 1.0f) << "Order-3 attenuation should change the wavefield. "
-                         << "norm_no_att=" << norm_no_att
-                         << ", norm_att=" << norm_att;
+                         << "norm_no_att=" << norm_no_att << ", norm_att=" << norm_att;
 }
 
 // ======================================================================
 // TEST: Stability (no NaN/Inf) with attenuation at order 2
 // ======================================================================
-TEST(AttenuationAcousticHighOrder, Order2NoNanOrInf)
-{
+TEST(AttenuationAcousticHighOrder, Order2NoNanOrInf) {
   const int order = 2;
   auto mesh = buildSmallMesh(order, false);
   mesh->setQualityFactors(50.0f, 50.0f);
   int numNodes = mesh->getNumberOfNodes();
 
   auto solver = solver_factory::createSolver(
-      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu,
-      utils::enums::meshType::kStruct,
-      utils::enums::modelLocationType::kOnElements,
-      utils::enums::physicType::kAcoustic, order);
+      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu, utils::enums::meshType::kStruct,
+      utils::enums::modelLocationType::kOnElements, utils::enums::physicType::kAcoustic, order);
   solver->setAnisotropyType(model::AnisotropyType::kIso);
 
   std::vector<float> freqs = {2.0f * static_cast<float>(M_PI) * 5.0f};
@@ -864,8 +746,7 @@ TEST(AttenuationAcousticHighOrder, Order2NoNanOrInf)
 
   auto pPrev = allocateVector<VECTOR_REAL_VIEW>(numNodes, "pPrev_o2");
   auto pCurr = allocateVector<VECTOR_REAL_VIEW>(numNodes, "pCurr_o2");
-  for (int i = 0; i < numNodes; ++i)
-  {
+  for (int i = 0; i < numNodes; ++i) {
     pPrev(i) = 0.0f;
     pCurr(i) = 0.0f;
   }
@@ -877,8 +758,7 @@ TEST(AttenuationAcousticHighOrder, Order2NoNanOrInf)
   auto rhsElem = allocateVector<VECTOR_INT_VIEW>(1, "re_o2");
   auto rhsW = allocateArray2D<ARRAY_REAL_VIEW>(1, npp, "rw_o2");
   rhsElem(0) = 0;
-  for (int j = 0; j < npp; ++j)
-  {
+  for (int j = 0; j < npp; ++j) {
     rhsTerm(0, j) = 0.0f;
     rhsW(0, j) = 0.0f;
   }
@@ -888,25 +768,21 @@ TEST(AttenuationAcousticHighOrder, Order2NoNanOrInf)
   SEMsolverDataAcoustic data(wf, rhs);
 
   float dt = 0.0005f;
-  for (int t = 0; t < numSteps; ++t)
-  {
+  for (int t = 0; t < numSteps; ++t) {
     solver->computeForces(dt, t, data);
     solver->updateSolution(dt, data);
     data.swapWavefields();
   }
 
-  for (int i = 0; i < numNodes; ++i)
-  {
-    EXPECT_TRUE(std::isfinite(data.getCurrentField(0)(i)))
-        << "Order-2: NaN/Inf at node " << i;
+  for (int i = 0; i < numNodes; ++i) {
+    EXPECT_TRUE(std::isfinite(data.getCurrentField(0)(i))) << "Order-2: NaN/Inf at node " << i;
   }
 }
 
 // ======================================================================
 // TEST: Stability (no NaN/Inf) elastic at order 3
 // ======================================================================
-TEST(AttenuationElasticHighOrder, Order3NoNanOrInf)
-{
+TEST(AttenuationElasticHighOrder, Order3NoNanOrInf) {
   const int order = 3;
   auto mesh = buildSmallMesh(order, true);
   mesh->setQualityFactors(30.0f, 20.0f);
@@ -914,10 +790,8 @@ TEST(AttenuationElasticHighOrder, Order3NoNanOrInf)
   int npp = (order + 1) * (order + 1) * (order + 1);
 
   auto solver = solver_factory::createSolver(
-      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu,
-      utils::enums::meshType::kStruct,
-      utils::enums::modelLocationType::kOnElements,
-      utils::enums::physicType::kElastic, order);
+      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu, utils::enums::meshType::kStruct,
+      utils::enums::modelLocationType::kOnElements, utils::enums::physicType::kElastic, order);
   solver->setAnisotropyType(model::AnisotropyType::kIso);
 
   std::vector<float> freqs = {2.0f * static_cast<float>(M_PI) * 5.0f};
@@ -930,8 +804,7 @@ TEST(AttenuationElasticHighOrder, Order3NoNanOrInf)
   auto uyC = allocateVector<VECTOR_REAL_VIEW>(numNodes, "uyC_o3");
   auto uzP = allocateVector<VECTOR_REAL_VIEW>(numNodes, "uzP_o3");
   auto uzC = allocateVector<VECTOR_REAL_VIEW>(numNodes, "uzC_o3");
-  for (int i = 0; i < numNodes; ++i)
-  {
+  for (int i = 0; i < numNodes; ++i) {
     uxP(i) = uxC(i) = uyP(i) = uyC(i) = uzP(i) = uzC(i) = 0.0f;
   }
   setImpulseSource(uzC, numNodes, 1.0f);
@@ -943,8 +816,7 @@ TEST(AttenuationElasticHighOrder, Order3NoNanOrInf)
   auto re = allocateVector<VECTOR_INT_VIEW>(1, "re_o3");
   auto rw = allocateArray2D<ARRAY_REAL_VIEW>(1, npp, "rw_o3");
   re(0) = 0;
-  for (int j = 0; j < npp; ++j)
-  {
+  for (int j = 0; j < npp; ++j) {
     rtx(0, j) = rty(0, j) = rtz(0, j) = rw(0, j) = 0.0f;
   }
 
@@ -953,17 +825,14 @@ TEST(AttenuationElasticHighOrder, Order3NoNanOrInf)
   SEMsolverDataElastic data(wf, rhs);
 
   float dt = 0.001f;  // CFL-safe (dt_max ~ 0.018 for order 3)
-  for (int t = 0; t < numSteps; ++t)
-  {
+  for (int t = 0; t < numSteps; ++t) {
     solver->computeForces(dt, t, data);
     solver->updateSolution(dt, data);
     data.swapWavefields();
   }
 
-  for (int f = 0; f < 3; ++f)
-  {
-    for (int i = 0; i < numNodes; ++i)
-    {
+  for (int f = 0; f < 3; ++f) {
+    for (int i = 0; i < numNodes; ++i) {
       EXPECT_TRUE(std::isfinite(data.getCurrentField(f)(i)))
           << "Order-3: NaN/Inf on elastic field " << f << " at node " << i;
     }

--- a/tests/units/solver/impl/test_attenuation_receiver.cc
+++ b/tests/units/solver/impl/test_attenuation_receiver.cc
@@ -34,14 +34,10 @@
 #include "wavefield_acoustic.h"
 #include "wavefield_elastic.h"
 
-namespace solver
-{
-namespace fe
-{
-namespace test
-{
-static VECTOR_REAL_VIEW toView(const std::vector<float>& v, const char* name)
-{
+namespace solver {
+namespace fe {
+namespace test {
+static VECTOR_REAL_VIEW toView(const std::vector<float>& v, const char* name) {
   if (v.empty()) return VECTOR_REAL_VIEW();
   auto view = allocateVector<VECTOR_REAL_VIEW>(v.size(), name);
   for (size_t i = 0; i < v.size(); ++i) view[i] = v[i];
@@ -51,33 +47,28 @@ static VECTOR_REAL_VIEW toView(const std::vector<float>& v, const char* name)
 // ======================================================================
 // Helper: build a larger mesh for receiver testing
 // ======================================================================
-static std::shared_ptr<model::ModelApi<float, int>> buildReceiverMesh(
-    bool isElastic, float qp = 1e9f, float qs = 1e9f, int order = 1)
-{
+static std::shared_ptr<model::ModelApi<float, int>> buildReceiverMesh(bool isElastic, float qp = 1e9f, float qs = 1e9f,
+                                                                      int order = 1) {
   constexpr float LX = 1000.0f, LY = 1000.0f, LZ = 1000.0f;
 
   std::shared_ptr<model::ModelApi<float, int>> mesh;
-  switch (order)
-  {
+  switch (order) {
     case 1: {
       constexpr int EX = 10, EY = 10, EZ = 10;
-      model::CartesianStructBuilder<float, int, 1> builder(
-          EX, LX, EY, LY, EZ, LZ, false, isElastic);
+      model::CartesianStructBuilder<float, int, 1> builder(EX, LX, EY, LY, EZ, LZ, false, isElastic);
       mesh = builder.getModel(false);
       break;
     }
     case 2: {
       // Use fewer elements at higher order to keep node count manageable
       constexpr int EX = 5, EY = 5, EZ = 5;
-      model::CartesianStructBuilder<float, int, 2> builder(
-          EX, LX, EY, LY, EZ, LZ, false, isElastic);
+      model::CartesianStructBuilder<float, int, 2> builder(EX, LX, EY, LY, EZ, LZ, false, isElastic);
       mesh = builder.getModel(false);
       break;
     }
     case 3: {
       constexpr int EX = 4, EY = 4, EZ = 4;
-      model::CartesianStructBuilder<float, int, 3> builder(
-          EX, LX, EY, LY, EZ, LZ, false, isElastic);
+      model::CartesianStructBuilder<float, int, 3> builder(EX, LX, EY, LY, EZ, LZ, false, isElastic);
       mesh = builder.getModel(false);
       break;
     }
@@ -92,17 +83,12 @@ static std::shared_ptr<model::ModelApi<float, int>> buildReceiverMesh(
 // Helper: find local peaks (positive maxima) in a time trace
 // Returns the values of the peaks in chronological order.
 // ======================================================================
-static std::vector<float> findPeaks(const std::vector<float>& trace,
-                                    int minSeparation = 10)
-{
+static std::vector<float> findPeaks(const std::vector<float>& trace, int minSeparation = 10) {
   std::vector<float> peaks;
   int lastPeakIdx = -minSeparation;
 
-  for (int i = 1; i < static_cast<int>(trace.size()) - 1; ++i)
-  {
-    if (trace[i] > trace[i - 1] && trace[i] > trace[i + 1] && trace[i] > 0.0f &&
-        (i - lastPeakIdx) >= minSeparation)
-    {
+  for (int i = 1; i < static_cast<int>(trace.size()) - 1; ++i) {
+    if (trace[i] > trace[i - 1] && trace[i] > trace[i + 1] && trace[i] > 0.0f && (i - lastPeakIdx) >= minSeparation) {
       peaks.push_back(trace[i]);
       lastPeakIdx = i;
     }
@@ -113,50 +99,41 @@ static std::vector<float> findPeaks(const std::vector<float>& trace,
 // ======================================================================
 // Helper: record acoustic seismogram at a receiver node
 // ======================================================================
-struct AcousticSeismogram
-{
+struct AcousticSeismogram {
   std::vector<float> trace;  // pressure at receiver vs time
   float finalNorm;           // L2 norm at end
 };
 
-static AcousticSeismogram runAcousticWithReceiver(
-    std::shared_ptr<model::ModelApi<float, int>> mesh,
-    const std::vector<float>& slsFreqs, int numTimeSteps, float dt,
-    int sourceNode, int receiverNode, int order = 1)
-{
+static AcousticSeismogram runAcousticWithReceiver(std::shared_ptr<model::ModelApi<float, int>> mesh,
+                                                  const std::vector<float>& slsFreqs, int numTimeSteps, float dt,
+                                                  int sourceNode, int receiverNode, int order = 1) {
   int numNodes = mesh->getNumberOfNodes();
   int npp = (order + 1) * (order + 1) * (order + 1);
 
   auto solver = solver_factory::createSolver(
-      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu,
-      utils::enums::meshType::kStruct,
-      utils::enums::modelLocationType::kOnElements,
-      utils::enums::physicType::kAcoustic, order);
+      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu, utils::enums::meshType::kStruct,
+      utils::enums::modelLocationType::kOnElements, utils::enums::physicType::kAcoustic, order);
   solver->setAnisotropyType(model::AnisotropyType::kIso);
 
-  if (!slsFreqs.empty())
-  {
+  if (!slsFreqs.empty()) {
     solver->setSLSAttenuation(toView(slsFreqs, "f"));
   }
   solver->computeFEInit(*mesh, {0, 0, 0}, false, 0.0f);
 
   auto pPrev = allocateVector<VECTOR_REAL_VIEW>(numNodes, "pPrev_rcv");
   auto pCurr = allocateVector<VECTOR_REAL_VIEW>(numNodes, "pCurr_rcv");
-  for (int i = 0; i < numNodes; ++i)
-  {
+  for (int i = 0; i < numNodes; ++i) {
     pPrev(i) = 0.0f;
     pCurr(i) = 0.0f;
   }
   // Point source at the given node
   pCurr(sourceNode) = 1.0f;
 
-  auto rhsTerm =
-      allocateArray2D<ARRAY_REAL_VIEW>(1, numTimeSteps, "rhsTerm_rcv");
+  auto rhsTerm = allocateArray2D<ARRAY_REAL_VIEW>(1, numTimeSteps, "rhsTerm_rcv");
   auto rhsElem = allocateVector<VECTOR_INT_VIEW>(1, "rhsElem_rcv");
   auto rhsWeights = allocateArray2D<ARRAY_REAL_VIEW>(1, npp, "rhsWeights_rcv");
   rhsElem(0) = 0;
-  for (int j = 0; j < npp; ++j)
-  {
+  for (int j = 0; j < npp; ++j) {
     rhsTerm(0, j) = 0.0f;
     rhsWeights(0, j) = 0.0f;
   }
@@ -168,8 +145,7 @@ static AcousticSeismogram runAcousticWithReceiver(
   AcousticSeismogram result;
   result.trace.reserve(numTimeSteps);
 
-  for (int t = 0; t < numTimeSteps; ++t)
-  {
+  for (int t = 0; t < numTimeSteps; ++t) {
     solver->computeForces(dt, t, data);
     solver->updateSolution(dt, data);
     data.swapWavefields();
@@ -177,8 +153,7 @@ static AcousticSeismogram runAcousticWithReceiver(
   }
 
   float sum = 0.0f;
-  for (int i = 0; i < numNodes; ++i)
-    sum += data.getCurrentField(0)(i) * data.getCurrentField(0)(i);
+  for (int i = 0; i < numNodes; ++i) sum += data.getCurrentField(0)(i) * data.getCurrentField(0)(i);
   result.finalNorm = std::sqrt(sum);
 
   return result;
@@ -187,29 +162,23 @@ static AcousticSeismogram runAcousticWithReceiver(
 // ======================================================================
 // Helper: record elastic seismogram at a receiver node
 // ======================================================================
-struct ElasticSeismogram
-{
+struct ElasticSeismogram {
   std::vector<float> traceUz;  // vertical displacement at receiver vs time
   float finalNorm;
 };
 
-static ElasticSeismogram runElasticWithReceiver(
-    std::shared_ptr<model::ModelApi<float, int>> mesh,
-    const std::vector<float>& slsFreqs, int numTimeSteps, float dt,
-    int sourceNode, int receiverNode, int order = 1)
-{
+static ElasticSeismogram runElasticWithReceiver(std::shared_ptr<model::ModelApi<float, int>> mesh,
+                                                const std::vector<float>& slsFreqs, int numTimeSteps, float dt,
+                                                int sourceNode, int receiverNode, int order = 1) {
   int numNodes = mesh->getNumberOfNodes();
   int npp = (order + 1) * (order + 1) * (order + 1);
 
   auto solver = solver_factory::createSolver(
-      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu,
-      utils::enums::meshType::kStruct,
-      utils::enums::modelLocationType::kOnElements,
-      utils::enums::physicType::kElastic, order);
+      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu, utils::enums::meshType::kStruct,
+      utils::enums::modelLocationType::kOnElements, utils::enums::physicType::kElastic, order);
   solver->setAnisotropyType(model::AnisotropyType::kIso);
 
-  if (!slsFreqs.empty())
-  {
+  if (!slsFreqs.empty()) {
     solver->setSLSAttenuation(toView(slsFreqs, "f"));
   }
   solver->computeFEInit(*mesh, {0, 0, 0}, false, 0.0f);
@@ -220,8 +189,7 @@ static ElasticSeismogram runElasticWithReceiver(
   auto uyC = allocateVector<VECTOR_REAL_VIEW>(numNodes, "uyC_rcv");
   auto uzP = allocateVector<VECTOR_REAL_VIEW>(numNodes, "uzP_rcv");
   auto uzC = allocateVector<VECTOR_REAL_VIEW>(numNodes, "uzC_rcv");
-  for (int i = 0; i < numNodes; ++i)
-  {
+  for (int i = 0; i < numNodes; ++i) {
     uxP(i) = uxC(i) = uyP(i) = uyC(i) = uzP(i) = uzC(i) = 0.0f;
   }
   // Vertical impulse source
@@ -233,8 +201,7 @@ static ElasticSeismogram runElasticWithReceiver(
   auto re = allocateVector<VECTOR_INT_VIEW>(1, "re_rcv");
   auto rw = allocateArray2D<ARRAY_REAL_VIEW>(1, npp, "rw_rcv");
   re(0) = 0;
-  for (int j = 0; j < npp; ++j)
-  {
+  for (int j = 0; j < npp; ++j) {
     rtx(0, j) = rty(0, j) = rtz(0, j) = rw(0, j) = 0.0f;
   }
 
@@ -245,8 +212,7 @@ static ElasticSeismogram runElasticWithReceiver(
   ElasticSeismogram result;
   result.traceUz.reserve(numTimeSteps);
 
-  for (int t = 0; t < numTimeSteps; ++t)
-  {
+  for (int t = 0; t < numTimeSteps; ++t) {
     solver->computeForces(dt, t, data);
     solver->updateSolution(dt, data);
     data.swapWavefields();
@@ -255,8 +221,7 @@ static ElasticSeismogram runElasticWithReceiver(
 
   float sum = 0.0f;
   for (int f = 0; f < 3; ++f)
-    for (int i = 0; i < numNodes; ++i)
-      sum += data.getCurrentField(f)(i) * data.getCurrentField(f)(i);
+    for (int i = 0; i < numNodes; ++i) sum += data.getCurrentField(f)(i) * data.getCurrentField(f)(i);
   result.finalNorm = std::sqrt(sum);
 
   return result;
@@ -273,8 +238,7 @@ static ElasticSeismogram runElasticWithReceiver(
 // and arrives back. With attenuation, each successive arrival should be
 // weaker than without attenuation.
 // ======================================================================
-TEST(AttenuationReceiver, AcousticReceiverTraceDecays)
-{
+TEST(AttenuationReceiver, AcousticReceiverTraceDecays) {
   const int numTimeSteps = 2000;
   const float dt = 0.0005f;
 
@@ -285,76 +249,62 @@ TEST(AttenuationReceiver, AcousticReceiverTraceDecays)
 
   // Run without attenuation
   auto mesh_noatt = buildReceiverMesh(false);
-  auto seis_noatt = runAcousticWithReceiver(mesh_noatt, {}, numTimeSteps, dt,
-                                            sourceNode, receiverNode);
+  auto seis_noatt = runAcousticWithReceiver(mesh_noatt, {}, numTimeSteps, dt, sourceNode, receiverNode);
 
   // Run with attenuation: Q=10, 1 SLS mechanism (strong attenuation)
   auto mesh_att = buildReceiverMesh(false, 10.0f, 10.0f);
   std::vector<float> freqs = {2.0f * static_cast<float>(M_PI) * 10.0f};
-  auto seis_att = runAcousticWithReceiver(mesh_att, freqs, numTimeSteps, dt,
-                                          sourceNode, receiverNode);
+  auto seis_att = runAcousticWithReceiver(mesh_att, freqs, numTimeSteps, dt, sourceNode, receiverNode);
 
   // Both traces should be finite
-  for (int t = 0; t < numTimeSteps; ++t)
-  {
-    ASSERT_TRUE(std::isfinite(seis_noatt.trace[t]))
-        << "Non-attenuated trace has NaN/Inf at step " << t;
-    ASSERT_TRUE(std::isfinite(seis_att.trace[t]))
-        << "Attenuated trace has NaN/Inf at step " << t;
+  for (int t = 0; t < numTimeSteps; ++t) {
+    ASSERT_TRUE(std::isfinite(seis_noatt.trace[t])) << "Non-attenuated trace has NaN/Inf at step " << t;
+    ASSERT_TRUE(std::isfinite(seis_att.trace[t])) << "Attenuated trace has NaN/Inf at step " << t;
   }
 
   // Compute absolute-value traces for peak comparison
   std::vector<float> absTrace_noatt(numTimeSteps);
   std::vector<float> absTrace_att(numTimeSteps);
-  for (int t = 0; t < numTimeSteps; ++t)
-  {
+  for (int t = 0; t < numTimeSteps; ++t) {
     absTrace_noatt[t] = std::fabs(seis_noatt.trace[t]);
     absTrace_att[t] = std::fabs(seis_att.trace[t]);
   }
 
   // Verify the traces are different (attenuation is active)
   bool tracesIdentical = true;
-  for (int t = 0; t < numTimeSteps; ++t)
-  {
-    if (std::fabs(seis_att.trace[t] - seis_noatt.trace[t]) > 1e-10f)
-    {
+  for (int t = 0; t < numTimeSteps; ++t) {
+    if (std::fabs(seis_att.trace[t] - seis_noatt.trace[t]) > 1e-10f) {
       tracesIdentical = false;
       break;
     }
   }
-  EXPECT_FALSE(tracesIdentical)
-      << "Attenuated and non-attenuated receiver traces should differ";
+  EXPECT_FALSE(tracesIdentical) << "Attenuated and non-attenuated receiver traces should differ";
 
   // Compare maximum amplitude in the second half of the simulation
   // (after the wave has had time to propagate, reflect, and be damped).
   // The attenuated max should be smaller than the non-attenuated max.
   float maxSecondHalf_noatt = 0.0f;
   float maxSecondHalf_att = 0.0f;
-  for (int t = numTimeSteps / 2; t < numTimeSteps; ++t)
-  {
+  for (int t = numTimeSteps / 2; t < numTimeSteps; ++t) {
     maxSecondHalf_noatt = std::max(maxSecondHalf_noatt, absTrace_noatt[t]);
     maxSecondHalf_att = std::max(maxSecondHalf_att, absTrace_att[t]);
   }
   // After many reflections, the attenuated simulation should have
   // lower peak amplitude in the late part of the signal
-  EXPECT_GT(maxSecondHalf_noatt, 0.0f)
-      << "Non-attenuated trace should have arrivals in second half";
+  EXPECT_GT(maxSecondHalf_noatt, 0.0f) << "Non-attenuated trace should have arrivals in second half";
   // The ratio should show clear reduction
-  if (maxSecondHalf_noatt > 1e-15f)
-  {
+  if (maxSecondHalf_noatt > 1e-15f) {
     float ratio = maxSecondHalf_att / maxSecondHalf_noatt;
-    EXPECT_LT(ratio, 1.0f)
-        << "Attenuation should reduce late-time peak amplitude. "
-        << "max_noatt=" << maxSecondHalf_noatt
-        << ", max_att=" << maxSecondHalf_att << ", ratio=" << ratio;
+    EXPECT_LT(ratio, 1.0f) << "Attenuation should reduce late-time peak amplitude. "
+                           << "max_noatt=" << maxSecondHalf_noatt << ", max_att=" << maxSecondHalf_att
+                           << ", ratio=" << ratio;
   }
 }
 
 // ======================================================================
 // TEST: Elastic receiver trace shows amplitude decay with attenuation
 // ======================================================================
-TEST(AttenuationReceiver, ElasticReceiverTraceDecays)
-{
+TEST(AttenuationReceiver, ElasticReceiverTraceDecays) {
   const int numTimeSteps = 1500;
   const float dt = 0.0005f;
 
@@ -364,30 +314,23 @@ TEST(AttenuationReceiver, ElasticReceiverTraceDecays)
 
   // Run without attenuation
   auto mesh_noatt = buildReceiverMesh(true);
-  auto seis_noatt = runElasticWithReceiver(mesh_noatt, {}, numTimeSteps, dt,
-                                           sourceNode, receiverNode);
+  auto seis_noatt = runElasticWithReceiver(mesh_noatt, {}, numTimeSteps, dt, sourceNode, receiverNode);
 
   // Run with attenuation: Q=10, 1 SLS mechanism
   auto mesh_att = buildReceiverMesh(true, 10.0f, 10.0f);
   std::vector<float> freqs = {2.0f * static_cast<float>(M_PI) * 5.0f};
-  auto seis_att = runElasticWithReceiver(mesh_att, freqs, numTimeSteps, dt,
-                                         sourceNode, receiverNode);
+  auto seis_att = runElasticWithReceiver(mesh_att, freqs, numTimeSteps, dt, sourceNode, receiverNode);
 
   // Both traces should be finite
-  for (int t = 0; t < numTimeSteps; ++t)
-  {
-    ASSERT_TRUE(std::isfinite(seis_noatt.traceUz[t]))
-        << "Non-attenuated Uz trace NaN/Inf at step " << t;
-    ASSERT_TRUE(std::isfinite(seis_att.traceUz[t]))
-        << "Attenuated Uz trace NaN/Inf at step " << t;
+  for (int t = 0; t < numTimeSteps; ++t) {
+    ASSERT_TRUE(std::isfinite(seis_noatt.traceUz[t])) << "Non-attenuated Uz trace NaN/Inf at step " << t;
+    ASSERT_TRUE(std::isfinite(seis_att.traceUz[t])) << "Attenuated Uz trace NaN/Inf at step " << t;
   }
 
   // Verify the traces are different
   bool tracesIdentical = true;
-  for (int t = 0; t < numTimeSteps; ++t)
-  {
-    if (std::fabs(seis_att.traceUz[t] - seis_noatt.traceUz[t]) > 1e-10f)
-    {
+  for (int t = 0; t < numTimeSteps; ++t) {
+    if (std::fabs(seis_att.traceUz[t] - seis_noatt.traceUz[t]) > 1e-10f) {
       tracesIdentical = false;
       break;
     }
@@ -397,15 +340,13 @@ TEST(AttenuationReceiver, ElasticReceiverTraceDecays)
   // The elastic test should show clear energy decay
   EXPECT_LT(seis_att.finalNorm, seis_noatt.finalNorm)
       << "Elastic attenuation should reduce total wavefield energy. "
-      << "norm_noatt=" << seis_noatt.finalNorm
-      << ", norm_att=" << seis_att.finalNorm;
+      << "norm_noatt=" << seis_noatt.finalNorm << ", norm_att=" << seis_att.finalNorm;
 }
 
 // ======================================================================
 // TEST: Receiver trace with lower Q shows more attenuation than higher Q
 // ======================================================================
-TEST(AttenuationReceiver, LowerQStrongerAttenuation)
-{
+TEST(AttenuationReceiver, LowerQStrongerAttenuation) {
   const int numTimeSteps = 1500;
   const float dt = 0.0005f;
 
@@ -417,13 +358,11 @@ TEST(AttenuationReceiver, LowerQStrongerAttenuation)
 
   // Q=50 (weak attenuation)
   auto mesh_q50 = buildReceiverMesh(true, 50.0f, 50.0f);
-  auto seis_q50 = runElasticWithReceiver(mesh_q50, freqs, numTimeSteps, dt,
-                                         sourceNode, receiverNode);
+  auto seis_q50 = runElasticWithReceiver(mesh_q50, freqs, numTimeSteps, dt, sourceNode, receiverNode);
 
   // Q=10 (strong attenuation)
   auto mesh_q10 = buildReceiverMesh(true, 10.0f, 10.0f);
-  auto seis_q10 = runElasticWithReceiver(mesh_q10, freqs, numTimeSteps, dt,
-                                         sourceNode, receiverNode);
+  auto seis_q10 = runElasticWithReceiver(mesh_q10, freqs, numTimeSteps, dt, sourceNode, receiverNode);
 
   // Both should be stable
   EXPECT_TRUE(std::isfinite(seis_q50.finalNorm));
@@ -434,8 +373,7 @@ TEST(AttenuationReceiver, LowerQStrongerAttenuation)
   // Lower Q (stronger attenuation) should result in lower energy
   EXPECT_LT(seis_q10.finalNorm, seis_q50.finalNorm)
       << "Q=10 should attenuate more than Q=50. "
-      << "norm_q50=" << seis_q50.finalNorm
-      << ", norm_q10=" << seis_q10.finalNorm;
+      << "norm_q50=" << seis_q50.finalNorm << ", norm_q10=" << seis_q10.finalNorm;
 }
 
 // ======================================================================
@@ -445,8 +383,7 @@ TEST(AttenuationReceiver, LowerQStrongerAttenuation)
 // Source at center node (5,5,5) = 5 + 5*11 + 5*121 = 665
 // Receiver at (8,5,5) = 8 + 5*11 + 5*121 = 668
 // ======================================================================
-TEST(AttenuationReceiverHighOrder, AcousticOrder2Decays)
-{
+TEST(AttenuationReceiverHighOrder, AcousticOrder2Decays) {
   const int order = 2;
   const int numTimeSteps = 1500;
   const float dt = 0.0003f;
@@ -457,61 +394,49 @@ TEST(AttenuationReceiverHighOrder, AcousticOrder2Decays)
   const int receiverNode = 8 + 5 * nx + 5 * nx * nx;
 
   auto mesh_noatt = buildReceiverMesh(false, 1e9f, 1e9f, order);
-  auto seis_noatt = runAcousticWithReceiver(mesh_noatt, {}, numTimeSteps, dt,
-                                            sourceNode, receiverNode, order);
+  auto seis_noatt = runAcousticWithReceiver(mesh_noatt, {}, numTimeSteps, dt, sourceNode, receiverNode, order);
 
   auto mesh_att = buildReceiverMesh(false, 30.0f, 30.0f, order);
   std::vector<float> freqs = {2.0f * static_cast<float>(M_PI) * 10.0f};
-  auto seis_att = runAcousticWithReceiver(mesh_att, freqs, numTimeSteps, dt,
-                                          sourceNode, receiverNode, order);
+  auto seis_att = runAcousticWithReceiver(mesh_att, freqs, numTimeSteps, dt, sourceNode, receiverNode, order);
 
   // Stability check
-  for (int t = 0; t < numTimeSteps; ++t)
-  {
-    ASSERT_TRUE(std::isfinite(seis_noatt.trace[t]))
-        << "Order-2: Non-attenuated trace NaN/Inf at step " << t;
-    ASSERT_TRUE(std::isfinite(seis_att.trace[t]))
-        << "Order-2: Attenuated trace NaN/Inf at step " << t;
+  for (int t = 0; t < numTimeSteps; ++t) {
+    ASSERT_TRUE(std::isfinite(seis_noatt.trace[t])) << "Order-2: Non-attenuated trace NaN/Inf at step " << t;
+    ASSERT_TRUE(std::isfinite(seis_att.trace[t])) << "Order-2: Attenuated trace NaN/Inf at step " << t;
   }
 
   // Traces should differ
   bool tracesIdentical = true;
-  for (int t = 0; t < numTimeSteps; ++t)
-  {
-    if (std::fabs(seis_att.trace[t] - seis_noatt.trace[t]) > 1e-10f)
-    {
+  for (int t = 0; t < numTimeSteps; ++t) {
+    if (std::fabs(seis_att.trace[t] - seis_noatt.trace[t]) > 1e-10f) {
       tracesIdentical = false;
       break;
     }
   }
-  EXPECT_FALSE(tracesIdentical)
-      << "Order-2: attenuated and non-attenuated traces should differ";
+  EXPECT_FALSE(tracesIdentical) << "Order-2: attenuated and non-attenuated traces should differ";
 
   // Late-time amplitude: on bounded domains with higher-order elements,
   // SLS velocity dispersion can shift wave arrivals, so we verify the
   // wavefield is meaningfully altered rather than strictly reduced.
   float maxLate_noatt = 0.0f, maxLate_att = 0.0f;
-  for (int t = numTimeSteps / 2; t < numTimeSteps; ++t)
-  {
+  for (int t = numTimeSteps / 2; t < numTimeSteps; ++t) {
     maxLate_noatt = std::max(maxLate_noatt, std::fabs(seis_noatt.trace[t]));
     maxLate_att = std::max(maxLate_att, std::fabs(seis_att.trace[t]));
   }
   EXPECT_GT(maxLate_noatt, 0.0f);
   // Verify the late-time amplitudes differ (attenuation changes the signal)
-  if (maxLate_noatt > 1e-15f)
-  {
+  if (maxLate_noatt > 1e-15f) {
     float ratio = maxLate_att / maxLate_noatt;
-    EXPECT_NE(ratio, 1.0f)
-        << "Order-2: attenuation should change late-time amplitude. "
-        << "ratio=" << ratio;
+    EXPECT_NE(ratio, 1.0f) << "Order-2: attenuation should change late-time amplitude. "
+                           << "ratio=" << ratio;
   }
 }
 
 // ======================================================================
 // TEST: Order-2 elastic receiver - energy decay with attenuation
 // ======================================================================
-TEST(AttenuationReceiverHighOrder, ElasticOrder2Decays)
-{
+TEST(AttenuationReceiverHighOrder, ElasticOrder2Decays) {
   const int order = 2;
   const int numTimeSteps = 1000;
   const float dt = 0.0003f;
@@ -521,16 +446,13 @@ TEST(AttenuationReceiverHighOrder, ElasticOrder2Decays)
   const int receiverNode = 8 + 5 * nx + 5 * nx * nx;
 
   auto mesh_noatt = buildReceiverMesh(true, 1e9f, 1e9f, order);
-  auto seis_noatt = runElasticWithReceiver(mesh_noatt, {}, numTimeSteps, dt,
-                                           sourceNode, receiverNode, order);
+  auto seis_noatt = runElasticWithReceiver(mesh_noatt, {}, numTimeSteps, dt, sourceNode, receiverNode, order);
 
   auto mesh_att = buildReceiverMesh(true, 10.0f, 10.0f, order);
   std::vector<float> freqs = {2.0f * static_cast<float>(M_PI) * 5.0f};
-  auto seis_att = runElasticWithReceiver(mesh_att, freqs, numTimeSteps, dt,
-                                         sourceNode, receiverNode, order);
+  auto seis_att = runElasticWithReceiver(mesh_att, freqs, numTimeSteps, dt, sourceNode, receiverNode, order);
 
-  for (int t = 0; t < numTimeSteps; ++t)
-  {
+  for (int t = 0; t < numTimeSteps; ++t) {
     ASSERT_TRUE(std::isfinite(seis_noatt.traceUz[t]));
     ASSERT_TRUE(std::isfinite(seis_att.traceUz[t]));
   }
@@ -538,18 +460,14 @@ TEST(AttenuationReceiverHighOrder, ElasticOrder2Decays)
   // On bounded domains, SLS dispersion can shift wave arrivals so total
   // energy may not strictly decrease. Verify the wavefield is modified.
   bool tracesIdentical = true;
-  for (int t = 0; t < numTimeSteps; ++t)
-  {
-    if (std::fabs(seis_att.traceUz[t] - seis_noatt.traceUz[t]) > 1e-10f)
-    {
+  for (int t = 0; t < numTimeSteps; ++t) {
+    if (std::fabs(seis_att.traceUz[t] - seis_noatt.traceUz[t]) > 1e-10f) {
       tracesIdentical = false;
       break;
     }
   }
-  EXPECT_FALSE(tracesIdentical)
-      << "Order-2 elastic attenuation should change the wavefield";
-  EXPECT_TRUE(std::isfinite(seis_att.finalNorm))
-      << "Order-2 elastic attenuation should remain stable";
+  EXPECT_FALSE(tracesIdentical) << "Order-2 elastic attenuation should change the wavefield";
+  EXPECT_TRUE(std::isfinite(seis_att.finalNorm)) << "Order-2 elastic attenuation should remain stable";
 }
 
 }  // namespace test

--- a/tests/units/solver/impl/test_attenuation_reference.cc
+++ b/tests/units/solver/impl/test_attenuation_reference.cc
@@ -68,14 +68,10 @@
 #include "solver_factory.h"
 #include "wavefield_acoustic.h"
 
-namespace solver
-{
-namespace fe
-{
-namespace test
-{
-static VECTOR_REAL_VIEW toView(const std::vector<float>& v, const char* name)
-{
+namespace solver {
+namespace fe {
+namespace test {
+static VECTOR_REAL_VIEW toView(const std::vector<float>& v, const char* name) {
   if (v.empty()) return VECTOR_REAL_VIEW();
   auto view = allocateVector<VECTOR_REAL_VIEW>(v.size(), name);
   for (size_t i = 0; i < v.size(); ++i) view[i] = v[i];
@@ -85,13 +81,10 @@ static VECTOR_REAL_VIEW toView(const std::vector<float>& v, const char* name)
 // ======================================================================
 // Helper: build a 5x5x5 order-2 mesh with given Q factors
 // ======================================================================
-static std::shared_ptr<model::ModelApi<float, int>> buildRefMesh(
-    float qp = 1e9f, float qs = 1e9f)
-{
+static std::shared_ptr<model::ModelApi<float, int>> buildRefMesh(float qp = 1e9f, float qs = 1e9f) {
   constexpr int EX = 5, EY = 5, EZ = 5;
   constexpr float LX = 1000.0f, LY = 1000.0f, LZ = 1000.0f;
-  model::CartesianStructBuilder<float, int, 2> builder(EX, LX, EY, LY, EZ, LZ,
-                                                       false, false);
+  model::CartesianStructBuilder<float, int, 2> builder(EX, LX, EY, LY, EZ, LZ, false, false);
   auto mesh = builder.getModel(false);
   mesh->setQualityFactors(qp, qs);
   return mesh;
@@ -100,8 +93,7 @@ static std::shared_ptr<model::ModelApi<float, int>> buildRefMesh(
 // ======================================================================
 // Helper: total wavefield energy  E = sum_i p_i^2
 // ======================================================================
-static float totalEnergy(const VECTOR_REAL_VIEW& field, int numNodes)
-{
+static float totalEnergy(const VECTOR_REAL_VIEW& field, int numNodes) {
   float sum = 0.0f;
   for (int i = 0; i < numNodes; ++i) sum += field(i) * field(i);
   return sum;
@@ -110,20 +102,16 @@ static float totalEnergy(const VECTOR_REAL_VIEW& field, int numNodes)
 // ======================================================================
 // Helper: run acoustic simulation, recording energy at checkpoints
 // ======================================================================
-static std::vector<float> runAndRecordEnergy(
-    std::shared_ptr<model::ModelApi<float, int>> mesh,
-    const std::vector<float>& slsFreqs, int numTimeSteps, float dt,
-    const std::vector<int>& checkpoints)
-{
+static std::vector<float> runAndRecordEnergy(std::shared_ptr<model::ModelApi<float, int>> mesh,
+                                             const std::vector<float>& slsFreqs, int numTimeSteps, float dt,
+                                             const std::vector<int>& checkpoints) {
   constexpr int order = 2;
   int numNodes = mesh->getNumberOfNodes();
   int npp = (order + 1) * (order + 1) * (order + 1);
 
   auto solver = solver_factory::createSolver(
-      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu,
-      utils::enums::meshType::kStruct,
-      utils::enums::modelLocationType::kOnElements,
-      utils::enums::physicType::kAcoustic, order);
+      utils::enums::methodType::kSem, utils::enums::implemType::kMakutu, utils::enums::meshType::kStruct,
+      utils::enums::modelLocationType::kOnElements, utils::enums::physicType::kAcoustic, order);
   solver->setAnisotropyType(model::AnisotropyType::kIso);
 
   if (!slsFreqs.empty()) solver->setSLSAttenuation(toView(slsFreqs, "f"));
@@ -132,8 +120,7 @@ static std::vector<float> runAndRecordEnergy(
 
   auto pPrev = allocateVector<VECTOR_REAL_VIEW>(numNodes, "pP_ref");
   auto pCurr = allocateVector<VECTOR_REAL_VIEW>(numNodes, "pC_ref");
-  for (int i = 0; i < numNodes; ++i)
-  {
+  for (int i = 0; i < numNodes; ++i) {
     pPrev(i) = 0.0f;
     pCurr(i) = 0.0f;
   }
@@ -144,8 +131,7 @@ static std::vector<float> runAndRecordEnergy(
   auto rhsElem = allocateVector<VECTOR_INT_VIEW>(1, "re_ref");
   auto rhsWeights = allocateArray2D<ARRAY_REAL_VIEW>(1, npp, "rw_ref");
   rhsElem(0) = 0;
-  for (int j = 0; j < npp; ++j)
-  {
+  for (int j = 0; j < npp; ++j) {
     rhsTerm(0, j) = 0.0f;
     rhsWeights(0, j) = 0.0f;
   }
@@ -157,15 +143,12 @@ static std::vector<float> runAndRecordEnergy(
   std::vector<float> energies;
   int checkIdx = 0;
 
-  for (int t = 0; t < numTimeSteps; ++t)
-  {
+  for (int t = 0; t < numTimeSteps; ++t) {
     solver->computeForces(dt, t, data);
     solver->updateSolution(dt, data);
     data.swapWavefields();
 
-    if (checkIdx < static_cast<int>(checkpoints.size()) &&
-        t + 1 == checkpoints[checkIdx])
-    {
+    if (checkIdx < static_cast<int>(checkpoints.size()) && t + 1 == checkpoints[checkIdx]) {
       energies.push_back(totalEnergy(data.getCurrentField(0), numNodes));
       ++checkIdx;
     }
@@ -189,8 +172,7 @@ static std::vector<float> runAndRecordEnergy(
 //        (within a tolerance to account for the broadband source
 //        and absorbing-boundary interplay)
 // ======================================================================
-TEST(AttenuationReferenceAcoustic, Order2EnergyDecayScalesWithQ)
-{
+TEST(AttenuationReferenceAcoustic, Order2EnergyDecayScalesWithQ) {
   const int numTimeSteps = 1000;
   const float dt = 0.0003f;
 
@@ -210,25 +192,19 @@ TEST(AttenuationReferenceAcoustic, Order2EnergyDecayScalesWithQ)
 
   // ---- Run 2: Q = 20 ----
   auto mesh_q20 = buildRefMesh(20.0f, 20.0f);
-  auto E_q20 =
-      runAndRecordEnergy(mesh_q20, freqs, numTimeSteps, dt, checkpoints);
+  auto E_q20 = runAndRecordEnergy(mesh_q20, freqs, numTimeSteps, dt, checkpoints);
 
   // ---- Run 3: Q = 60 ----
   auto mesh_q60 = buildRefMesh(60.0f, 60.0f);
-  auto E_q60 =
-      runAndRecordEnergy(mesh_q60, freqs, numTimeSteps, dt, checkpoints);
+  auto E_q60 = runAndRecordEnergy(mesh_q60, freqs, numTimeSteps, dt, checkpoints);
 
   // ==== Assertions ====
 
   // 1. All energies must be finite and positive
-  for (size_t i = 0; i < checkpoints.size(); ++i)
-  {
-    ASSERT_TRUE(std::isfinite(E_ref[i]))
-        << "Reference energy not finite at checkpoint " << i;
-    ASSERT_TRUE(std::isfinite(E_q20[i]))
-        << "Q=20 energy not finite at checkpoint " << i;
-    ASSERT_TRUE(std::isfinite(E_q60[i]))
-        << "Q=60 energy not finite at checkpoint " << i;
+  for (size_t i = 0; i < checkpoints.size(); ++i) {
+    ASSERT_TRUE(std::isfinite(E_ref[i])) << "Reference energy not finite at checkpoint " << i;
+    ASSERT_TRUE(std::isfinite(E_q20[i])) << "Q=20 energy not finite at checkpoint " << i;
+    ASSERT_TRUE(std::isfinite(E_q60[i])) << "Q=60 energy not finite at checkpoint " << i;
     ASSERT_GT(E_ref[i], 0.0f);
     ASSERT_GT(E_q20[i], 0.0f);
     ASSERT_GT(E_q60[i], 0.0f);
@@ -237,15 +213,12 @@ TEST(AttenuationReferenceAcoustic, Order2EnergyDecayScalesWithQ)
   // 2. Both attenuated runs should have less energy than reference
   //    at the last checkpoint (earliest checkpoints may not yet show
   //    a clear difference if the wave hasn't propagated far enough).
-  EXPECT_LT(E_q20.back(), E_ref.back())
-      << "Q=20 should have less energy than reference";
-  EXPECT_LT(E_q60.back(), E_ref.back())
-      << "Q=60 should have less energy than reference";
+  EXPECT_LT(E_q20.back(), E_ref.back()) << "Q=20 should have less energy than reference";
+  EXPECT_LT(E_q60.back(), E_ref.back()) << "Q=60 should have less energy than reference";
 
   // 3. Q = 20 should lose more energy than Q = 60 at last checkpoint
-  EXPECT_LT(E_q20.back(), E_q60.back())
-      << "Q=20 should have less energy than Q=60" << " (E_Q20=" << E_q20.back()
-      << ", E_Q60=" << E_q60.back() << ")";
+  EXPECT_LT(E_q20.back(), E_q60.back()) << "Q=20 should have less energy than Q=60" << " (E_Q20=" << E_q20.back()
+                                        << ", E_Q60=" << E_q60.back() << ")";
 
   // 4. Quantitative scaling check at the last checkpoint.
   //
@@ -259,35 +232,27 @@ TEST(AttenuationReferenceAcoustic, Order2EnergyDecayScalesWithQ)
   float lnR20 = std::log(E_q20.back() / E_ref.back());
   float lnR60 = std::log(E_q60.back() / E_ref.back());
 
-  ASSERT_LT(lnR60, 0.0f)
-      << "Q=60 log-ratio should be negative (energy decreasing)";
-  ASSERT_LT(lnR20, lnR60)
-      << "Q=20 should have a more negative log-ratio than Q=60";
+  ASSERT_LT(lnR60, 0.0f) << "Q=60 log-ratio should be negative (energy decreasing)";
+  ASSERT_LT(lnR20, lnR60) << "Q=20 should have a more negative log-ratio than Q=60";
 
   float scalingRatio = lnR20 / lnR60;
 
-  EXPECT_GT(scalingRatio, 2.0f) << "Q-scaling ratio too low: " << scalingRatio
-                                << " (expected ~3.0 = Q60/Q20)";
-  EXPECT_LT(scalingRatio, 5.0f) << "Q-scaling ratio too high: " << scalingRatio
-                                << " (expected ~3.0 = Q60/Q20)";
+  EXPECT_GT(scalingRatio, 2.0f) << "Q-scaling ratio too low: " << scalingRatio << " (expected ~3.0 = Q60/Q20)";
+  EXPECT_LT(scalingRatio, 5.0f) << "Q-scaling ratio too high: " << scalingRatio << " (expected ~3.0 = Q60/Q20)";
 
   // ---- Diagnostic output ----
   std::cout << "\n=== Acoustic Attenuation Reference Test (Order 2) ===\n"
             << "Domain: 1000 m cube, 5x5x5 elements, order 2\n"
             << "Material: Vp = 1500 m/s, rho = 1 kg/m^3\n"
             << "SLS: 1 mechanism at f0 = 10 Hz\n"
-            << "dt = " << dt << " s, steps = " << numTimeSteps
-            << ", T = " << dt * numTimeSteps << " s\n\n";
-  for (size_t i = 0; i < checkpoints.size(); ++i)
-  {
+            << "dt = " << dt << " s, steps = " << numTimeSteps << ", T = " << dt * numTimeSteps << " s\n\n";
+  for (size_t i = 0; i < checkpoints.size(); ++i) {
     float t = checkpoints[i] * dt;
-    std::cout << "  t = " << t << " s : " << "E_ref = " << E_ref[i]
-              << "  E_Q20 = " << E_q20[i] << "  E_Q60 = " << E_q60[i]
-              << "  R20 = " << E_q20[i] / E_ref[i]
-              << "  R60 = " << E_q60[i] / E_ref[i] << "\n";
+    std::cout << "  t = " << t << " s : " << "E_ref = " << E_ref[i] << "  E_Q20 = " << E_q20[i]
+              << "  E_Q60 = " << E_q60[i] << "  R20 = " << E_q20[i] / E_ref[i] << "  R60 = " << E_q60[i] / E_ref[i]
+              << "\n";
   }
-  std::cout << "\n  Q-scaling ratio: ln(R20)/ln(R60) = " << scalingRatio
-            << " (theoretical: " << 60.0 / 20.0 << ")\n"
+  std::cout << "\n  Q-scaling ratio: ln(R20)/ln(R60) = " << scalingRatio << " (theoretical: " << 60.0 / 20.0 << ")\n"
             << "=====================================================\n\n";
 }
 

--- a/tests/units/solver/impl/test_gradients_acoustic.cc
+++ b/tests/units/solver/impl/test_gradients_acoustic.cc
@@ -4,41 +4,30 @@
 #include "data_type.h"
 #include "gradients_acoustic.h"
 
-namespace solver
-{
-namespace fe
-{
-namespace test
-{
+namespace solver {
+namespace fe {
+namespace test {
 
-class GradientsAcousticTest : public ::testing::Test
-{
+class GradientsAcousticTest : public ::testing::Test {
  protected:
-  void SetUp() override
-  {
+  void SetUp() override {
     // Create test vectors for gradients
     num_elements = 10;
     num_nodes = 100;
 
     // Allocate gradient vectors
-    grad_kappa_elem =
-        allocateVector<VECTOR_REAL_VIEW>(num_elements, "grad_kappa_elem");
-    grad_buoyancy_elem =
-        allocateVector<VECTOR_REAL_VIEW>(num_elements, "grad_buoyancy_elem");
-    grad_kappa_node =
-        allocateVector<VECTOR_REAL_VIEW>(num_nodes, "grad_kappa_node");
-    grad_buoyancy_node =
-        allocateVector<VECTOR_REAL_VIEW>(num_nodes, "grad_buoyancy_node");
+    grad_kappa_elem = allocateVector<VECTOR_REAL_VIEW>(num_elements, "grad_kappa_elem");
+    grad_buoyancy_elem = allocateVector<VECTOR_REAL_VIEW>(num_elements, "grad_buoyancy_elem");
+    grad_kappa_node = allocateVector<VECTOR_REAL_VIEW>(num_nodes, "grad_kappa_node");
+    grad_buoyancy_node = allocateVector<VECTOR_REAL_VIEW>(num_nodes, "grad_buoyancy_node");
 
     // Initialize with test values
-    for (size_t i = 0; i < num_elements; ++i)
-    {
+    for (size_t i = 0; i < num_elements; ++i) {
       grad_kappa_elem(i) = i * 1.5f;
       grad_buoyancy_elem(i) = i * 2.5f;
     }
 
-    for (size_t i = 0; i < num_nodes; ++i)
-    {
+    for (size_t i = 0; i < num_nodes; ++i) {
       grad_kappa_node(i) = i * 0.5f;
       grad_buoyancy_node(i) = i * 1.0f;
     }
@@ -52,23 +41,20 @@ class GradientsAcousticTest : public ::testing::Test
   VECTOR_REAL_VIEW grad_buoyancy_node;
 };
 
-TEST_F(GradientsAcousticTest, Constructor)
-{
+TEST_F(GradientsAcousticTest, Constructor) {
   GradientsAcoustic gradients(grad_kappa_elem, grad_buoyancy_elem);
 
   EXPECT_EQ(gradients.m_gradKappa.extent(0), num_elements);
   EXPECT_EQ(gradients.m_gradBuoyancy.extent(0), num_elements);
 }
 
-TEST_F(GradientsAcousticTest, GetNumGrads)
-{
+TEST_F(GradientsAcousticTest, GetNumGrads) {
   GradientsAcoustic gradients(grad_kappa_elem, grad_buoyancy_elem);
 
   EXPECT_EQ(gradients.getNumGrads(), 2);
 }
 
-TEST_F(GradientsAcousticTest, GetGradsNames)
-{
+TEST_F(GradientsAcousticTest, GetGradsNames) {
   GradientsAcoustic gradients(grad_kappa_elem, grad_buoyancy_elem);
 
   const char* const* names = gradients.getGradsNames();
@@ -76,38 +62,33 @@ TEST_F(GradientsAcousticTest, GetGradsNames)
   EXPECT_STREQ(names[1], "gradBuoyancy");
 }
 
-TEST_F(GradientsAcousticTest, GetCurrentGrads)
-{
+TEST_F(GradientsAcousticTest, GetCurrentGrads) {
   GradientsAcoustic gradients(grad_kappa_elem, grad_buoyancy_elem);
 
   auto grad_kappa = gradients.getCurrentGrads(0);
   auto grad_buoyancy = gradients.getCurrentGrads(1);
 
   // Verify data access
-  for (size_t i = 0; i < num_elements; ++i)
-  {
+  for (size_t i = 0; i < num_elements; ++i) {
     EXPECT_FLOAT_EQ(grad_kappa(i), i * 1.5f);
     EXPECT_FLOAT_EQ(grad_buoyancy(i), i * 2.5f);
   }
 }
 
-TEST_F(GradientsAcousticTest, NodeBasedGradients)
-{
+TEST_F(GradientsAcousticTest, NodeBasedGradients) {
   GradientsAcoustic gradients(grad_kappa_node, grad_buoyancy_node);
 
   auto grad_kappa = gradients.getCurrentGrads(0);
   auto grad_buoyancy = gradients.getCurrentGrads(1);
 
   // Verify node-based access
-  for (size_t i = 0; i < num_nodes; ++i)
-  {
+  for (size_t i = 0; i < num_nodes; ++i) {
     EXPECT_FLOAT_EQ(grad_kappa(i), i * 0.5f);
     EXPECT_FLOAT_EQ(grad_buoyancy(i), i * 1.0f);
   }
 }
 
-TEST_F(GradientsAcousticTest, OutOfBoundsAccess)
-{
+TEST_F(GradientsAcousticTest, OutOfBoundsAccess) {
   GradientsAcoustic gradients(grad_kappa_elem, grad_buoyancy_elem);
 
   // Accessing out-of-bounds gradient index should return first gradient
@@ -115,8 +96,7 @@ TEST_F(GradientsAcousticTest, OutOfBoundsAccess)
   EXPECT_EQ(fallback.extent(0), num_elements);
 }
 
-TEST_F(GradientsAcousticTest, AccumulationPattern)
-{
+TEST_F(GradientsAcousticTest, AccumulationPattern) {
   // Test that gradients can be accumulated/modified
   GradientsAcoustic gradients(grad_kappa_elem, grad_buoyancy_elem);
 

--- a/tests/units/solver/impl/test_gradients_elastic.cc
+++ b/tests/units/solver/impl/test_gradients_elastic.cc
@@ -4,48 +4,36 @@
 #include "data_type.h"
 #include "gradients_elastic.h"
 
-namespace solver
-{
-namespace fe
-{
-namespace test
-{
+namespace solver {
+namespace fe {
+namespace test {
 
-class GradientsElasticTest : public ::testing::Test
-{
+class GradientsElasticTest : public ::testing::Test {
  protected:
-  void SetUp() override
-  {
+  void SetUp() override {
     // Create test vectors for gradients
     num_elements = 10;
     num_nodes = 100;
 
     // Allocate element-based gradient vectors
-    grad_rho_elem =
-        allocateVector<VECTOR_REAL_VIEW>(num_elements, "grad_rho_elem");
-    grad_lambda_elem =
-        allocateVector<VECTOR_REAL_VIEW>(num_elements, "grad_lambda_elem");
-    grad_mu_elem =
-        allocateVector<VECTOR_REAL_VIEW>(num_elements, "grad_mu_elem");
+    grad_rho_elem = allocateVector<VECTOR_REAL_VIEW>(num_elements, "grad_rho_elem");
+    grad_lambda_elem = allocateVector<VECTOR_REAL_VIEW>(num_elements, "grad_lambda_elem");
+    grad_mu_elem = allocateVector<VECTOR_REAL_VIEW>(num_elements, "grad_mu_elem");
 
     // Allocate node-based gradient vectors
-    grad_rho_node =
-        allocateVector<VECTOR_REAL_VIEW>(num_nodes, "grad_rho_node");
-    grad_lambda_node =
-        allocateVector<VECTOR_REAL_VIEW>(num_nodes, "grad_lambda_node");
+    grad_rho_node = allocateVector<VECTOR_REAL_VIEW>(num_nodes, "grad_rho_node");
+    grad_lambda_node = allocateVector<VECTOR_REAL_VIEW>(num_nodes, "grad_lambda_node");
     grad_mu_node = allocateVector<VECTOR_REAL_VIEW>(num_nodes, "grad_mu_node");
 
     // Initialize element-based gradients
-    for (size_t i = 0; i < num_elements; ++i)
-    {
+    for (size_t i = 0; i < num_elements; ++i) {
       grad_rho_elem(i) = i * 1.0f;
       grad_lambda_elem(i) = i * 2.0f;
       grad_mu_elem(i) = i * 3.0f;
     }
 
     // Initialize node-based gradients
-    for (size_t i = 0; i < num_nodes; ++i)
-    {
+    for (size_t i = 0; i < num_nodes; ++i) {
       grad_rho_node(i) = i * 0.1f;
       grad_lambda_node(i) = i * 0.2f;
       grad_mu_node(i) = i * 0.3f;
@@ -62,8 +50,7 @@ class GradientsElasticTest : public ::testing::Test
   VECTOR_REAL_VIEW grad_mu_node;
 };
 
-TEST_F(GradientsElasticTest, Constructor)
-{
+TEST_F(GradientsElasticTest, Constructor) {
   GradientsElastic gradients(grad_rho_elem, grad_lambda_elem, grad_mu_elem);
 
   EXPECT_EQ(gradients.m_gradRho.extent(0), num_elements);
@@ -71,15 +58,13 @@ TEST_F(GradientsElasticTest, Constructor)
   EXPECT_EQ(gradients.m_gradMu.extent(0), num_elements);
 }
 
-TEST_F(GradientsElasticTest, GetNumGrads)
-{
+TEST_F(GradientsElasticTest, GetNumGrads) {
   GradientsElastic gradients(grad_rho_elem, grad_lambda_elem, grad_mu_elem);
 
   EXPECT_EQ(gradients.getNumGrads(), 3);
 }
 
-TEST_F(GradientsElasticTest, GetGradsNames)
-{
+TEST_F(GradientsElasticTest, GetGradsNames) {
   GradientsElastic gradients(grad_rho_elem, grad_lambda_elem, grad_mu_elem);
 
   const char* const* names = gradients.getGradsNames();
@@ -88,8 +73,7 @@ TEST_F(GradientsElasticTest, GetGradsNames)
   EXPECT_STREQ(names[2], "gradMu");
 }
 
-TEST_F(GradientsElasticTest, GetCurrentGradsElement)
-{
+TEST_F(GradientsElasticTest, GetCurrentGradsElement) {
   GradientsElastic gradients(grad_rho_elem, grad_lambda_elem, grad_mu_elem);
 
   auto grad_rho = gradients.getCurrentGrads(0);
@@ -97,16 +81,14 @@ TEST_F(GradientsElasticTest, GetCurrentGradsElement)
   auto grad_mu = gradients.getCurrentGrads(2);
 
   // Verify element-based data access
-  for (size_t i = 0; i < num_elements; ++i)
-  {
+  for (size_t i = 0; i < num_elements; ++i) {
     EXPECT_FLOAT_EQ(grad_rho(i), i * 1.0f);
     EXPECT_FLOAT_EQ(grad_lambda(i), i * 2.0f);
     EXPECT_FLOAT_EQ(grad_mu(i), i * 3.0f);
   }
 }
 
-TEST_F(GradientsElasticTest, GetCurrentGradsNode)
-{
+TEST_F(GradientsElasticTest, GetCurrentGradsNode) {
   GradientsElastic gradients(grad_rho_node, grad_lambda_node, grad_mu_node);
 
   auto grad_rho = gradients.getCurrentGrads(0);
@@ -114,16 +96,14 @@ TEST_F(GradientsElasticTest, GetCurrentGradsNode)
   auto grad_mu = gradients.getCurrentGrads(2);
 
   // Verify node-based data access
-  for (size_t i = 0; i < num_nodes; ++i)
-  {
+  for (size_t i = 0; i < num_nodes; ++i) {
     EXPECT_FLOAT_EQ(grad_rho(i), i * 0.1f);
     EXPECT_FLOAT_EQ(grad_lambda(i), i * 0.2f);
     EXPECT_FLOAT_EQ(grad_mu(i), i * 0.3f);
   }
 }
 
-TEST_F(GradientsElasticTest, MixedAccess)
-{
+TEST_F(GradientsElasticTest, MixedAccess) {
   GradientsElastic gradients(grad_rho_elem, grad_lambda_elem, grad_mu_elem);
 
   auto grad_rho = gradients.getCurrentGrads(0);
@@ -137,8 +117,7 @@ TEST_F(GradientsElasticTest, MixedAccess)
   EXPECT_FLOAT_EQ(grad_lambda(5), 10.0f);
 }
 
-TEST_F(GradientsElasticTest, OutOfBoundsAccess)
-{
+TEST_F(GradientsElasticTest, OutOfBoundsAccess) {
   GradientsElastic gradients(grad_rho_elem, grad_lambda_elem, grad_mu_elem);
 
   // Accessing out-of-bounds gradient index should return first gradient
@@ -146,8 +125,7 @@ TEST_F(GradientsElasticTest, OutOfBoundsAccess)
   EXPECT_EQ(fallback.extent(0), num_elements);
 }
 
-TEST_F(GradientsElasticTest, Print)
-{
+TEST_F(GradientsElasticTest, Print) {
   GradientsElastic gradients(grad_rho_elem, grad_lambda_elem, grad_mu_elem);
 
   // Just verify print() doesn't crash

--- a/tests/units/solver/impl/test_mpi_partitioning.cc
+++ b/tests/units/solver/impl/test_mpi_partitioning.cc
@@ -4,17 +4,14 @@
 #include "cartesian_params.h"
 #include "cartesian_partitioner.h"
 
-class MPIPartitionerTest : public ::testing::Test
-{
+class MPIPartitionerTest : public ::testing::Test {
  protected:
-  static void SetUpTestSuite()
-  {
+  static void SetUpTestSuite() {
     // MPI is initialized by GTest main or we assume it's initialized
   }
 };
 
-TEST_F(MPIPartitionerTest, SumLocalElementsEqualsGlobal)
-{
+TEST_F(MPIPartitionerTest, SumLocalElementsEqualsGlobal) {
   int rank, size;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &size);
@@ -49,27 +46,23 @@ TEST_F(MPIPartitionerTest, SumLocalElementsEqualsGlobal)
   // Verify Origin Shifts
   // Gather all origins
   std::vector<float> origins(size);
-  MPI_Allgather(&local.origin_x, 1, MPI_FLOAT, origins.data(), 1, MPI_FLOAT,
-                MPI_COMM_WORLD);
+  MPI_Allgather(&local.origin_x, 1, MPI_FLOAT, origins.data(), 1, MPI_FLOAT, MPI_COMM_WORLD);
 
   // Check contiguous
-  if (rank == 0)
-  {
+  if (rank == 0) {
     float current_x = 0.0;
     float dx = global.lx / global.ex;
 
     // We can't easily check exact origin without knowing the split count per
     // rank, but we can check order.
-    for (int r = 0; r < size; ++r)
-    {
+    for (int r = 0; r < size; ++r) {
       EXPECT_GE(origins[r], current_x - 0.001);  // should be increasing
       current_x = origins[r];
     }
   }
 }
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   MPI_Init(&argc, &argv);
   int result = RUN_ALL_TESTS();

--- a/tests/units/solver/impl/test_rhs_acoustic.cc
+++ b/tests/units/solver/impl/test_rhs_acoustic.cc
@@ -4,48 +4,37 @@
 #include "data_type.h"
 #include "rhs_acoustic.h"
 
-namespace solver
-{
-namespace fe
-{
-namespace test
-{
+namespace solver {
+namespace fe {
+namespace test {
 
-class RhsAcousticTest : public ::testing::Test
-{
+class RhsAcousticTest : public ::testing::Test {
  protected:
-  void SetUp() override
-  {
+  void SetUp() override {
     // Create test data with specific sizes
     numElements = 10;
     numNodesPerElement = 8;
 
-    term = allocateArray2D<ARRAY_REAL_VIEW>(numElements, numNodesPerElement,
-                                            "term");
+    term = allocateArray2D<ARRAY_REAL_VIEW>(numElements, numNodesPerElement, "term");
     element = allocateVector<VECTOR_INT_VIEW>(numElements, "element");
-    weights = allocateArray2D<ARRAY_REAL_VIEW>(numElements, numNodesPerElement,
-                                               "weights");
+    weights = allocateArray2D<ARRAY_REAL_VIEW>(numElements, numNodesPerElement, "weights");
 
     term2 = allocateArray2D<ARRAY_REAL_VIEW>(20, 12, "term2");
     element2 = allocateVector<VECTOR_INT_VIEW>(20, "element2");
     weights2 = allocateArray2D<ARRAY_REAL_VIEW>(20, 12, "weights2");
 
     // Initialize with test values
-    for (size_t i = 0; i < numElements; ++i)
-    {
+    for (size_t i = 0; i < numElements; ++i) {
       element(i) = i * 10;
-      for (size_t j = 0; j < numNodesPerElement; ++j)
-      {
+      for (size_t j = 0; j < numNodesPerElement; ++j) {
         term(i, j) = i * 100 + j;
         weights(i, j) = i + j * 0.1;
       }
     }
 
-    for (size_t i = 0; i < 20; ++i)
-    {
+    for (size_t i = 0; i < 20; ++i) {
       element2(i) = i * 5;
-      for (size_t j = 0; j < 12; ++j)
-      {
+      for (size_t j = 0; j < 12; ++j) {
         term2(i, j) = i * 50 + j;
         weights2(i, j) = i * 2 + j * 0.2;
       }
@@ -59,8 +48,7 @@ class RhsAcousticTest : public ::testing::Test
   ARRAY_REAL_VIEW weights, weights2;
 };
 
-TEST_F(RhsAcousticTest, Constructor)
-{
+TEST_F(RhsAcousticTest, Constructor) {
   RhsAcoustic rhs(term, element, weights);
 
   EXPECT_EQ(rhs.m_term.extent(0), numElements);
@@ -70,19 +58,16 @@ TEST_F(RhsAcousticTest, Constructor)
   EXPECT_EQ(rhs.m_weights.extent(1), numNodesPerElement);
 
   // Verify data is correctly stored
-  for (size_t i = 0; i < numElements; ++i)
-  {
+  for (size_t i = 0; i < numElements; ++i) {
     EXPECT_EQ(rhs.m_element(i), i * 10);
-    for (size_t j = 0; j < numNodesPerElement; ++j)
-    {
+    for (size_t j = 0; j < numNodesPerElement; ++j) {
       EXPECT_FLOAT_EQ(rhs.m_term(i, j), i * 100 + j);
       EXPECT_FLOAT_EQ(rhs.m_weights(i, j), i + j * 0.1);
     }
   }
 }
 
-TEST_F(RhsAcousticTest, CopyConstructor)
-{
+TEST_F(RhsAcousticTest, CopyConstructor) {
   RhsAcoustic original(term, element, weights);
   RhsAcoustic copy(original);
 
@@ -94,11 +79,9 @@ TEST_F(RhsAcousticTest, CopyConstructor)
   EXPECT_EQ(copy.m_weights.extent(1), original.m_weights.extent(1));
 
   // Check that copy has the same data
-  for (size_t i = 0; i < numElements; ++i)
-  {
+  for (size_t i = 0; i < numElements; ++i) {
     EXPECT_EQ(copy.m_element(i), original.m_element(i));
-    for (size_t j = 0; j < numNodesPerElement; ++j)
-    {
+    for (size_t j = 0; j < numNodesPerElement; ++j) {
       EXPECT_FLOAT_EQ(copy.m_term(i, j), original.m_term(i, j));
       EXPECT_FLOAT_EQ(copy.m_weights(i, j), original.m_weights(i, j));
     }
@@ -114,8 +97,7 @@ TEST_F(RhsAcousticTest, CopyConstructor)
   EXPECT_FLOAT_EQ(copy.m_weights(2, 3), 777.0f);
 }
 
-TEST_F(RhsAcousticTest, CopyAssignmentOperator)
-{
+TEST_F(RhsAcousticTest, CopyAssignmentOperator) {
   RhsAcoustic rhs1(term, element, weights);
   RhsAcoustic rhs2(term2, element2, weights2);
 
@@ -135,11 +117,9 @@ TEST_F(RhsAcousticTest, CopyAssignmentOperator)
   EXPECT_EQ(rhs2.m_weights.extent(1), numNodesPerElement);
 
   // Check that data matches
-  for (size_t i = 0; i < numElements; ++i)
-  {
+  for (size_t i = 0; i < numElements; ++i) {
     EXPECT_EQ(rhs2.m_element(i), rhs1.m_element(i));
-    for (size_t j = 0; j < numNodesPerElement; ++j)
-    {
+    for (size_t j = 0; j < numNodesPerElement; ++j) {
       EXPECT_FLOAT_EQ(rhs2.m_term(i, j), rhs1.m_term(i, j));
       EXPECT_FLOAT_EQ(rhs2.m_weights(i, j), rhs1.m_weights(i, j));
     }
@@ -153,8 +133,7 @@ TEST_F(RhsAcousticTest, CopyAssignmentOperator)
   EXPECT_EQ(rhs2.m_element(1), 666);
 }
 
-TEST_F(RhsAcousticTest, CopyAssignmentSelfAssignment)
-{
+TEST_F(RhsAcousticTest, CopyAssignmentSelfAssignment) {
   RhsAcoustic rhs(term, element, weights);
 
   // Self-assignment should not cause issues
@@ -165,19 +144,16 @@ TEST_F(RhsAcousticTest, CopyAssignmentSelfAssignment)
   EXPECT_EQ(rhs.m_term.extent(1), numNodesPerElement);
   EXPECT_EQ(rhs.m_element.extent(0), numElements);
 
-  for (size_t i = 0; i < numElements; ++i)
-  {
+  for (size_t i = 0; i < numElements; ++i) {
     EXPECT_EQ(rhs.m_element(i), i * 10);
-    for (size_t j = 0; j < numNodesPerElement; ++j)
-    {
+    for (size_t j = 0; j < numNodesPerElement; ++j) {
       EXPECT_FLOAT_EQ(rhs.m_term(i, j), i * 100 + j);
       EXPECT_FLOAT_EQ(rhs.m_weights(i, j), i + j * 0.1);
     }
   }
 }
 
-TEST_F(RhsAcousticTest, GetTerm)
-{
+TEST_F(RhsAcousticTest, GetTerm) {
   RhsAcoustic rhs(term, element, weights);
 
   // For acoustic, getTerm should return the same term regardless of index
@@ -190,10 +166,8 @@ TEST_F(RhsAcousticTest, GetTerm)
   EXPECT_EQ(term1.extent(0), numElements);
   EXPECT_EQ(term2.extent(0), numElements);
 
-  for (size_t i = 0; i < numElements; ++i)
-  {
-    for (size_t j = 0; j < numNodesPerElement; ++j)
-    {
+  for (size_t i = 0; i < numElements; ++i) {
+    for (size_t j = 0; j < numNodesPerElement; ++j) {
       EXPECT_FLOAT_EQ(term0(i, j), i * 100 + j);
       EXPECT_FLOAT_EQ(term1(i, j), i * 100 + j);
       EXPECT_FLOAT_EQ(term2(i, j), i * 100 + j);
@@ -201,38 +175,32 @@ TEST_F(RhsAcousticTest, GetTerm)
   }
 }
 
-TEST_F(RhsAcousticTest, GetElement)
-{
+TEST_F(RhsAcousticTest, GetElement) {
   RhsAcoustic rhs(term, element, weights);
 
   auto elem = rhs.getElement();
 
   EXPECT_EQ(elem.extent(0), numElements);
-  for (size_t i = 0; i < numElements; ++i)
-  {
+  for (size_t i = 0; i < numElements; ++i) {
     EXPECT_EQ(elem(i), i * 10);
   }
 }
 
-TEST_F(RhsAcousticTest, GetWeights)
-{
+TEST_F(RhsAcousticTest, GetWeights) {
   RhsAcoustic rhs(term, element, weights);
 
   auto w = rhs.getWeights();
 
   EXPECT_EQ(w.extent(0), numElements);
   EXPECT_EQ(w.extent(1), numNodesPerElement);
-  for (size_t i = 0; i < numElements; ++i)
-  {
-    for (size_t j = 0; j < numNodesPerElement; ++j)
-    {
+  for (size_t i = 0; i < numElements; ++i) {
+    for (size_t j = 0; j < numNodesPerElement; ++j) {
       EXPECT_FLOAT_EQ(w(i, j), i + j * 0.1);
     }
   }
 }
 
-TEST_F(RhsAcousticTest, EmptyFields)
-{
+TEST_F(RhsAcousticTest, EmptyFields) {
   auto emptyTerm = allocateArray2D<ARRAY_REAL_VIEW>(0, 0, "emptyTerm");
   auto emptyElement = allocateVector<VECTOR_INT_VIEW>(0, "emptyElement");
   auto emptyWeights = allocateArray2D<ARRAY_REAL_VIEW>(0, 0, "emptyWeights");
@@ -244,8 +212,7 @@ TEST_F(RhsAcousticTest, EmptyFields)
   EXPECT_EQ(rhs.m_weights.extent(0), 0);
 }
 
-TEST_F(RhsAcousticTest, ModifyAfterConstruction)
-{
+TEST_F(RhsAcousticTest, ModifyAfterConstruction) {
   RhsAcoustic rhs(term, element, weights);
 
   // Modify data through the RHS object
@@ -264,11 +231,9 @@ TEST_F(RhsAcousticTest, ModifyAfterConstruction)
   EXPECT_FLOAT_EQ(weights(2, 1), 0.999f);
 }
 
-TEST_F(RhsAcousticTest, CopyInContainerClass)
-{
+TEST_F(RhsAcousticTest, CopyInContainerClass) {
   // Create a simple container class that stores rhs by copy
-  struct RhsContainer
-  {
+  struct RhsContainer {
     RhsAcoustic rhs;
 
     RhsContainer(const RhsAcoustic& r) : rhs(r) {}

--- a/tests/units/solver/impl/test_rhs_elastic.cc
+++ b/tests/units/solver/impl/test_rhs_elastic.cc
@@ -4,31 +4,22 @@
 #include "data_type.h"
 #include "rhs_elastic.h"
 
-namespace solver
-{
-namespace fe
-{
-namespace test
-{
+namespace solver {
+namespace fe {
+namespace test {
 
-class RhsElasticTest : public ::testing::Test
-{
+class RhsElasticTest : public ::testing::Test {
  protected:
-  void SetUp() override
-  {
+  void SetUp() override {
     // Create test data with specific sizes
     numElements = 10;
     numNodesPerElement = 8;
 
-    termx = allocateArray2D<ARRAY_REAL_VIEW>(numElements, numNodesPerElement,
-                                             "termx");
-    termy = allocateArray2D<ARRAY_REAL_VIEW>(numElements, numNodesPerElement,
-                                             "termy");
-    termz = allocateArray2D<ARRAY_REAL_VIEW>(numElements, numNodesPerElement,
-                                             "termz");
+    termx = allocateArray2D<ARRAY_REAL_VIEW>(numElements, numNodesPerElement, "termx");
+    termy = allocateArray2D<ARRAY_REAL_VIEW>(numElements, numNodesPerElement, "termy");
+    termz = allocateArray2D<ARRAY_REAL_VIEW>(numElements, numNodesPerElement, "termz");
     element = allocateVector<VECTOR_INT_VIEW>(numElements, "element");
-    weights = allocateArray2D<ARRAY_REAL_VIEW>(numElements, numNodesPerElement,
-                                               "weights");
+    weights = allocateArray2D<ARRAY_REAL_VIEW>(numElements, numNodesPerElement, "weights");
 
     termx2 = allocateArray2D<ARRAY_REAL_VIEW>(20, 12, "termx2");
     termy2 = allocateArray2D<ARRAY_REAL_VIEW>(20, 12, "termy2");
@@ -37,11 +28,9 @@ class RhsElasticTest : public ::testing::Test
     weights2 = allocateArray2D<ARRAY_REAL_VIEW>(20, 12, "weights2");
 
     // Initialize with test values
-    for (size_t i = 0; i < numElements; ++i)
-    {
+    for (size_t i = 0; i < numElements; ++i) {
       element(i) = i * 10;
-      for (size_t j = 0; j < numNodesPerElement; ++j)
-      {
+      for (size_t j = 0; j < numNodesPerElement; ++j) {
         termx(i, j) = i * 100 + j;
         termy(i, j) = i * 200 + j;
         termz(i, j) = i * 300 + j;
@@ -49,11 +38,9 @@ class RhsElasticTest : public ::testing::Test
       }
     }
 
-    for (size_t i = 0; i < 20; ++i)
-    {
+    for (size_t i = 0; i < 20; ++i) {
       element2(i) = i * 5;
-      for (size_t j = 0; j < 12; ++j)
-      {
+      for (size_t j = 0; j < 12; ++j) {
         termx2(i, j) = i * 50 + j;
         termy2(i, j) = i * 60 + j;
         termz2(i, j) = i * 70 + j;
@@ -70,8 +57,7 @@ class RhsElasticTest : public ::testing::Test
   ARRAY_REAL_VIEW weights, weights2;
 };
 
-TEST_F(RhsElasticTest, Constructor)
-{
+TEST_F(RhsElasticTest, Constructor) {
   RhsElastic rhs(termx, termy, termz, element, weights);
 
   EXPECT_EQ(rhs.m_termx.extent(0), numElements);
@@ -85,11 +71,9 @@ TEST_F(RhsElasticTest, Constructor)
   EXPECT_EQ(rhs.m_weights.extent(1), numNodesPerElement);
 
   // Verify data is correctly stored
-  for (size_t i = 0; i < numElements; ++i)
-  {
+  for (size_t i = 0; i < numElements; ++i) {
     EXPECT_EQ(rhs.m_element(i), i * 10);
-    for (size_t j = 0; j < numNodesPerElement; ++j)
-    {
+    for (size_t j = 0; j < numNodesPerElement; ++j) {
       EXPECT_FLOAT_EQ(rhs.m_termx(i, j), i * 100 + j);
       EXPECT_FLOAT_EQ(rhs.m_termy(i, j), i * 200 + j);
       EXPECT_FLOAT_EQ(rhs.m_termz(i, j), i * 300 + j);
@@ -98,8 +82,7 @@ TEST_F(RhsElasticTest, Constructor)
   }
 }
 
-TEST_F(RhsElasticTest, CopyConstructor)
-{
+TEST_F(RhsElasticTest, CopyConstructor) {
   RhsElastic original(termx, termy, termz, element, weights);
   RhsElastic copy(original);
 
@@ -115,11 +98,9 @@ TEST_F(RhsElasticTest, CopyConstructor)
   EXPECT_EQ(copy.m_weights.extent(1), original.m_weights.extent(1));
 
   // Check that copy has the same data
-  for (size_t i = 0; i < numElements; ++i)
-  {
+  for (size_t i = 0; i < numElements; ++i) {
     EXPECT_EQ(copy.m_element(i), original.m_element(i));
-    for (size_t j = 0; j < numNodesPerElement; ++j)
-    {
+    for (size_t j = 0; j < numNodesPerElement; ++j) {
       EXPECT_FLOAT_EQ(copy.m_termx(i, j), original.m_termx(i, j));
       EXPECT_FLOAT_EQ(copy.m_termy(i, j), original.m_termy(i, j));
       EXPECT_FLOAT_EQ(copy.m_termz(i, j), original.m_termz(i, j));
@@ -141,8 +122,7 @@ TEST_F(RhsElasticTest, CopyConstructor)
   EXPECT_FLOAT_EQ(copy.m_weights(4, 5), 555.0f);
 }
 
-TEST_F(RhsElasticTest, CopyAssignmentOperator)
-{
+TEST_F(RhsElasticTest, CopyAssignmentOperator) {
   RhsElastic rhs1(termx, termy, termz, element, weights);
   RhsElastic rhs2(termx2, termy2, termz2, element2, weights2);
 
@@ -166,11 +146,9 @@ TEST_F(RhsElasticTest, CopyAssignmentOperator)
   EXPECT_EQ(rhs2.m_weights.extent(1), numNodesPerElement);
 
   // Check that data matches
-  for (size_t i = 0; i < numElements; ++i)
-  {
+  for (size_t i = 0; i < numElements; ++i) {
     EXPECT_EQ(rhs2.m_element(i), rhs1.m_element(i));
-    for (size_t j = 0; j < numNodesPerElement; ++j)
-    {
+    for (size_t j = 0; j < numNodesPerElement; ++j) {
       EXPECT_FLOAT_EQ(rhs2.m_termx(i, j), rhs1.m_termx(i, j));
       EXPECT_FLOAT_EQ(rhs2.m_termy(i, j), rhs1.m_termy(i, j));
       EXPECT_FLOAT_EQ(rhs2.m_termz(i, j), rhs1.m_termz(i, j));
@@ -188,8 +166,7 @@ TEST_F(RhsElasticTest, CopyAssignmentOperator)
   EXPECT_EQ(rhs2.m_element(2), 555);
 }
 
-TEST_F(RhsElasticTest, CopyAssignmentSelfAssignment)
-{
+TEST_F(RhsElasticTest, CopyAssignmentSelfAssignment) {
   RhsElastic rhs(termx, termy, termz, element, weights);
 
   // Self-assignment should not cause issues
@@ -202,11 +179,9 @@ TEST_F(RhsElasticTest, CopyAssignmentSelfAssignment)
   EXPECT_EQ(rhs.m_termz.extent(0), numElements);
   EXPECT_EQ(rhs.m_element.extent(0), numElements);
 
-  for (size_t i = 0; i < numElements; ++i)
-  {
+  for (size_t i = 0; i < numElements; ++i) {
     EXPECT_EQ(rhs.m_element(i), i * 10);
-    for (size_t j = 0; j < numNodesPerElement; ++j)
-    {
+    for (size_t j = 0; j < numNodesPerElement; ++j) {
       EXPECT_FLOAT_EQ(rhs.m_termx(i, j), i * 100 + j);
       EXPECT_FLOAT_EQ(rhs.m_termy(i, j), i * 200 + j);
       EXPECT_FLOAT_EQ(rhs.m_termz(i, j), i * 300 + j);
@@ -215,8 +190,7 @@ TEST_F(RhsElasticTest, CopyAssignmentSelfAssignment)
   }
 }
 
-TEST_F(RhsElasticTest, GetTerm)
-{
+TEST_F(RhsElasticTest, GetTerm) {
   RhsElastic rhs(termx, termy, termz, element, weights);
 
   auto tx = rhs.getTerm(0);
@@ -230,10 +204,8 @@ TEST_F(RhsElasticTest, GetTerm)
   EXPECT_EQ(tz.extent(0), numElements);
   EXPECT_EQ(tz.extent(1), numNodesPerElement);
 
-  for (size_t i = 0; i < numElements; ++i)
-  {
-    for (size_t j = 0; j < numNodesPerElement; ++j)
-    {
+  for (size_t i = 0; i < numElements; ++i) {
+    for (size_t j = 0; j < numNodesPerElement; ++j) {
       EXPECT_FLOAT_EQ(tx(i, j), i * 100 + j);
       EXPECT_FLOAT_EQ(ty(i, j), i * 200 + j);
       EXPECT_FLOAT_EQ(tz(i, j), i * 300 + j);
@@ -241,46 +213,39 @@ TEST_F(RhsElasticTest, GetTerm)
   }
 }
 
-TEST_F(RhsElasticTest, GetElement)
-{
+TEST_F(RhsElasticTest, GetElement) {
   RhsElastic rhs(termx, termy, termz, element, weights);
 
   auto elem = rhs.getElement();
 
   EXPECT_EQ(elem.extent(0), numElements);
-  for (size_t i = 0; i < numElements; ++i)
-  {
+  for (size_t i = 0; i < numElements; ++i) {
     EXPECT_EQ(elem(i), i * 10);
   }
 }
 
-TEST_F(RhsElasticTest, GetWeights)
-{
+TEST_F(RhsElasticTest, GetWeights) {
   RhsElastic rhs(termx, termy, termz, element, weights);
 
   auto w = rhs.getWeights();
 
   EXPECT_EQ(w.extent(0), numElements);
   EXPECT_EQ(w.extent(1), numNodesPerElement);
-  for (size_t i = 0; i < numElements; ++i)
-  {
-    for (size_t j = 0; j < numNodesPerElement; ++j)
-    {
+  for (size_t i = 0; i < numElements; ++i) {
+    for (size_t j = 0; j < numNodesPerElement; ++j) {
       EXPECT_FLOAT_EQ(w(i, j), i + j * 0.1);
     }
   }
 }
 
-TEST_F(RhsElasticTest, EmptyFields)
-{
+TEST_F(RhsElasticTest, EmptyFields) {
   auto emptyTermx = allocateArray2D<ARRAY_REAL_VIEW>(0, 0, "emptyTermx");
   auto emptyTermy = allocateArray2D<ARRAY_REAL_VIEW>(0, 0, "emptyTermy");
   auto emptyTermz = allocateArray2D<ARRAY_REAL_VIEW>(0, 0, "emptyTermz");
   auto emptyElement = allocateVector<VECTOR_INT_VIEW>(0, "emptyElement");
   auto emptyWeights = allocateArray2D<ARRAY_REAL_VIEW>(0, 0, "emptyWeights");
 
-  RhsElastic rhs(emptyTermx, emptyTermy, emptyTermz, emptyElement,
-                 emptyWeights);
+  RhsElastic rhs(emptyTermx, emptyTermy, emptyTermz, emptyElement, emptyWeights);
 
   EXPECT_EQ(rhs.m_termx.extent(0), 0);
   EXPECT_EQ(rhs.m_termy.extent(0), 0);
@@ -289,8 +254,7 @@ TEST_F(RhsElasticTest, EmptyFields)
   EXPECT_EQ(rhs.m_weights.extent(0), 0);
 }
 
-TEST_F(RhsElasticTest, ModifyAfterConstruction)
-{
+TEST_F(RhsElasticTest, ModifyAfterConstruction) {
   RhsElastic rhs(termx, termy, termz, element, weights);
 
   // Modify data through the RHS object
@@ -315,11 +279,9 @@ TEST_F(RhsElasticTest, ModifyAfterConstruction)
   EXPECT_FLOAT_EQ(weights(2, 1), 0.999f);
 }
 
-TEST_F(RhsElasticTest, CopyInContainerClass)
-{
+TEST_F(RhsElasticTest, CopyInContainerClass) {
   // Create a simple container class that stores rhs by copy
-  struct RhsContainer
-  {
+  struct RhsContainer {
     RhsElastic rhs;
 
     RhsContainer(const RhsElastic& r) : rhs(r) {}

--- a/tests/units/solver/impl/test_wavefield_acoustic.cc
+++ b/tests/units/solver/impl/test_wavefield_acoustic.cc
@@ -4,18 +4,13 @@
 #include "data_type.h"
 #include "wavefield_acoustic.h"
 
-namespace solver
-{
-namespace fe
-{
-namespace test
-{
+namespace solver {
+namespace fe {
+namespace test {
 
-class WavefieldAcousticTest : public ::testing::Test
-{
+class WavefieldAcousticTest : public ::testing::Test {
  protected:
-  void SetUp() override
-  {
+  void SetUp() override {
     // Create test data with specific sizes
     size1 = 100;
     size2 = 200;
@@ -26,14 +21,12 @@ class WavefieldAcousticTest : public ::testing::Test
     currField2 = allocateVector<VECTOR_REAL_VIEW>(size2, "currField2");
 
     // Initialize with test values
-    for (size_t i = 0; i < size1; ++i)
-    {
+    for (size_t i = 0; i < size1; ++i) {
       prevField(i) = i;
       currField(i) = i * 2;
     }
 
-    for (size_t i = 0; i < size2; ++i)
-    {
+    for (size_t i = 0; i < size2; ++i) {
       prevField2(i) = i * 3;
       currField2(i) = i * 4;
     }
@@ -47,23 +40,20 @@ class WavefieldAcousticTest : public ::testing::Test
   VECTOR_REAL_VIEW currField2;
 };
 
-TEST_F(WavefieldAcousticTest, Constructor)
-{
+TEST_F(WavefieldAcousticTest, Constructor) {
   WavefieldAcoustic wavefield(prevField, currField);
 
   EXPECT_EQ(wavefield.m_pnGlobalPrev.extent(0), size1);
   EXPECT_EQ(wavefield.m_pnGlobalCurr.extent(0), size1);
 
   // Verify data is correctly stored
-  for (size_t i = 0; i < size1; ++i)
-  {
+  for (size_t i = 0; i < size1; ++i) {
     EXPECT_FLOAT_EQ(wavefield.m_pnGlobalPrev(i), i);
     EXPECT_FLOAT_EQ(wavefield.m_pnGlobalCurr(i), i * 2);
   }
 }
 
-TEST_F(WavefieldAcousticTest, CopyConstructor)
-{
+TEST_F(WavefieldAcousticTest, CopyConstructor) {
   WavefieldAcoustic original(prevField, currField);
   WavefieldAcoustic copy(original);
 
@@ -72,8 +62,7 @@ TEST_F(WavefieldAcousticTest, CopyConstructor)
   EXPECT_EQ(copy.m_pnGlobalCurr.extent(0), original.m_pnGlobalCurr.extent(0));
 
   // Check that copy has the same data
-  for (size_t i = 0; i < size1; ++i)
-  {
+  for (size_t i = 0; i < size1; ++i) {
     EXPECT_FLOAT_EQ(copy.m_pnGlobalPrev(i), original.m_pnGlobalPrev(i));
     EXPECT_FLOAT_EQ(copy.m_pnGlobalCurr(i), original.m_pnGlobalCurr(i));
   }
@@ -86,8 +75,7 @@ TEST_F(WavefieldAcousticTest, CopyConstructor)
   EXPECT_FLOAT_EQ(copy.m_pnGlobalCurr(0), 888.0f);
 }
 
-TEST_F(WavefieldAcousticTest, CopyAssignmentOperator)
-{
+TEST_F(WavefieldAcousticTest, CopyAssignmentOperator) {
   WavefieldAcoustic wavefield1(prevField, currField);
   WavefieldAcoustic wavefield2(prevField2, currField2);
 
@@ -103,8 +91,7 @@ TEST_F(WavefieldAcousticTest, CopyAssignmentOperator)
   EXPECT_EQ(wavefield2.m_pnGlobalCurr.extent(0), size1);
 
   // Check that data matches
-  for (size_t i = 0; i < size1; ++i)
-  {
+  for (size_t i = 0; i < size1; ++i) {
     EXPECT_FLOAT_EQ(wavefield2.m_pnGlobalPrev(i), wavefield1.m_pnGlobalPrev(i));
     EXPECT_FLOAT_EQ(wavefield2.m_pnGlobalCurr(i), wavefield1.m_pnGlobalCurr(i));
   }
@@ -117,8 +104,7 @@ TEST_F(WavefieldAcousticTest, CopyAssignmentOperator)
   EXPECT_FLOAT_EQ(wavefield2.m_pnGlobalCurr(0), 666.0f);
 }
 
-TEST_F(WavefieldAcousticTest, CopyAssignmentSelfAssignment)
-{
+TEST_F(WavefieldAcousticTest, CopyAssignmentSelfAssignment) {
   WavefieldAcoustic wavefield(prevField, currField);
 
   // Self-assignment should not cause issues
@@ -128,41 +114,35 @@ TEST_F(WavefieldAcousticTest, CopyAssignmentSelfAssignment)
   EXPECT_EQ(wavefield.m_pnGlobalPrev.extent(0), size1);
   EXPECT_EQ(wavefield.m_pnGlobalCurr.extent(0), size1);
 
-  for (size_t i = 0; i < size1; ++i)
-  {
+  for (size_t i = 0; i < size1; ++i) {
     EXPECT_FLOAT_EQ(wavefield.m_pnGlobalPrev(i), i);
     EXPECT_FLOAT_EQ(wavefield.m_pnGlobalCurr(i), i * 2);
   }
 }
 
-TEST_F(WavefieldAcousticTest, GetCurrentField)
-{
+TEST_F(WavefieldAcousticTest, GetCurrentField) {
   WavefieldAcoustic wavefield(prevField, currField);
 
   auto current = wavefield.getCurrentField(0);
 
   EXPECT_EQ(current.extent(0), size1);
-  for (size_t i = 0; i < size1; ++i)
-  {
+  for (size_t i = 0; i < size1; ++i) {
     EXPECT_FLOAT_EQ(current(i), i * 2);
   }
 }
 
-TEST_F(WavefieldAcousticTest, GetPreviousField)
-{
+TEST_F(WavefieldAcousticTest, GetPreviousField) {
   WavefieldAcoustic wavefield(prevField, currField);
 
   auto previous = wavefield.getPreviousField(0);
 
   EXPECT_EQ(previous.extent(0), size1);
-  for (size_t i = 0; i < size1; ++i)
-  {
+  for (size_t i = 0; i < size1; ++i) {
     EXPECT_FLOAT_EQ(previous(i), i);
   }
 }
 
-TEST_F(WavefieldAcousticTest, Swap)
-{
+TEST_F(WavefieldAcousticTest, Swap) {
   WavefieldAcoustic wavefield(prevField, currField);
 
   // Store original values
@@ -177,22 +157,19 @@ TEST_F(WavefieldAcousticTest, Swap)
   EXPECT_FLOAT_EQ(wavefield.m_pnGlobalCurr(0), originalPrev0);
 
   // Verify all elements were swapped
-  for (size_t i = 0; i < size1; ++i)
-  {
+  for (size_t i = 0; i < size1; ++i) {
     EXPECT_FLOAT_EQ(wavefield.m_pnGlobalPrev(i), i * 2);
     EXPECT_FLOAT_EQ(wavefield.m_pnGlobalCurr(i), i);
   }
 }
 
-TEST_F(WavefieldAcousticTest, SwapTwice)
-{
+TEST_F(WavefieldAcousticTest, SwapTwice) {
   WavefieldAcoustic wavefield(prevField, currField);
 
   // Store original values
   std::vector<float> originalPrev(size1);
   std::vector<float> originalCurr(size1);
-  for (size_t i = 0; i < size1; ++i)
-  {
+  for (size_t i = 0; i < size1; ++i) {
     originalPrev[i] = wavefield.m_pnGlobalPrev(i);
     originalCurr[i] = wavefield.m_pnGlobalCurr(i);
   }
@@ -202,15 +179,13 @@ TEST_F(WavefieldAcousticTest, SwapTwice)
   wavefield.swap();
 
   // Verify restoration
-  for (size_t i = 0; i < size1; ++i)
-  {
+  for (size_t i = 0; i < size1; ++i) {
     EXPECT_FLOAT_EQ(wavefield.m_pnGlobalPrev(i), originalPrev[i]);
     EXPECT_FLOAT_EQ(wavefield.m_pnGlobalCurr(i), originalCurr[i]);
   }
 }
 
-TEST_F(WavefieldAcousticTest, SwapWithModification)
-{
+TEST_F(WavefieldAcousticTest, SwapWithModification) {
   WavefieldAcoustic wavefield(prevField, currField);
 
   // Modify current field
@@ -224,8 +199,7 @@ TEST_F(WavefieldAcousticTest, SwapWithModification)
   EXPECT_FLOAT_EQ(wavefield.m_pnGlobalCurr(5), 5.0f);
 }
 
-TEST_F(WavefieldAcousticTest, CopyConstructorAfterSwap)
-{
+TEST_F(WavefieldAcousticTest, CopyConstructorAfterSwap) {
   WavefieldAcoustic original(prevField, currField);
 
   // Swap the original
@@ -235,15 +209,13 @@ TEST_F(WavefieldAcousticTest, CopyConstructorAfterSwap)
   WavefieldAcoustic copy(original);
 
   // Verify copy has the swapped state
-  for (size_t i = 0; i < size1; ++i)
-  {
+  for (size_t i = 0; i < size1; ++i) {
     EXPECT_FLOAT_EQ(copy.m_pnGlobalPrev(i), i * 2);
     EXPECT_FLOAT_EQ(copy.m_pnGlobalCurr(i), i);
   }
 }
 
-TEST_F(WavefieldAcousticTest, EmptyFields)
-{
+TEST_F(WavefieldAcousticTest, EmptyFields) {
   auto emptyPrev = allocateVector<VECTOR_REAL_VIEW>(0, "emptyPrev");
   auto emptyCurr = allocateVector<VECTOR_REAL_VIEW>(0, "emptyCurr");
 
@@ -258,11 +230,9 @@ TEST_F(WavefieldAcousticTest, EmptyFields)
   EXPECT_EQ(wavefield.m_pnGlobalCurr.extent(0), 0);
 }
 
-TEST_F(WavefieldAcousticTest, CopyInContainerClass)
-{
+TEST_F(WavefieldAcousticTest, CopyInContainerClass) {
   // Create a simple container class that stores wavefield by copy
-  struct WavefieldContainer
-  {
+  struct WavefieldContainer {
     WavefieldAcoustic wavefield;
 
     WavefieldContainer(const WavefieldAcoustic& wf) : wavefield(wf) {}
@@ -275,8 +245,7 @@ TEST_F(WavefieldAcousticTest, CopyInContainerClass)
   // Store original values
   std::vector<float> originalPrev(size1);
   std::vector<float> originalCurr(size1);
-  for (size_t i = 0; i < size1; ++i)
-  {
+  for (size_t i = 0; i < size1; ++i) {
     originalPrev[i] = original.m_pnGlobalPrev(i);
     originalCurr[i] = original.m_pnGlobalCurr(i);
   }
@@ -285,8 +254,7 @@ TEST_F(WavefieldAcousticTest, CopyInContainerClass)
   WavefieldContainer container(original);
 
   // Verify container has correct initial state
-  for (size_t i = 0; i < size1; ++i)
-  {
+  for (size_t i = 0; i < size1; ++i) {
     EXPECT_FLOAT_EQ(container.wavefield.m_pnGlobalPrev(i), originalPrev[i]);
     EXPECT_FLOAT_EQ(container.wavefield.m_pnGlobalCurr(i), originalCurr[i]);
   }
@@ -327,8 +295,7 @@ TEST_F(WavefieldAcousticTest, CopyInContainerClass)
   EXPECT_FLOAT_EQ(original.m_pnGlobalCurr(30), 777.0f);
 }
 
-TEST_F(WavefieldAcousticTest, SwapWithRotationRotatesThreeBuffers)
-{
+TEST_F(WavefieldAcousticTest, SwapWithRotationRotatesThreeBuffers) {
   // prevprev = {10, 10, ...}, prev = {i}, curr = {i*2}
   auto prevPrev = allocateVector<VECTOR_REAL_VIEW>(size1, "prevPrev");
   for (size_t i = 0; i < size1; ++i) prevPrev(i) = 10.0f;
@@ -340,16 +307,14 @@ TEST_F(WavefieldAcousticTest, SwapWithRotationRotatesThreeBuffers)
   //   curr      ← old prevPrev  (value = 10.0)
   //   prev      ← old curr      (value = i*2)
   //   prevPrev  ← old prev      (value = i)
-  for (size_t i = 0; i < size1; ++i)
-  {
+  for (size_t i = 0; i < size1; ++i) {
     EXPECT_FLOAT_EQ(wavefield.m_pnGlobalCurr(i), 10.0f);
     EXPECT_FLOAT_EQ(wavefield.m_pnGlobalPrev(i), i * 2);
     EXPECT_FLOAT_EQ(prevPrev(i), static_cast<float>(i));
   }
 }
 
-TEST_F(WavefieldAcousticTest, SwapWithRotationThreeTimesRestoresState)
-{
+TEST_F(WavefieldAcousticTest, SwapWithRotationThreeTimesRestoresState) {
   auto prevPrev = allocateVector<VECTOR_REAL_VIEW>(size1, "prevPrev");
   for (size_t i = 0; i < size1; ++i) prevPrev(i) = 10.0f;
 
@@ -370,8 +335,7 @@ TEST_F(WavefieldAcousticTest, SwapWithRotationThreeTimesRestoresState)
   EXPECT_FLOAT_EQ(prevPrev(0), initialPrevPrev0);
 }
 
-TEST_F(WavefieldAcousticTest, SwapWithRotationNoDataCopy)
-{
+TEST_F(WavefieldAcousticTest, SwapWithRotationNoDataCopy) {
   // Verifies that the rotation is view-handle only: mutating the underlying
   // buffer is visible through the rotated handle.
   auto prevPrev = allocateVector<VECTOR_REAL_VIEW>(size1, "prevPrev");

--- a/tests/units/solver/impl/test_wavefield_elastic.cc
+++ b/tests/units/solver/impl/test_wavefield_elastic.cc
@@ -4,18 +4,13 @@
 #include "data_type.h"
 #include "wavefield_elastic.h"
 
-namespace solver
-{
-namespace fe
-{
-namespace test
-{
+namespace solver {
+namespace fe {
+namespace test {
 
-class WavefieldElasticTest : public ::testing::Test
-{
+class WavefieldElasticTest : public ::testing::Test {
  protected:
-  void SetUp() override
-  {
+  void SetUp() override {
     // Create test data with specific sizes
     size1 = 100;
     size2 = 200;
@@ -35,8 +30,7 @@ class WavefieldElasticTest : public ::testing::Test
     uzCurrField2 = allocateVector<VECTOR_REAL_VIEW>(size2, "uzCurrField2");
 
     // Initialize with test values
-    for (size_t i = 0; i < size1; ++i)
-    {
+    for (size_t i = 0; i < size1; ++i) {
       uxPrevField(i) = i;
       uxCurrField(i) = i * 2;
       uyPrevField(i) = i * 3;
@@ -45,8 +39,7 @@ class WavefieldElasticTest : public ::testing::Test
       uzCurrField(i) = i * 6;
     }
 
-    for (size_t i = 0; i < size2; ++i)
-    {
+    for (size_t i = 0; i < size2; ++i) {
       uxPrevField2(i) = i * 7;
       uxCurrField2(i) = i * 8;
       uyPrevField2(i) = i * 9;
@@ -66,10 +59,8 @@ class WavefieldElasticTest : public ::testing::Test
   VECTOR_REAL_VIEW uzPrevField2, uzCurrField2;
 };
 
-TEST_F(WavefieldElasticTest, Constructor)
-{
-  WavefieldElastic wavefield(uxPrevField, uxCurrField, uyPrevField, uyCurrField,
-                             uzPrevField, uzCurrField);
+TEST_F(WavefieldElasticTest, Constructor) {
+  WavefieldElastic wavefield(uxPrevField, uxCurrField, uyPrevField, uyCurrField, uzPrevField, uzCurrField);
 
   EXPECT_EQ(wavefield.m_uxnGlobalPrev.extent(0), size1);
   EXPECT_EQ(wavefield.m_uxnGlobalCurr.extent(0), size1);
@@ -79,8 +70,7 @@ TEST_F(WavefieldElasticTest, Constructor)
   EXPECT_EQ(wavefield.m_uznGlobalCurr.extent(0), size1);
 
   // Verify data is correctly stored
-  for (size_t i = 0; i < size1; ++i)
-  {
+  for (size_t i = 0; i < size1; ++i) {
     EXPECT_FLOAT_EQ(wavefield.m_uxnGlobalPrev(i), i);
     EXPECT_FLOAT_EQ(wavefield.m_uxnGlobalCurr(i), i * 2);
     EXPECT_FLOAT_EQ(wavefield.m_uynGlobalPrev(i), i * 3);
@@ -90,10 +80,8 @@ TEST_F(WavefieldElasticTest, Constructor)
   }
 }
 
-TEST_F(WavefieldElasticTest, CopyConstructor)
-{
-  WavefieldElastic original(uxPrevField, uxCurrField, uyPrevField, uyCurrField,
-                            uzPrevField, uzCurrField);
+TEST_F(WavefieldElasticTest, CopyConstructor) {
+  WavefieldElastic original(uxPrevField, uxCurrField, uyPrevField, uyCurrField, uzPrevField, uzCurrField);
   WavefieldElastic copy(original);
 
   // Check that copy has the same extent
@@ -105,8 +93,7 @@ TEST_F(WavefieldElasticTest, CopyConstructor)
   EXPECT_EQ(copy.m_uznGlobalCurr.extent(0), original.m_uznGlobalCurr.extent(0));
 
   // Check that copy has the same data
-  for (size_t i = 0; i < size1; ++i)
-  {
+  for (size_t i = 0; i < size1; ++i) {
     EXPECT_FLOAT_EQ(copy.m_uxnGlobalPrev(i), original.m_uxnGlobalPrev(i));
     EXPECT_FLOAT_EQ(copy.m_uxnGlobalCurr(i), original.m_uxnGlobalCurr(i));
     EXPECT_FLOAT_EQ(copy.m_uynGlobalPrev(i), original.m_uynGlobalPrev(i));
@@ -131,12 +118,9 @@ TEST_F(WavefieldElasticTest, CopyConstructor)
   EXPECT_FLOAT_EQ(copy.m_uznGlobalCurr(0), 444.0f);
 }
 
-TEST_F(WavefieldElasticTest, CopyAssignmentOperator)
-{
-  WavefieldElastic wavefield1(uxPrevField, uxCurrField, uyPrevField,
-                              uyCurrField, uzPrevField, uzCurrField);
-  WavefieldElastic wavefield2(uxPrevField2, uxCurrField2, uyPrevField2,
-                              uyCurrField2, uzPrevField2, uzCurrField2);
+TEST_F(WavefieldElasticTest, CopyAssignmentOperator) {
+  WavefieldElastic wavefield1(uxPrevField, uxCurrField, uyPrevField, uyCurrField, uzPrevField, uzCurrField);
+  WavefieldElastic wavefield2(uxPrevField2, uxCurrField2, uyPrevField2, uyCurrField2, uzPrevField2, uzCurrField2);
 
   // Verify initial state
   EXPECT_EQ(wavefield2.m_uxnGlobalPrev.extent(0), size2);
@@ -154,20 +138,13 @@ TEST_F(WavefieldElasticTest, CopyAssignmentOperator)
   EXPECT_EQ(wavefield2.m_uznGlobalCurr.extent(0), size1);
 
   // Check that data matches
-  for (size_t i = 0; i < size1; ++i)
-  {
-    EXPECT_FLOAT_EQ(wavefield2.m_uxnGlobalPrev(i),
-                    wavefield1.m_uxnGlobalPrev(i));
-    EXPECT_FLOAT_EQ(wavefield2.m_uxnGlobalCurr(i),
-                    wavefield1.m_uxnGlobalCurr(i));
-    EXPECT_FLOAT_EQ(wavefield2.m_uynGlobalPrev(i),
-                    wavefield1.m_uynGlobalPrev(i));
-    EXPECT_FLOAT_EQ(wavefield2.m_uynGlobalCurr(i),
-                    wavefield1.m_uynGlobalCurr(i));
-    EXPECT_FLOAT_EQ(wavefield2.m_uznGlobalPrev(i),
-                    wavefield1.m_uznGlobalPrev(i));
-    EXPECT_FLOAT_EQ(wavefield2.m_uznGlobalCurr(i),
-                    wavefield1.m_uznGlobalCurr(i));
+  for (size_t i = 0; i < size1; ++i) {
+    EXPECT_FLOAT_EQ(wavefield2.m_uxnGlobalPrev(i), wavefield1.m_uxnGlobalPrev(i));
+    EXPECT_FLOAT_EQ(wavefield2.m_uxnGlobalCurr(i), wavefield1.m_uxnGlobalCurr(i));
+    EXPECT_FLOAT_EQ(wavefield2.m_uynGlobalPrev(i), wavefield1.m_uynGlobalPrev(i));
+    EXPECT_FLOAT_EQ(wavefield2.m_uynGlobalCurr(i), wavefield1.m_uynGlobalCurr(i));
+    EXPECT_FLOAT_EQ(wavefield2.m_uznGlobalPrev(i), wavefield1.m_uznGlobalPrev(i));
+    EXPECT_FLOAT_EQ(wavefield2.m_uznGlobalCurr(i), wavefield1.m_uznGlobalCurr(i));
   }
 
   // Modify original data to verify shallow copy behavior (Kokkos views are
@@ -178,10 +155,8 @@ TEST_F(WavefieldElasticTest, CopyAssignmentOperator)
   EXPECT_FLOAT_EQ(wavefield2.m_uxnGlobalCurr(0), 666.0f);
 }
 
-TEST_F(WavefieldElasticTest, CopyAssignmentSelfAssignment)
-{
-  WavefieldElastic wavefield(uxPrevField, uxCurrField, uyPrevField, uyCurrField,
-                             uzPrevField, uzCurrField);
+TEST_F(WavefieldElasticTest, CopyAssignmentSelfAssignment) {
+  WavefieldElastic wavefield(uxPrevField, uxCurrField, uyPrevField, uyCurrField, uzPrevField, uzCurrField);
 
   // Self-assignment should not cause issues
   wavefield = wavefield;
@@ -194,8 +169,7 @@ TEST_F(WavefieldElasticTest, CopyAssignmentSelfAssignment)
   EXPECT_EQ(wavefield.m_uznGlobalPrev.extent(0), size1);
   EXPECT_EQ(wavefield.m_uznGlobalCurr.extent(0), size1);
 
-  for (size_t i = 0; i < size1; ++i)
-  {
+  for (size_t i = 0; i < size1; ++i) {
     EXPECT_FLOAT_EQ(wavefield.m_uxnGlobalPrev(i), i);
     EXPECT_FLOAT_EQ(wavefield.m_uxnGlobalCurr(i), i * 2);
     EXPECT_FLOAT_EQ(wavefield.m_uynGlobalPrev(i), i * 3);
@@ -205,10 +179,8 @@ TEST_F(WavefieldElasticTest, CopyAssignmentSelfAssignment)
   }
 }
 
-TEST_F(WavefieldElasticTest, GetCurrentField)
-{
-  WavefieldElastic wavefield(uxPrevField, uxCurrField, uyPrevField, uyCurrField,
-                             uzPrevField, uzCurrField);
+TEST_F(WavefieldElasticTest, GetCurrentField) {
+  WavefieldElastic wavefield(uxPrevField, uxCurrField, uyPrevField, uyCurrField, uzPrevField, uzCurrField);
 
   auto currentX = wavefield.getCurrentField(0);
   auto currentY = wavefield.getCurrentField(1);
@@ -218,18 +190,15 @@ TEST_F(WavefieldElasticTest, GetCurrentField)
   EXPECT_EQ(currentY.extent(0), size1);
   EXPECT_EQ(currentZ.extent(0), size1);
 
-  for (size_t i = 0; i < size1; ++i)
-  {
+  for (size_t i = 0; i < size1; ++i) {
     EXPECT_FLOAT_EQ(currentX(i), i * 2);
     EXPECT_FLOAT_EQ(currentY(i), i * 4);
     EXPECT_FLOAT_EQ(currentZ(i), i * 6);
   }
 }
 
-TEST_F(WavefieldElasticTest, GetPreviousField)
-{
-  WavefieldElastic wavefield(uxPrevField, uxCurrField, uyPrevField, uyCurrField,
-                             uzPrevField, uzCurrField);
+TEST_F(WavefieldElasticTest, GetPreviousField) {
+  WavefieldElastic wavefield(uxPrevField, uxCurrField, uyPrevField, uyCurrField, uzPrevField, uzCurrField);
 
   auto previousX = wavefield.getPreviousField(0);
   auto previousY = wavefield.getPreviousField(1);
@@ -239,18 +208,15 @@ TEST_F(WavefieldElasticTest, GetPreviousField)
   EXPECT_EQ(previousY.extent(0), size1);
   EXPECT_EQ(previousZ.extent(0), size1);
 
-  for (size_t i = 0; i < size1; ++i)
-  {
+  for (size_t i = 0; i < size1; ++i) {
     EXPECT_FLOAT_EQ(previousX(i), i);
     EXPECT_FLOAT_EQ(previousY(i), i * 3);
     EXPECT_FLOAT_EQ(previousZ(i), i * 5);
   }
 }
 
-TEST_F(WavefieldElasticTest, Swap)
-{
-  WavefieldElastic wavefield(uxPrevField, uxCurrField, uyPrevField, uyCurrField,
-                             uzPrevField, uzCurrField);
+TEST_F(WavefieldElasticTest, Swap) {
+  WavefieldElastic wavefield(uxPrevField, uxCurrField, uyPrevField, uyCurrField, uzPrevField, uzCurrField);
 
   // Store original values
   float originalUxPrev0 = wavefield.m_uxnGlobalPrev(0);
@@ -272,8 +238,7 @@ TEST_F(WavefieldElasticTest, Swap)
   EXPECT_FLOAT_EQ(wavefield.m_uznGlobalCurr(0), originalUzPrev0);
 
   // Verify all elements were swapped
-  for (size_t i = 0; i < size1; ++i)
-  {
+  for (size_t i = 0; i < size1; ++i) {
     EXPECT_FLOAT_EQ(wavefield.m_uxnGlobalPrev(i), i * 2);
     EXPECT_FLOAT_EQ(wavefield.m_uxnGlobalCurr(i), i);
     EXPECT_FLOAT_EQ(wavefield.m_uynGlobalPrev(i), i * 4);
@@ -283,18 +248,15 @@ TEST_F(WavefieldElasticTest, Swap)
   }
 }
 
-TEST_F(WavefieldElasticTest, SwapTwice)
-{
-  WavefieldElastic wavefield(uxPrevField, uxCurrField, uyPrevField, uyCurrField,
-                             uzPrevField, uzCurrField);
+TEST_F(WavefieldElasticTest, SwapTwice) {
+  WavefieldElastic wavefield(uxPrevField, uxCurrField, uyPrevField, uyCurrField, uzPrevField, uzCurrField);
 
   // Store original values
   std::vector<float> originalUxPrev(size1), originalUxCurr(size1);
   std::vector<float> originalUyPrev(size1), originalUyCurr(size1);
   std::vector<float> originalUzPrev(size1), originalUzCurr(size1);
 
-  for (size_t i = 0; i < size1; ++i)
-  {
+  for (size_t i = 0; i < size1; ++i) {
     originalUxPrev[i] = wavefield.m_uxnGlobalPrev(i);
     originalUxCurr[i] = wavefield.m_uxnGlobalCurr(i);
     originalUyPrev[i] = wavefield.m_uynGlobalPrev(i);
@@ -308,8 +270,7 @@ TEST_F(WavefieldElasticTest, SwapTwice)
   wavefield.swap();
 
   // Verify restoration
-  for (size_t i = 0; i < size1; ++i)
-  {
+  for (size_t i = 0; i < size1; ++i) {
     EXPECT_FLOAT_EQ(wavefield.m_uxnGlobalPrev(i), originalUxPrev[i]);
     EXPECT_FLOAT_EQ(wavefield.m_uxnGlobalCurr(i), originalUxCurr[i]);
     EXPECT_FLOAT_EQ(wavefield.m_uynGlobalPrev(i), originalUyPrev[i]);
@@ -319,10 +280,8 @@ TEST_F(WavefieldElasticTest, SwapTwice)
   }
 }
 
-TEST_F(WavefieldElasticTest, SwapWithModification)
-{
-  WavefieldElastic wavefield(uxPrevField, uxCurrField, uyPrevField, uyCurrField,
-                             uzPrevField, uzCurrField);
+TEST_F(WavefieldElasticTest, SwapWithModification) {
+  WavefieldElastic wavefield(uxPrevField, uxCurrField, uyPrevField, uyCurrField, uzPrevField, uzCurrField);
 
   // Modify current fields
   wavefield.m_uxnGlobalCurr(5) = 123.456f;
@@ -341,10 +300,8 @@ TEST_F(WavefieldElasticTest, SwapWithModification)
   EXPECT_FLOAT_EQ(wavefield.m_uznGlobalCurr(9), 45.0f);
 }
 
-TEST_F(WavefieldElasticTest, CopyConstructorAfterSwap)
-{
-  WavefieldElastic original(uxPrevField, uxCurrField, uyPrevField, uyCurrField,
-                            uzPrevField, uzCurrField);
+TEST_F(WavefieldElasticTest, CopyConstructorAfterSwap) {
+  WavefieldElastic original(uxPrevField, uxCurrField, uyPrevField, uyCurrField, uzPrevField, uzCurrField);
 
   // Swap the original
   original.swap();
@@ -353,8 +310,7 @@ TEST_F(WavefieldElasticTest, CopyConstructorAfterSwap)
   WavefieldElastic copy(original);
 
   // Verify copy has the swapped state
-  for (size_t i = 0; i < size1; ++i)
-  {
+  for (size_t i = 0; i < size1; ++i) {
     EXPECT_FLOAT_EQ(copy.m_uxnGlobalPrev(i), i * 2);
     EXPECT_FLOAT_EQ(copy.m_uxnGlobalCurr(i), i);
     EXPECT_FLOAT_EQ(copy.m_uynGlobalPrev(i), i * 4);
@@ -364,8 +320,7 @@ TEST_F(WavefieldElasticTest, CopyConstructorAfterSwap)
   }
 }
 
-TEST_F(WavefieldElasticTest, EmptyFields)
-{
+TEST_F(WavefieldElasticTest, EmptyFields) {
   auto emptyUxPrev = allocateVector<VECTOR_REAL_VIEW>(0, "emptyUxPrev");
   auto emptyUxCurr = allocateVector<VECTOR_REAL_VIEW>(0, "emptyUxCurr");
   auto emptyUyPrev = allocateVector<VECTOR_REAL_VIEW>(0, "emptyUyPrev");
@@ -373,8 +328,7 @@ TEST_F(WavefieldElasticTest, EmptyFields)
   auto emptyUzPrev = allocateVector<VECTOR_REAL_VIEW>(0, "emptyUzPrev");
   auto emptyUzCurr = allocateVector<VECTOR_REAL_VIEW>(0, "emptyUzCurr");
 
-  WavefieldElastic wavefield(emptyUxPrev, emptyUxCurr, emptyUyPrev, emptyUyCurr,
-                             emptyUzPrev, emptyUzCurr);
+  WavefieldElastic wavefield(emptyUxPrev, emptyUxCurr, emptyUyPrev, emptyUyCurr, emptyUzPrev, emptyUzCurr);
 
   EXPECT_EQ(wavefield.m_uxnGlobalPrev.extent(0), 0);
   EXPECT_EQ(wavefield.m_uxnGlobalCurr.extent(0), 0);
@@ -393,11 +347,9 @@ TEST_F(WavefieldElasticTest, EmptyFields)
   EXPECT_EQ(wavefield.m_uznGlobalCurr.extent(0), 0);
 }
 
-TEST_F(WavefieldElasticTest, CopyInContainerClass)
-{
+TEST_F(WavefieldElasticTest, CopyInContainerClass) {
   // Create a simple container class that stores wavefield by copy
-  struct WavefieldContainer
-  {
+  struct WavefieldContainer {
     WavefieldElastic wavefield;
 
     WavefieldContainer(const WavefieldElastic& wf) : wavefield(wf) {}
@@ -405,16 +357,14 @@ TEST_F(WavefieldElasticTest, CopyInContainerClass)
     void swap() { wavefield.swap(); }
   };
 
-  WavefieldElastic original(uxPrevField, uxCurrField, uyPrevField, uyCurrField,
-                            uzPrevField, uzCurrField);
+  WavefieldElastic original(uxPrevField, uxCurrField, uyPrevField, uyCurrField, uzPrevField, uzCurrField);
 
   // Store original values
   std::vector<float> originalUxPrev(size1), originalUxCurr(size1);
   std::vector<float> originalUyPrev(size1), originalUyCurr(size1);
   std::vector<float> originalUzPrev(size1), originalUzCurr(size1);
 
-  for (size_t i = 0; i < size1; ++i)
-  {
+  for (size_t i = 0; i < size1; ++i) {
     originalUxPrev[i] = original.m_uxnGlobalPrev(i);
     originalUxCurr[i] = original.m_uxnGlobalCurr(i);
     originalUyPrev[i] = original.m_uynGlobalPrev(i);
@@ -427,8 +377,7 @@ TEST_F(WavefieldElasticTest, CopyInContainerClass)
   WavefieldContainer container(original);
 
   // Verify container has correct initial state
-  for (size_t i = 0; i < size1; ++i)
-  {
+  for (size_t i = 0; i < size1; ++i) {
     EXPECT_FLOAT_EQ(container.wavefield.m_uxnGlobalPrev(i), originalUxPrev[i]);
     EXPECT_FLOAT_EQ(container.wavefield.m_uxnGlobalCurr(i), originalUxCurr[i]);
     EXPECT_FLOAT_EQ(container.wavefield.m_uynGlobalPrev(i), originalUyPrev[i]);
@@ -479,21 +428,18 @@ TEST_F(WavefieldElasticTest, CopyInContainerClass)
   EXPECT_FLOAT_EQ(original.m_uznGlobalCurr(30), 666.0f);
 }
 
-TEST_F(WavefieldElasticTest, SwapWithRotationRotatesThreeBuffers)
-{
+TEST_F(WavefieldElasticTest, SwapWithRotationRotatesThreeBuffers) {
   // Allocate prevprev buffers initialised to 10*component_index
   auto uxPrevPrev = allocateVector<VECTOR_REAL_VIEW>(size1, "uxPrevPrev");
   auto uyPrevPrev = allocateVector<VECTOR_REAL_VIEW>(size1, "uyPrevPrev");
   auto uzPrevPrev = allocateVector<VECTOR_REAL_VIEW>(size1, "uzPrevPrev");
-  for (size_t i = 0; i < size1; ++i)
-  {
+  for (size_t i = 0; i < size1; ++i) {
     uxPrevPrev(i) = 10.0f;
     uyPrevPrev(i) = 20.0f;
     uzPrevPrev(i) = 30.0f;
   }
 
-  WavefieldElastic wavefield(uxPrevField, uxCurrField, uyPrevField, uyCurrField,
-                             uzPrevField, uzCurrField);
+  WavefieldElastic wavefield(uxPrevField, uxCurrField, uyPrevField, uyCurrField, uzPrevField, uzCurrField);
   wavefield.swapWithRotation(uxPrevPrev, 0);
   wavefield.swapWithRotation(uyPrevPrev, 1);
   wavefield.swapWithRotation(uzPrevPrev, 2);
@@ -502,8 +448,7 @@ TEST_F(WavefieldElasticTest, SwapWithRotationRotatesThreeBuffers)
   //   curr      ← old prevPrev  (ux=10, uy=20, uz=30)
   //   prev      ← old curr      (ux=i*2, uy=i*4, uz=i*6)
   //   prevPrev  ← old prev      (ux=i,   uy=i*3, uz=i*5)
-  for (size_t i = 0; i < size1; ++i)
-  {
+  for (size_t i = 0; i < size1; ++i) {
     EXPECT_FLOAT_EQ(wavefield.m_uxnGlobalCurr(i), 10.0f);
     EXPECT_FLOAT_EQ(wavefield.m_uynGlobalCurr(i), 20.0f);
     EXPECT_FLOAT_EQ(wavefield.m_uznGlobalCurr(i), 30.0f);
@@ -518,13 +463,11 @@ TEST_F(WavefieldElasticTest, SwapWithRotationRotatesThreeBuffers)
   }
 }
 
-TEST_F(WavefieldElasticTest, SwapWithRotationThreeTimesRestoresState)
-{
+TEST_F(WavefieldElasticTest, SwapWithRotationThreeTimesRestoresState) {
   auto uxPrevPrev = allocateVector<VECTOR_REAL_VIEW>(size1, "uxPrevPrev");
   auto uyPrevPrev = allocateVector<VECTOR_REAL_VIEW>(size1, "uyPrevPrev");
   auto uzPrevPrev = allocateVector<VECTOR_REAL_VIEW>(size1, "uzPrevPrev");
-  for (size_t i = 0; i < size1; ++i)
-  {
+  for (size_t i = 0; i < size1; ++i) {
     uxPrevPrev(i) = 10.0f;
     uyPrevPrev(i) = 20.0f;
     uzPrevPrev(i) = 30.0f;
@@ -534,8 +477,7 @@ TEST_F(WavefieldElasticTest, SwapWithRotationThreeTimesRestoresState)
   float initialUxCurr0 = uxCurrField(0);
   float initialUxPP0 = uxPrevPrev(0);
 
-  WavefieldElastic wavefield(uxPrevField, uxCurrField, uyPrevField, uyCurrField,
-                             uzPrevField, uzCurrField);
+  WavefieldElastic wavefield(uxPrevField, uxCurrField, uyPrevField, uyCurrField, uzPrevField, uzCurrField);
 
   wavefield.swapWithRotation(uxPrevPrev, 0);
   wavefield.swapWithRotation(uyPrevPrev, 1);
@@ -552,20 +494,17 @@ TEST_F(WavefieldElasticTest, SwapWithRotationThreeTimesRestoresState)
   EXPECT_FLOAT_EQ(uxPrevPrev(0), initialUxPP0);
 }
 
-TEST_F(WavefieldElasticTest, SwapWithRotationNoDataCopy)
-{
+TEST_F(WavefieldElasticTest, SwapWithRotationNoDataCopy) {
   auto uxPrevPrev = allocateVector<VECTOR_REAL_VIEW>(size1, "uxPrevPrev");
   auto uyPrevPrev = allocateVector<VECTOR_REAL_VIEW>(size1, "uyPrevPrev");
   auto uzPrevPrev = allocateVector<VECTOR_REAL_VIEW>(size1, "uzPrevPrev");
-  for (size_t i = 0; i < size1; ++i)
-  {
+  for (size_t i = 0; i < size1; ++i) {
     uxPrevPrev(i) = 10.0f;
     uyPrevPrev(i) = 20.0f;
     uzPrevPrev(i) = 30.0f;
   }
 
-  WavefieldElastic wavefield(uxPrevField, uxCurrField, uyPrevField, uyCurrField,
-                             uzPrevField, uzCurrField);
+  WavefieldElastic wavefield(uxPrevField, uxCurrField, uyPrevField, uyCurrField, uzPrevField, uzCurrField);
   wavefield.swapWithRotation(uxPrevPrev, 0);
   wavefield.swapWithRotation(uyPrevPrev, 1);
   wavefield.swapWithRotation(uzPrevPrev, 2);

--- a/tests/units/utils/test_common_macros_find_max_1d.cc
+++ b/tests/units/utils/test_common_macros_find_max_1d.cc
@@ -3,33 +3,27 @@
 #include "common_macros.h"
 #include "data_type.h"
 
-namespace utils
-{
-namespace test
-{
+namespace utils {
+namespace test {
 
 // Wrapper class to test FIND_MAX macro
 // since in GoogleTest, the test body is inside a class,
 // but the class is non-copyable, so [=, *this] fails.
-class FindMax1DHelper
-{
+class FindMax1DHelper {
  public:
-  float find_max(const VECTOR_REAL_VIEW& array, int N) const
-  {
+  float find_max(const VECTOR_REAL_VIEW& array, int N) const {
     float result;
     FIND_MAX_1D(array, N, result);
     return result;
   }
 };
 
-class CommonMacrosTest : public ::testing::Test
-{
+class CommonMacrosTest : public ::testing::Test {
  protected:
   FindMax1DHelper helper;
 };
 
-TEST_F(CommonMacrosTest, FindMax1D)
-{
+TEST_F(CommonMacrosTest, FindMax1D) {
   constexpr int N = 5;
   auto array = allocateVector<VECTOR_REAL_VIEW>(N, "array");
   array(1) = 1.0f;
@@ -41,12 +35,10 @@ TEST_F(CommonMacrosTest, FindMax1D)
   EXPECT_FLOAT_EQ(result, 7.2f);
 }
 
-TEST_F(CommonMacrosTest, FindMax1DLargeArray)
-{
+TEST_F(CommonMacrosTest, FindMax1DLargeArray) {
   constexpr int N = 2000;
   auto array = allocateVector<VECTOR_REAL_VIEW>(N, "array_large");
-  for (int i = 0; i < N; ++i)
-  {
+  for (int i = 0; i < N; ++i) {
     array(i) = 3000.0f;
   }
   array(N / 2) = 3300.0f;  // One element is different
@@ -54,8 +46,7 @@ TEST_F(CommonMacrosTest, FindMax1DLargeArray)
   EXPECT_FLOAT_EQ(result, 3300.0f);
 }
 
-TEST_F(CommonMacrosTest, FindMax1DAllNegative)
-{
+TEST_F(CommonMacrosTest, FindMax1DAllNegative) {
   constexpr int N = 4;
   auto array = allocateVector<VECTOR_REAL_VIEW>(N, "array_neg");
   array(0) = -5.0f;
@@ -66,8 +57,7 @@ TEST_F(CommonMacrosTest, FindMax1DAllNegative)
   EXPECT_FLOAT_EQ(result, -1.1f);
 }
 
-TEST_F(CommonMacrosTest, FindMax1DAllEqual)
-{
+TEST_F(CommonMacrosTest, FindMax1DAllEqual) {
   constexpr int N = 3;
   auto array = allocateVector<VECTOR_REAL_VIEW>(N, "array_eq");
   array(0) = 2.5f;
@@ -77,8 +67,7 @@ TEST_F(CommonMacrosTest, FindMax1DAllEqual)
   EXPECT_FLOAT_EQ(result, 2.5f);
 }
 
-TEST_F(CommonMacrosTest, FindMax1DSingleElement)
-{
+TEST_F(CommonMacrosTest, FindMax1DSingleElement) {
   constexpr int N = 1;
   auto array = allocateVector<VECTOR_REAL_VIEW>(N, "array_single");
   array(0) = 42.0f;
@@ -86,8 +75,7 @@ TEST_F(CommonMacrosTest, FindMax1DSingleElement)
   EXPECT_FLOAT_EQ(result, 42.0f);
 }
 
-TEST_F(CommonMacrosTest, FindMax1DEmptyArrayThrows)
-{
+TEST_F(CommonMacrosTest, FindMax1DEmptyArrayThrows) {
   constexpr int N = 0;
   auto array = allocateVector<VECTOR_REAL_VIEW>(N, "array_empty");
   EXPECT_THROW(helper.find_max(array, N), std::runtime_error);

--- a/tests/units/utils/test_das_receiver.cc
+++ b/tests/units/utils/test_das_receiver.cc
@@ -4,29 +4,23 @@
 
 #include "source_and_receiver_utils.h"
 
-namespace utils
-{
-namespace test
-{
+namespace utils {
+namespace test {
 
 using SourceAndReceiverUtils::ComputeDASVector;
 using SourceAndReceiverUtils::ComputeDASWeightsForSample;
 using SourceAndReceiverUtils::DASType;
 
-class DASReceiverTest : public ::testing::Test
-{
+class DASReceiverTest : public ::testing::Test {
  protected:
   // Helper: build corner coordinates for a Cartesian element [x0,x1]^3
-  void makeCornerCoords(float x0, float y0, float z0, float dx, float dy,
-                        float dz, real_t (&corners)[8][3])
-  {
+  void makeCornerCoords(float x0, float y0, float z0, float dx, float dy, float dz, real_t (&corners)[8][3]) {
     // Corner ordering: (0,0,0),(1,0,0),(0,1,0),(1,1,0),
     //                  (0,0,1),(1,0,1),(0,1,1),(1,1,1)
     float cx[8] = {x0, x0 + dx, x0, x0 + dx, x0, x0 + dx, x0, x0 + dx};
     float cy[8] = {y0, y0, y0 + dy, y0 + dy, y0, y0, y0 + dy, y0 + dy};
     float cz[8] = {z0, z0, z0, z0, z0 + dz, z0 + dz, z0 + dz, z0 + dz};
-    for (int i = 0; i < 8; ++i)
-    {
+    for (int i = 0; i < 8; ++i) {
       corners[i][0] = cx[i];
       corners[i][1] = cy[i];
       corners[i][2] = cz[i];
@@ -37,8 +31,7 @@ class DASReceiverTest : public ::testing::Test
 // ---------------------------------------------------------------
 // Test ComputeDASVector
 // ---------------------------------------------------------------
-TEST_F(DASReceiverTest, DASVectorHorizontalX)
-{
+TEST_F(DASReceiverTest, DASVectorHorizontalX) {
   // dip=0, azimuth=0 → direction should be (1,0,0)
   auto v = ComputeDASVector(0.0f, 0.0f);
   EXPECT_NEAR(v[0], 1.0f, 1e-6f);
@@ -46,8 +39,7 @@ TEST_F(DASReceiverTest, DASVectorHorizontalX)
   EXPECT_NEAR(v[2], 0.0f, 1e-6f);
 }
 
-TEST_F(DASReceiverTest, DASVectorHorizontalY)
-{
+TEST_F(DASReceiverTest, DASVectorHorizontalY) {
   // dip=0, azimuth=90 → direction should be (0,1,0)
   auto v = ComputeDASVector(0.0f, 90.0f);
   EXPECT_NEAR(v[0], 0.0f, 1e-5f);
@@ -55,8 +47,7 @@ TEST_F(DASReceiverTest, DASVectorHorizontalY)
   EXPECT_NEAR(v[2], 0.0f, 1e-5f);
 }
 
-TEST_F(DASReceiverTest, DASVectorVertical)
-{
+TEST_F(DASReceiverTest, DASVectorVertical) {
   // dip=90, azimuth=0 → direction should be (0,0,1)
   auto v = ComputeDASVector(90.0f, 0.0f);
   EXPECT_NEAR(v[0], 0.0f, 1e-5f);
@@ -64,8 +55,7 @@ TEST_F(DASReceiverTest, DASVectorVertical)
   EXPECT_NEAR(v[2], 1.0f, 1e-5f);
 }
 
-TEST_F(DASReceiverTest, DASVectorIsUnitLength)
-{
+TEST_F(DASReceiverTest, DASVectorIsUnitLength) {
   auto v = ComputeDASVector(30.0f, 45.0f);
   float len = std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
   EXPECT_NEAR(len, 1.0f, 1e-6f);
@@ -74,8 +64,7 @@ TEST_F(DASReceiverTest, DASVectorIsUnitLength)
 // ---------------------------------------------------------------
 // Test ComputeDASWeightsForSample — Dipole mode
 // ---------------------------------------------------------------
-TEST_F(DASReceiverTest, DipoleWeightsSumToOne)
-{
+TEST_F(DASReceiverTest, DipoleWeightsSumToOne) {
   // For dipole mode with integrationConstant=1, the weights should be
   // shape function values at the sample point. They should sum to 1.
   real_t corners[8][3];
@@ -86,20 +75,17 @@ TEST_F(DASReceiverTest, DipoleWeightsSumToOne)
   std::array<float, 3> direction = {1.0f, 0.0f, 0.0f};
 
   constexpr int ORDER = 2;
-  constexpr int npe =
-      Qk_Hexahedron_Lagrange_GaussLobatto_Selector<ORDER>::type::numNodes;
+  constexpr int npe = Qk_Hexahedron_Lagrange_GaussLobatto_Selector<ORDER>::type::numNodes;
   float weights[npe] = {0};
 
-  ComputeDASWeightsForSample<ORDER>(corners, coord, direction, 1.0f,
-                                    DASType::kDipole, weights);
+  ComputeDASWeightsForSample<ORDER>(corners, coord, direction, 1.0f, DASType::kDipole, weights);
 
   float sum = 0;
   for (int i = 0; i < npe; ++i) sum += weights[i];
   EXPECT_NEAR(sum, 1.0f, 1e-5f);
 }
 
-TEST_F(DASReceiverTest, DipoleWeightsAtCorner)
-{
+TEST_F(DASReceiverTest, DipoleWeightsAtCorner) {
   // Sample at corner (0,0,0) → only the corner basis function should be 1
   real_t corners[8][3];
   makeCornerCoords(0.0f, 0.0f, 0.0f, 100.0f, 100.0f, 100.0f, corners);
@@ -108,20 +94,17 @@ TEST_F(DASReceiverTest, DipoleWeightsAtCorner)
   std::array<float, 3> direction = {1.0f, 0.0f, 0.0f};
 
   constexpr int ORDER = 1;
-  constexpr int npe =
-      Qk_Hexahedron_Lagrange_GaussLobatto_Selector<ORDER>::type::numNodes;
+  constexpr int npe = Qk_Hexahedron_Lagrange_GaussLobatto_Selector<ORDER>::type::numNodes;
   float weights[npe] = {0};
 
-  ComputeDASWeightsForSample<ORDER>(corners, coord, direction, 1.0f,
-                                    DASType::kDipole, weights);
+  ComputeDASWeightsForSample<ORDER>(corners, coord, direction, 1.0f, DASType::kDipole, weights);
 
   // Node 0 (a=0,b=0,c=0) should have weight 1, others 0
   EXPECT_NEAR(weights[0], 1.0f, 1e-5f);
   for (int i = 1; i < npe; ++i) EXPECT_NEAR(weights[i], 0.0f, 1e-5f);
 }
 
-TEST_F(DASReceiverTest, DipoleWeightsAllPositive)
-{
+TEST_F(DASReceiverTest, DipoleWeightsAllPositive) {
   // For a point inside the element, all basis function values should
   // be non-negative (Lagrange on GLL points are not always positive,
   // but at the center they should be).
@@ -132,12 +115,10 @@ TEST_F(DASReceiverTest, DipoleWeightsAllPositive)
   std::array<float, 3> direction = {1.0f, 0.0f, 0.0f};
 
   constexpr int ORDER = 1;
-  constexpr int npe =
-      Qk_Hexahedron_Lagrange_GaussLobatto_Selector<ORDER>::type::numNodes;
+  constexpr int npe = Qk_Hexahedron_Lagrange_GaussLobatto_Selector<ORDER>::type::numNodes;
   float weights[npe] = {0};
 
-  ComputeDASWeightsForSample<ORDER>(corners, coord, direction, 1.0f,
-                                    DASType::kDipole, weights);
+  ComputeDASWeightsForSample<ORDER>(corners, coord, direction, 1.0f, DASType::kDipole, weights);
 
   // For linear elements, all shape functions are positive inside the element
   for (int i = 0; i < npe; ++i) EXPECT_GE(weights[i], 0.0f);
@@ -146,8 +127,7 @@ TEST_F(DASReceiverTest, DipoleWeightsAllPositive)
 // ---------------------------------------------------------------
 // Test ComputeDASWeightsForSample — Strain Integration mode
 // ---------------------------------------------------------------
-TEST_F(DASReceiverTest, StrainWeightsGradientSumZero)
-{
+TEST_F(DASReceiverTest, StrainWeightsGradientSumZero) {
   // Gradient of shape functions should sum to zero (partition of unity).
   // So for strain integration at any point, sum of weights should be ~0.
   real_t corners[8][3];
@@ -157,20 +137,17 @@ TEST_F(DASReceiverTest, StrainWeightsGradientSumZero)
   std::array<float, 3> direction = {1.0f, 0.0f, 0.0f};
 
   constexpr int ORDER = 2;
-  constexpr int npe =
-      Qk_Hexahedron_Lagrange_GaussLobatto_Selector<ORDER>::type::numNodes;
+  constexpr int npe = Qk_Hexahedron_Lagrange_GaussLobatto_Selector<ORDER>::type::numNodes;
   float weights[npe] = {0};
 
-  ComputeDASWeightsForSample<ORDER>(corners, coord, direction, 1.0f,
-                                    DASType::kStrainIntegration, weights);
+  ComputeDASWeightsForSample<ORDER>(corners, coord, direction, 1.0f, DASType::kStrainIntegration, weights);
 
   float sum = 0;
   for (int i = 0; i < npe; ++i) sum += weights[i];
   EXPECT_NEAR(sum, 0.0f, 1e-4f);
 }
 
-TEST_F(DASReceiverTest, StrainWeightsLinearFieldGivesConstantStrain)
-{
+TEST_F(DASReceiverTest, StrainWeightsLinearFieldGivesConstantStrain) {
   // For a linear displacement field u_x = x, the strain du_x/dx = 1.
   // DAS weights dotted with node displacements should give ≈1.
   real_t corners[8][3];
@@ -183,13 +160,11 @@ TEST_F(DASReceiverTest, StrainWeightsLinearFieldGivesConstantStrain)
   std::array<float, 3> direction = {1.0f, 0.0f, 0.0f};
 
   constexpr int ORDER = 2;
-  using FEType =
-      typename Qk_Hexahedron_Lagrange_GaussLobatto_Selector<ORDER>::type;
+  using FEType = typename Qk_Hexahedron_Lagrange_GaussLobatto_Selector<ORDER>::type;
   constexpr int npe = FEType::numNodes;
   float weights[npe] = {0};
 
-  ComputeDASWeightsForSample<ORDER>(corners, coord, direction, 1.0f,
-                                    DASType::kStrainIntegration, weights);
+  ComputeDASWeightsForSample<ORDER>(corners, coord, direction, 1.0f, DASType::kStrainIntegration, weights);
 
   // Assign node displacements: u_x = x_node (linear in x)
   // Need to compute node positions. For a Cartesian element with ORDER=2,
@@ -200,8 +175,7 @@ TEST_F(DASReceiverTest, StrainWeightsLinearFieldGivesConstantStrain)
   float strain = 0;
   for (int c = 0; c <= ORDER; ++c)
     for (int b = 0; b <= ORDER; ++b)
-      for (int a = 0; a <= ORDER; ++a)
-      {
+      for (int a = 0; a <= ORDER; ++a) {
         int nodeIdx = a + b * (ORDER + 1) + c * (ORDER + 1) * (ORDER + 1);
         // GLL points for order 2: xi = {-1, 0, 1} → physical x = x0 +
         // dx*(xi+1)/2 More precisely: node a of (ORDER+1) → xi_a. For ORDER=2:
@@ -214,8 +188,7 @@ TEST_F(DASReceiverTest, StrainWeightsLinearFieldGivesConstantStrain)
   EXPECT_NEAR(strain, 1.0f, 1e-3f);
 }
 
-TEST_F(DASReceiverTest, StrainWeightsOrder1)
-{
+TEST_F(DASReceiverTest, StrainWeightsOrder1) {
   // Test strain weights for order 1 element
   real_t corners[8][3];
   makeCornerCoords(0.0f, 0.0f, 0.0f, 10.0f, 10.0f, 10.0f, corners);
@@ -224,12 +197,10 @@ TEST_F(DASReceiverTest, StrainWeightsOrder1)
   std::array<float, 3> direction = {0.0f, 1.0f, 0.0f};  // Y-direction
 
   constexpr int ORDER = 1;
-  constexpr int npe =
-      Qk_Hexahedron_Lagrange_GaussLobatto_Selector<ORDER>::type::numNodes;
+  constexpr int npe = Qk_Hexahedron_Lagrange_GaussLobatto_Selector<ORDER>::type::numNodes;
   float weights[npe] = {0};
 
-  ComputeDASWeightsForSample<ORDER>(corners, coord, direction, 1.0f,
-                                    DASType::kStrainIntegration, weights);
+  ComputeDASWeightsForSample<ORDER>(corners, coord, direction, 1.0f, DASType::kStrainIntegration, weights);
 
   // Gradients of shape functions in Y direction should sum to 0
   float sum = 0;
@@ -242,8 +213,7 @@ TEST_F(DASReceiverTest, StrainWeightsOrder1)
   // So weights should be ±0.25/dy = ±0.025
   float invDy = 1.0f / 10.0f;
   for (int c = 0; c < 2; ++c)
-    for (int a = 0; a < 2; ++a)
-    {
+    for (int a = 0; a < 2; ++a) {
       int n0 = a + 0 * 2 + c * 4;  // b=0
       int n1 = a + 1 * 2 + c * 4;  // b=1
       EXPECT_NEAR(weights[n0], -0.25f * invDy, 1e-5f);
@@ -251,8 +221,7 @@ TEST_F(DASReceiverTest, StrainWeightsOrder1)
     }
 }
 
-TEST_F(DASReceiverTest, StrainWeightsOrder3)
-{
+TEST_F(DASReceiverTest, StrainWeightsOrder3) {
   // Verify that order 3 strain weights have the right size and sum to 0
   real_t corners[8][3];
   makeCornerCoords(0.0f, 0.0f, 0.0f, 100.0f, 100.0f, 100.0f, corners);
@@ -261,13 +230,11 @@ TEST_F(DASReceiverTest, StrainWeightsOrder3)
   std::array<float, 3> direction = {0.0f, 0.0f, 1.0f};
 
   constexpr int ORDER = 3;
-  constexpr int npe =
-      Qk_Hexahedron_Lagrange_GaussLobatto_Selector<ORDER>::type::numNodes;
+  constexpr int npe = Qk_Hexahedron_Lagrange_GaussLobatto_Selector<ORDER>::type::numNodes;
   static_assert(npe == 64, "Order 3 should have 64 nodes");
   float weights[npe] = {0};
 
-  ComputeDASWeightsForSample<ORDER>(corners, coord, direction, 1.0f,
-                                    DASType::kStrainIntegration, weights);
+  ComputeDASWeightsForSample<ORDER>(corners, coord, direction, 1.0f, DASType::kStrainIntegration, weights);
 
   float sum = 0;
   for (int i = 0; i < npe; ++i) sum += weights[i];
@@ -277,8 +244,7 @@ TEST_F(DASReceiverTest, StrainWeightsOrder3)
 // ---------------------------------------------------------------
 // Test integration constant scaling
 // ---------------------------------------------------------------
-TEST_F(DASReceiverTest, IntegrationConstantScaling)
-{
+TEST_F(DASReceiverTest, IntegrationConstantScaling) {
   real_t corners[8][3];
   makeCornerCoords(0.0f, 0.0f, 0.0f, 100.0f, 100.0f, 100.0f, corners);
 
@@ -286,19 +252,15 @@ TEST_F(DASReceiverTest, IntegrationConstantScaling)
   std::array<float, 3> direction = {1.0f, 0.0f, 0.0f};
 
   constexpr int ORDER = 2;
-  constexpr int npe =
-      Qk_Hexahedron_Lagrange_GaussLobatto_Selector<ORDER>::type::numNodes;
+  constexpr int npe = Qk_Hexahedron_Lagrange_GaussLobatto_Selector<ORDER>::type::numNodes;
 
   float weights1[npe] = {0};
   float weights2[npe] = {0};
 
-  ComputeDASWeightsForSample<ORDER>(corners, coord, direction, 1.0f,
-                                    DASType::kDipole, weights1);
-  ComputeDASWeightsForSample<ORDER>(corners, coord, direction, 3.0f,
-                                    DASType::kDipole, weights2);
+  ComputeDASWeightsForSample<ORDER>(corners, coord, direction, 1.0f, DASType::kDipole, weights1);
+  ComputeDASWeightsForSample<ORDER>(corners, coord, direction, 3.0f, DASType::kDipole, weights2);
 
-  for (int i = 0; i < npe; ++i)
-    EXPECT_NEAR(weights2[i], 3.0f * weights1[i], 1e-6f);
+  for (int i = 0; i < npe; ++i) EXPECT_NEAR(weights2[i], 3.0f * weights1[i], 1e-6f);
 }
 
 }  // namespace test

--- a/tests/units/utils/test_evaluate_ricker.cc
+++ b/tests/units/utils/test_evaluate_ricker.cc
@@ -4,13 +4,10 @@
 
 #include "utils.h"
 
-namespace utils
-{
-namespace test
-{
+namespace utils {
+namespace test {
 
-class EvaluateRickerTest : public ::testing::Test
-{
+class EvaluateRickerTest : public ::testing::Test {
  protected:
   SolverUtils ricker;
   static constexpr float f0 = 5.0f;
@@ -21,21 +18,18 @@ class EvaluateRickerTest : public ::testing::Test
 
 // --- Order 0: g(t) = -(t - tpeak) * exp(-2*lam*(t-tpeak)^2) ---
 // At t = tpeak => 0
-TEST_F(EvaluateRickerTest, Order0_AtPeak_IsZero)
-{
+TEST_F(EvaluateRickerTest, Order0_AtPeak_IsZero) {
   EXPECT_NEAR(ricker.evaluateRicker(tpeak, f0, 0, tpeak), 0.0f, 1e-7f);
 }
 
 // --- Order 1 (first derivative of Gaussian): -2*lam*(t-tpeak)*exp(...)  ---
 // At t = tpeak => 0  (odd function around tpeak)
-TEST_F(EvaluateRickerTest, Order1_AtPeak_IsZero)
-{
+TEST_F(EvaluateRickerTest, Order1_AtPeak_IsZero) {
   EXPECT_NEAR(ricker.evaluateRicker(tpeak, f0, 1, tpeak), 0.0f, 1e-7f);
 }
 
 // Order 1 is antisymmetric: f(tpeak + dt) = -f(tpeak - dt)
-TEST_F(EvaluateRickerTest, Order1_IsAntisymmetric)
-{
+TEST_F(EvaluateRickerTest, Order1_IsAntisymmetric) {
   float dt = 0.02f;
   float vp = ricker.evaluateRicker(tpeak + dt, f0, 1, tpeak);
   float vm = ricker.evaluateRicker(tpeak - dt, f0, 1, tpeak);
@@ -44,15 +38,13 @@ TEST_F(EvaluateRickerTest, Order1_IsAntisymmetric)
 
 // --- Order 2 (Ricker wavelet / Mexican hat): peak at tpeak ---
 // At t = tpeak: 2*lam*(0 - 1)*exp(0) = -2*lam
-TEST_F(EvaluateRickerTest, Order2_AtPeak)
-{
+TEST_F(EvaluateRickerTest, Order2_AtPeak) {
   float expected = -2.0f * lam;
   EXPECT_NEAR(ricker.evaluateRicker(tpeak, f0, 2, tpeak), expected, 1e-3f);
 }
 
 // Order 2 is symmetric: f(tpeak + dt) = f(tpeak - dt)
-TEST_F(EvaluateRickerTest, Order2_IsSymmetric)
-{
+TEST_F(EvaluateRickerTest, Order2_IsSymmetric) {
   float dt = 0.03f;
   float vp = ricker.evaluateRicker(tpeak + dt, f0, 2, tpeak);
   float vm = ricker.evaluateRicker(tpeak - dt, f0, 2, tpeak);
@@ -61,14 +53,12 @@ TEST_F(EvaluateRickerTest, Order2_IsSymmetric)
 
 // --- Order 3 (third derivative): antisymmetric ---
 // At t = tpeak: (time_n - o_tpeak) = 0 => pulse = 0
-TEST_F(EvaluateRickerTest, Order3_AtPeak_IsZero)
-{
+TEST_F(EvaluateRickerTest, Order3_AtPeak_IsZero) {
   EXPECT_NEAR(ricker.evaluateRicker(tpeak, f0, 3, tpeak), 0.0f, 1e-7f);
 }
 
 // Order 3 is antisymmetric
-TEST_F(EvaluateRickerTest, Order3_IsAntisymmetric)
-{
+TEST_F(EvaluateRickerTest, Order3_IsAntisymmetric) {
   float dt = 0.02f;
   float vp = ricker.evaluateRicker(tpeak + dt, f0, 3, tpeak);
   float vm = ricker.evaluateRicker(tpeak - dt, f0, 3, tpeak);
@@ -77,15 +67,13 @@ TEST_F(EvaluateRickerTest, Order3_IsAntisymmetric)
 
 // --- Order 4 (fourth derivative): symmetric ---
 // At t = tpeak: 4*lam^2 * (3 - 0 + 0) * exp(0) = 12*lam^2
-TEST_F(EvaluateRickerTest, Order4_AtPeak)
-{
+TEST_F(EvaluateRickerTest, Order4_AtPeak) {
   float expected = 12.0f * lam * lam;
   EXPECT_NEAR(ricker.evaluateRicker(tpeak, f0, 4, tpeak), expected, 1e-1f);
 }
 
 // Order 4 is symmetric
-TEST_F(EvaluateRickerTest, Order4_IsSymmetric)
-{
+TEST_F(EvaluateRickerTest, Order4_IsSymmetric) {
   float dt = 0.02f;
   float vp = ricker.evaluateRicker(tpeak + dt, f0, 4, tpeak);
   float vm = ricker.evaluateRicker(tpeak - dt, f0, 4, tpeak);
@@ -93,50 +81,37 @@ TEST_F(EvaluateRickerTest, Order4_IsSymmetric)
 }
 
 // --- Window clipping: outside [-0.9*tpeak, 2.9*tpeak] returns 0 ---
-TEST_F(EvaluateRickerTest, OutsideWindow_ReturnsZero)
-{
-  for (int ord = 0; ord <= 4; ++ord)
-  {
-    EXPECT_FLOAT_EQ(
-        ricker.evaluateRicker(-0.9f * tpeak - 0.001f, f0, ord, tpeak), 0.0f)
+TEST_F(EvaluateRickerTest, OutsideWindow_ReturnsZero) {
+  for (int ord = 0; ord <= 4; ++ord) {
+    EXPECT_FLOAT_EQ(ricker.evaluateRicker(-0.9f * tpeak - 0.001f, f0, ord, tpeak), 0.0f)
         << "order=" << ord << " before window";
-    EXPECT_FLOAT_EQ(
-        ricker.evaluateRicker(2.9f * tpeak + 0.001f, f0, ord, tpeak), 0.0f)
+    EXPECT_FLOAT_EQ(ricker.evaluateRicker(2.9f * tpeak + 0.001f, f0, ord, tpeak), 0.0f)
         << "order=" << ord << " after window";
   }
 }
 
 // --- Derivative consistency: finite-diff of order n-1 ≈ order n ---
 // Verifies that d/dt[ricker(t, order)] ≈ ricker(t, order+1) numerically.
-TEST_F(EvaluateRickerTest, DerivativeConsistency_Order1vs2)
-{
+TEST_F(EvaluateRickerTest, DerivativeConsistency_Order1vs2) {
   float t = tpeak + 0.04f;
   float h = 1e-4f;
-  float fd = (ricker.evaluateRicker(t + h, f0, 1, tpeak) -
-              ricker.evaluateRicker(t - h, f0, 1, tpeak)) /
-             (2.0f * h);
+  float fd = (ricker.evaluateRicker(t + h, f0, 1, tpeak) - ricker.evaluateRicker(t - h, f0, 1, tpeak)) / (2.0f * h);
   float analytical = ricker.evaluateRicker(t, f0, 2, tpeak);
   EXPECT_NEAR(fd, analytical, std::abs(analytical) * 0.01f);
 }
 
-TEST_F(EvaluateRickerTest, DerivativeConsistency_Order2vs3)
-{
+TEST_F(EvaluateRickerTest, DerivativeConsistency_Order2vs3) {
   float t = tpeak + 0.04f;
   float h = 1e-4f;
-  float fd = (ricker.evaluateRicker(t + h, f0, 2, tpeak) -
-              ricker.evaluateRicker(t - h, f0, 2, tpeak)) /
-             (2.0f * h);
+  float fd = (ricker.evaluateRicker(t + h, f0, 2, tpeak) - ricker.evaluateRicker(t - h, f0, 2, tpeak)) / (2.0f * h);
   float analytical = ricker.evaluateRicker(t, f0, 3, tpeak);
   EXPECT_NEAR(fd, analytical, std::abs(analytical) * 0.01f);
 }
 
-TEST_F(EvaluateRickerTest, DerivativeConsistency_Order3vs4)
-{
+TEST_F(EvaluateRickerTest, DerivativeConsistency_Order3vs4) {
   float t = tpeak + 0.04f;
   float h = 1e-4f;
-  float fd = (ricker.evaluateRicker(t + h, f0, 3, tpeak) -
-              ricker.evaluateRicker(t - h, f0, 3, tpeak)) /
-             (2.0f * h);
+  float fd = (ricker.evaluateRicker(t + h, f0, 3, tpeak) - ricker.evaluateRicker(t - h, f0, 3, tpeak)) / (2.0f * h);
   float analytical = ricker.evaluateRicker(t, f0, 4, tpeak);
   EXPECT_NEAR(fd, analytical, std::abs(analytical) * 0.01f);
 }

--- a/tests/validation/validate_solution.cc
+++ b/tests/validation/validate_solution.cc
@@ -24,13 +24,11 @@
  * @struct ComparisonResult
  * @brief Stores error metrics from solution comparison
  */
-struct ComparisonResult
-{
-  double l2_error;    ///< L2 norm of the error
-  double linf_error;  ///< L-infinity norm of the error
-  double
-      relative_l2_error;  ///< Relative L2 error (normalized by analytical norm)
-  size_t num_points;      ///< Number of points compared
+struct ComparisonResult {
+  double l2_error;           ///< L2 norm of the error
+  double linf_error;         ///< L-infinity norm of the error
+  double relative_l2_error;  ///< Relative L2 error (normalized by analytical norm)
+  size_t num_points;         ///< Number of points compared
 };
 
 /**
@@ -39,12 +37,10 @@ struct ComparisonResult
  * @param command The command string to execute
  * @return true if command succeeded (return code 0), false otherwise
  */
-bool execute_command(const std::string& command)
-{
+bool execute_command(const std::string& command) {
   std::cout << "Executing: " << command << std::endl;
   int ret = std::system(command.c_str());
-  if (ret != 0)
-  {
+  if (ret != 0) {
     std::cerr << "Command failed with return code: " << ret << std::endl;
     return false;
   }
@@ -64,23 +60,18 @@ bool execute_command(const std::string& command)
  * @return Vector containing the column values
  * @throw std::runtime_error if file cannot be opened
  */
-std::vector<double> read_column(const std::string& filename, int column_index,
-                                bool invert_sign = false)
-{
+std::vector<double> read_column(const std::string& filename, int column_index, bool invert_sign = false) {
   std::vector<double> data;
   std::ifstream file(filename);
 
-  if (!file.is_open())
-  {
+  if (!file.is_open()) {
     throw std::runtime_error("Cannot open file: " + filename);
   }
 
   std::string line;
-  while (std::getline(file, line))
-  {
+  while (std::getline(file, line)) {
     // Skip empty lines and comments
-    if (line.empty() || line[0] == '#')
-    {
+    if (line.empty() || line[0] == '#') {
       continue;
     }
 
@@ -88,17 +79,14 @@ std::vector<double> read_column(const std::string& filename, int column_index,
     std::vector<double> row_values;
     double value;
 
-    while (iss >> value)
-    {
+    while (iss >> value) {
       row_values.push_back(value);
     }
 
-    if (column_index < static_cast<int>(row_values.size()))
-    {
+    if (column_index < static_cast<int>(row_values.size())) {
       double column_value = row_values[column_index];
       // Invert sign if requested (for elastic case where formulations differ)
-      if (invert_sign)
-      {
+      if (invert_sign) {
         column_value = -column_value;
       }
       data.push_back(column_value);
@@ -123,15 +111,11 @@ std::vector<double> read_column(const std::string& filename, int column_index,
  * @return ComparisonResult structure containing error metrics
  * @throw std::runtime_error if solution sizes don't match
  */
-ComparisonResult compare_solutions(const std::vector<double>& numerical,
-                                   const std::vector<double>& analytical,
-                                   bool normalize = true)
-{
-  if (numerical.size() != analytical.size())
-  {
-    throw std::runtime_error(
-        "Size mismatch: numerical (" + std::to_string(numerical.size()) +
-        ") vs analytical (" + std::to_string(analytical.size()) + ")");
+ComparisonResult compare_solutions(const std::vector<double>& numerical, const std::vector<double>& analytical,
+                                   bool normalize = true) {
+  if (numerical.size() != analytical.size()) {
+    throw std::runtime_error("Size mismatch: numerical (" + std::to_string(numerical.size()) + ") vs analytical (" +
+                             std::to_string(analytical.size()) + ")");
   }
 
   // Make copies for normalization
@@ -139,13 +123,11 @@ ComparisonResult compare_solutions(const std::vector<double>& numerical,
   std::vector<double> ana_data = analytical;
 
   // Normalize if requested (to handle amplitude differences)
-  if (normalize)
-  {
+  if (normalize) {
     // Calculate norms
     double num_norm = 0.0;
     double ana_norm = 0.0;
-    for (size_t i = 0; i < num_data.size(); ++i)
-    {
+    for (size_t i = 0; i < num_data.size(); ++i) {
       num_norm += num_data[i] * num_data[i];
       ana_norm += ana_data[i] * ana_data[i];
     }
@@ -153,10 +135,8 @@ ComparisonResult compare_solutions(const std::vector<double>& numerical,
     ana_norm = std::sqrt(ana_norm);
 
     // Normalize both solutions to unit norm
-    if (num_norm > 1e-14 && ana_norm > 1e-14)
-    {
-      for (size_t i = 0; i < num_data.size(); ++i)
-      {
+    if (num_norm > 1e-14 && ana_norm > 1e-14) {
+      for (size_t i = 0; i < num_data.size(); ++i) {
         num_data[i] /= num_norm;
         ana_data[i] /= ana_norm;
       }
@@ -176,12 +156,10 @@ ComparisonResult compare_solutions(const std::vector<double>& numerical,
   size_t max_error_index = 0;
 
   // Compute error metrics
-  for (size_t i = 0; i < num_data.size(); ++i)
-  {
+  for (size_t i = 0; i < num_data.size(); ++i) {
     double diff = std::abs(num_data[i] - ana_data[i]);
     result.l2_error += diff * diff;
-    if (diff > result.linf_error)
-    {
+    if (diff > result.linf_error) {
       result.linf_error = diff;
       max_error_index = i;
     }
@@ -192,23 +170,17 @@ ComparisonResult compare_solutions(const std::vector<double>& numerical,
   analytical_norm = std::sqrt(analytical_norm);
 
   // Compute relative error (avoid division by zero)
-  if (analytical_norm > 1e-14)
-  {
+  if (analytical_norm > 1e-14) {
     result.relative_l2_error = result.l2_error / analytical_norm;
-  }
-  else
-  {
-    result.relative_l2_error =
-        result.l2_error;  // Absolute error if norm is too small
+  } else {
+    result.relative_l2_error = result.l2_error;  // Absolute error if norm is too small
   }
 
   // Print location of maximum error for debugging
   std::cout << "\nMaximum error location:" << std::endl;
   std::cout << "  Point index:           " << max_error_index << std::endl;
-  std::cout << "  Numerical value:       " << num_data[max_error_index]
-            << std::endl;
-  std::cout << "  Analytical value:      " << ana_data[max_error_index]
-            << std::endl;
+  std::cout << "  Numerical value:       " << num_data[max_error_index] << std::endl;
+  std::cout << "  Analytical value:      " << ana_data[max_error_index] << std::endl;
   std::cout << "  Absolute difference:   " << result.linf_error << std::endl;
 
   return result;
@@ -220,8 +192,7 @@ ComparisonResult compare_solutions(const std::vector<double>& numerical,
  * @param result The comparison result to display
  * @param tolerance The tolerance threshold for validation
  */
-void print_results(const ComparisonResult& result, double tolerance)
-{
+void print_results(const ComparisonResult& result, double tolerance) {
   std::cout << "\n" << std::string(60, '=') << std::endl;
   std::cout << "VALIDATION RESULTS" << std::endl;
   std::cout << std::string(60, '=') << std::endl;
@@ -229,17 +200,13 @@ void print_results(const ComparisonResult& result, double tolerance)
   std::cout << "Number of points:     " << result.num_points << std::endl;
   std::cout << "L2 error:             " << result.l2_error << std::endl;
   std::cout << "L_inf error:          " << result.linf_error << std::endl;
-  std::cout << "Relative L2 error:    " << result.relative_l2_error
-            << std::endl;
+  std::cout << "Relative L2 error:    " << result.relative_l2_error << std::endl;
   std::cout << "Tolerance:            " << tolerance << std::endl;
   std::cout << std::string(60, '=') << std::endl;
 
-  if (result.relative_l2_error < tolerance)
-  {
+  if (result.relative_l2_error < tolerance) {
     std::cout << "✓ VALIDATION PASSED" << std::endl;
-  }
-  else
-  {
+  } else {
     std::cout << "✗ VALIDATION FAILED" << std::endl;
   }
   std::cout << std::string(60, '=') << std::endl;
@@ -259,8 +226,7 @@ void print_results(const ComparisonResult& result, double tolerance)
  * @param argv Array of command line argument strings
  * @return 0 if validation passed, 1 if validation failed or error occurred
  */
-int main(int argc, char* argv[])
-{
+int main(int argc, char* argv[]) {
   // ====================================================================
   // Default paths (can be overridden by CMake at compile time)
   // ====================================================================
@@ -275,13 +241,11 @@ int main(int argc, char* argv[])
 #endif
 
 #ifndef VALIDATION_REFERENCE_ACOUSTIC
-#define VALIDATION_REFERENCE_ACOUSTIC \
-  "../tests/validation/analyticalsolution/P.dat"
+#define VALIDATION_REFERENCE_ACOUSTIC "../tests/validation/analyticalsolution/P.dat"
 #endif
 
 #ifndef VALIDATION_REFERENCE_ELASTIC
-#define VALIDATION_REFERENCE_ELASTIC \
-  "../tests/validation/analyticalsolution/Ux.dat"
+#define VALIDATION_REFERENCE_ELASTIC "../tests/validation/analyticalsolution/Ux.dat"
 #endif
 
   // ====================================================================
@@ -293,12 +257,11 @@ int main(int argc, char* argv[])
 
   // Set MPLBACKEND=Agg to prevent matplotlib from showing plots
   // (non-interactive mode)
-  std::string postprocess_command =
-      std::string("MPLBACKEND=Agg python3 ") + EXTRACT_RECEIVERS_SCRIPT;
+  std::string postprocess_command = std::string("MPLBACKEND=Agg python3 ") + EXTRACT_RECEIVERS_SCRIPT;
 
   // Files to compare
   std::string numerical_file = "seismogram_output.txt";  // FUnTiDES output
-  std::string analytical_file;  // Will be set based on test type
+  std::string analytical_file;                           // Will be set based on test type
 
   // Column indices for comparison (0-based indexing)
   int numerical_column = 0;   // For FUnTiDES output, solution is in 1st column
@@ -316,41 +279,25 @@ int main(int argc, char* argv[])
   bool is_model_on_nodes = false;       // Default: model not on nodes
   std::string mesh_type = "cartesian";  // Default: cartesian mesh
 
-  for (int i = 1; i < argc; ++i)
-  {
+  for (int i = 1; i < argc; ++i) {
     std::string arg = argv[i];
-    if (arg == "--tolerance" && i + 1 < argc)
-    {
+    if (arg == "--tolerance" && i + 1 < argc) {
       tolerance = std::stod(argv[++i]);
-    }
-    else if (arg == "--order" && i + 1 < argc)
-    {
+    } else if (arg == "--order" && i + 1 < argc) {
       polynomial_order = std::stoi(argv[++i]);
-    }
-    else if (arg == "--elastic" || arg == "--is-elastic")
-    {
+    } else if (arg == "--elastic" || arg == "--is-elastic") {
       is_elastic = true;
-    }
-    else if (arg == "--is-model-on-nodes")
-    {
+    } else if (arg == "--is-model-on-nodes") {
       is_model_on_nodes = true;
-    }
-    else if (arg == "--mesh" && i + 1 < argc)
-    {
+    } else if (arg == "--mesh" && i + 1 < argc) {
       mesh_type = argv[++i];
-    }
-    else if (arg == "--help")
-    {
+    } else if (arg == "--help") {
       std::cout << "Usage: " << argv[0] << " [OPTIONS]" << std::endl;
       std::cout << "Options:" << std::endl;
-      std::cout << "  --tolerance VALUE    Validation tolerance (default: "
-                << tolerance << ")" << std::endl;
-      std::cout << "  --order N            Polynomial order (default: 1)"
-                << std::endl;
-      std::cout << "  --elastic            Run elastic case (default: acoustic)"
-                << std::endl;
-      std::cout << "  --is-model-on-nodes  Enable model on nodes (default: off)"
-                << std::endl;
+      std::cout << "  --tolerance VALUE    Validation tolerance (default: " << tolerance << ")" << std::endl;
+      std::cout << "  --order N            Polynomial order (default: 1)" << std::endl;
+      std::cout << "  --elastic            Run elastic case (default: acoustic)" << std::endl;
+      std::cout << "  --is-model-on-nodes  Enable model on nodes (default: off)" << std::endl;
       std::cout << "  --mesh TYPE          Mesh type: cartesian or ucartesian "
                    "(default: cartesian)"
                 << std::endl;
@@ -365,8 +312,7 @@ int main(int argc, char* argv[])
 
   // Build optional flags
   std::string elastic_flag = is_elastic ? " --is-elastic" : "";
-  std::string model_on_nodes_flag =
-      is_model_on_nodes ? " --is-model-on-nodes" : "";
+  std::string model_on_nodes_flag = is_model_on_nodes ? " --is-model-on-nodes" : "";
 
   // Adjust mesh resolution based on polynomial order to keep similar number of
   // DOFs For order p, an element has (p+1) points per direction To keep total
@@ -376,18 +322,14 @@ int main(int argc, char* argv[])
   int elements_per_direction = base_points / (polynomial_order + 1);
 
   // Construct full solver command
-  solver_command = std::string(FUNTIDES_EXECUTABLE) + " --order " +
-                   std::to_string(polynomial_order) + " --mesh=" + mesh_type +
-                   " --ex " + std::to_string(elements_per_direction) +
-                   " --ey " + std::to_string(elements_per_direction) +
-                   " --ez " + std::to_string(elements_per_direction) +
-                   " --implem makutu --dt 0.001 --anisotropy iso " +
-                   elastic_flag + model_on_nodes_flag;
+  solver_command = std::string(FUNTIDES_EXECUTABLE) + " --order " + std::to_string(polynomial_order) +
+                   " --mesh=" + mesh_type + " --ex " + std::to_string(elements_per_direction) + " --ey " +
+                   std::to_string(elements_per_direction) + " --ez " + std::to_string(elements_per_direction) +
+                   " --implem makutu --dt 0.001 --anisotropy iso " + elastic_flag + model_on_nodes_flag;
 
   // Select reference file based on test type
   std::string test_type = is_elastic ? "elastic" : "acoustic";
-  analytical_file =
-      is_elastic ? VALIDATION_REFERENCE_ELASTIC : VALIDATION_REFERENCE_ACOUSTIC;
+  analytical_file = is_elastic ? VALIDATION_REFERENCE_ELASTIC : VALIDATION_REFERENCE_ACOUSTIC;
 
   // ====================================================================
   // Display configuration
@@ -399,13 +341,10 @@ int main(int argc, char* argv[])
   std::cout << "Test type:            " << test_type << std::endl;
   std::cout << "Polynomial order:     " << polynomial_order << std::endl;
   std::cout << "Mesh type:            " << mesh_type << std::endl;
-  std::cout << "Model on nodes:       " << (is_model_on_nodes ? "yes" : "no")
-            << std::endl;
-  std::cout << "Mesh resolution:      " << elements_per_direction << "x"
-            << elements_per_direction << "x" << elements_per_direction
-            << " elements" << std::endl;
-  std::cout << "Points per direction: ~"
-            << elements_per_direction * (polynomial_order + 1) << std::endl;
+  std::cout << "Model on nodes:       " << (is_model_on_nodes ? "yes" : "no") << std::endl;
+  std::cout << "Mesh resolution:      " << elements_per_direction << "x" << elements_per_direction << "x"
+            << elements_per_direction << " elements" << std::endl;
+  std::cout << "Points per direction: ~" << elements_per_direction * (polynomial_order + 1) << std::endl;
   std::cout << "Tolerance:            " << tolerance << std::endl;
   std::cout << "Reference file:       " << analytical_file << std::endl;
   std::cout << std::string(60, '=') << std::endl;
@@ -414,20 +353,17 @@ int main(int argc, char* argv[])
   // EXECUTION
   // ====================================================================
 
-  try
-  {
+  try {
     // Step 1: Run the solver
     std::cout << "\n[1/3] Running FUnTiDES solver..." << std::endl;
-    if (!execute_command(solver_command))
-    {
+    if (!execute_command(solver_command)) {
       std::cerr << "Solver execution failed!" << std::endl;
       return 1;
     }
 
     // Step 2: Post-process results to generate receiver file
     std::cout << "\n[2/3] Post-processing results..." << std::endl;
-    if (!execute_command(postprocess_command))
-    {
+    if (!execute_command(postprocess_command)) {
       std::cerr << "Post-processing failed!" << std::endl;
       return 1;
     }
@@ -436,20 +372,15 @@ int main(int argc, char* argv[])
     std::cout << "\n[3/3] Comparing solutions..." << std::endl;
 
     // Read numerical solution
-    std::vector<double> numerical =
-        read_column(numerical_file, numerical_column);
+    std::vector<double> numerical = read_column(numerical_file, numerical_column);
 
     // Read analytical solution (invert sign for elastic case due to formulation
     // differences)
-    std::vector<double> analytical =
-        read_column(analytical_file, analytical_column, is_elastic);
+    std::vector<double> analytical = read_column(analytical_file, analytical_column, is_elastic);
 
-    std::cout << "Read " << numerical.size()
-              << " points from numerical solution" << std::endl;
-    std::cout << "Read " << analytical.size()
-              << " points from reference solution";
-    if (is_elastic)
-    {
+    std::cout << "Read " << numerical.size() << " points from numerical solution" << std::endl;
+    std::cout << "Read " << analytical.size() << " points from reference solution";
+    if (is_elastic) {
       std::cout << " (sign inverted for elastic formulation)";
     }
     std::cout << std::endl;
@@ -459,12 +390,9 @@ int main(int argc, char* argv[])
 
     // Debug: show first few values to check alignment
     std::cout << "\nFirst 5 values comparison:" << std::endl;
-    for (size_t i = 0; i < std::min(size_t(5), numerical.size()); ++i)
-    {
-      std::cout << "  Point " << i << ": numerical=" << numerical[i]
-                << ", analytical=" << analytical[i]
-                << ", diff=" << std::abs(numerical[i] - analytical[i])
-                << std::endl;
+    for (size_t i = 0; i < std::min(size_t(5), numerical.size()); ++i) {
+      std::cout << "  Point " << i << ": numerical=" << numerical[i] << ", analytical=" << analytical[i]
+                << ", diff=" << std::abs(numerical[i] - analytical[i]) << std::endl;
     }
 
     // Print results and determine pass/fail
@@ -472,9 +400,7 @@ int main(int argc, char* argv[])
 
     // Return appropriate exit code
     return (result.relative_l2_error < tolerance) ? 0 : 1;
-  }
-  catch (const std::exception& e)
-  {
+  } catch (const std::exception& e) {
     std::cerr << "Error: " << e.what() << std::endl;
     return 1;
   }


### PR DESCRIPTION
Enforce strict google formatting standard.
Also change line size to 120 for better lisibility with heavy templating.

CI/CD `clang-format` version upgrade from 18 to 19.