### PR TITLE
adding coverage (and better coverage)

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -70,12 +70,12 @@ jobs:
 
       - name: Generate Coverage Report
         run: |
-          cd build
-          mkdir -p coverage-report
-          gcovr -r .. . \
-            --html-details coverage-report/coverage.html \
-            --xml coverage-report/coverage.xml \
-            --filter '.*/src/.*' \
+          mkdir -p build/coverage-report
+
+          gcovr -r . build/ \
+            --html-details build/coverage-report/coverage.html \
+            --xml build/coverage-report/coverage.xml \
+            --filter '^src/' \
             -j $(nproc)
 
       - name: Parse Coverage XML for GitHub

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,110 @@
+name: Code Coverage
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  format-check:
+    uses: ./.github/workflows/format-check.yaml
+
+  coverage:
+    name: C++ Code Coverage
+    needs: format-check
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    defaults:
+      run:
+        shell: bash
+    container:
+      image: ghcr.io/funtides-sim/funtides/funtides-env:latest
+      options: --user root
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Install coverage tools
+        run: |
+          apt-get update
+          apt-get install -y gcovr
+
+      - name: Configure CMake
+        run: |
+          mkdir build
+          cd build
+          CC=gcc-13 CXX=g++-13 cmake .. \
+            -DCOMPILE_FD=ON \
+            -DCOMPILE_SEM=ON \
+            -DMAX_SOLVER_ORDER=3 \
+            -DMAX_DIFFERENTIATOR_ORDER=3 \
+            -DENABLE_PYWRAP=OFF \
+            -DENABLE_COVERAGE=ON
+
+      - name: Build
+        run: |
+          cd build
+          make -j$(nproc)
+
+      - name: Run Tests
+        env:
+          OMP_NUM_THREADS: 2
+          KOKKOS_NUM_THREADS: 2
+        run: |
+          cd build
+          ctest -LE "benchmark|validation" --output-on-failure
+
+      - name: Generate Coverage Report
+        run: |
+          cd build
+          mkdir -p coverage-report
+          gcovr -r .. . \
+            --html-details coverage-report/coverage.html \
+            --xml coverage-report/coverage.xml \
+            --exclude '.*/tests/.*' \
+            --exclude '.*/_deps/.*' \
+            --exclude '.*/tpl/.*' \
+            -j $(nproc)
+
+      - name: Parse Coverage XML for GitHub
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: build/coverage-report/coverage.xml
+          badge: true
+          format: markdown
+          output: both
+          indicators: true
+          thresholds: '60 80'
+
+      - name: Write to Job Summary
+        run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY
+
+      - name: Add Coverage PR Comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event_name == 'pull_request'
+        with:
+          recreate: true
+          path: code-coverage-results.md
+
+      - name: Upload Coverage Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cxx-coverage-report
+          path: build/coverage-report/
+          retention-days: 14

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -14,21 +14,19 @@ on:
   workflow_dispatch:
 
 jobs:
-  format-check:
-    uses: ./.github/workflows/format-check.yaml
-
   coverage:
     name: C++ Code Coverage
-    needs: format-check
     runs-on: ubuntu-latest
 
     permissions:
       contents: read
       pull-requests: write
+      packages: read
 
     defaults:
       run:
         shell: bash
+
     container:
       image: ghcr.io/funtides-sim/funtides/funtides-env:latest
       options: --user root
@@ -77,9 +75,7 @@ jobs:
           gcovr -r .. . \
             --html-details coverage-report/coverage.html \
             --xml coverage-report/coverage.xml \
-            --exclude '.*/tests/.*' \
-            --exclude '.*/_deps/.*' \
-            --exclude '.*/tpl/.*' \
+            --filter '.*/src/.*' \
             -j $(nproc)
 
       - name: Parse Coverage XML for GitHub

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -76,6 +76,7 @@ jobs:
             --html-details build/coverage-report/coverage.html \
             --xml build/coverage-report/coverage.xml \
             --filter '^src/' \
+            --exclude '.*/fd/.*' \
             -j $(nproc)
 
       - name: Parse Coverage XML for GitHub

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The following options can be used to configure your build:
 | `COMPILE_FD`               | Enable compilation of the FD proxy (default: ON)                                   |
 | `COMPILE_SEM`              | Enable compilation of the SEM proxy (default: ON)                                  |
 | `ENABLE_PYWRAP`            | Enable Python bindings via pybind11 (experimental)                                 |
+| `ENABLE_COVERAGE`          | Enable Code coverage. Does not work with device enable                             |
 | `CMAKE_INSTALL_PREFIX`     | Where to install FUnTiDES                                                          |
 | `MAX_SOLVER_ORDER`         | Max polynomial order generated for solvers (reduces compile time & binary size)    |
 | `MAX_DIFFERENTIATOR_ORDER` | Max polynomial order generated for differentiators (reduces compile time)          |

--- a/README.md
+++ b/README.md
@@ -220,3 +220,35 @@ python ./scripts/adios/adios_single_receiver_viz.py
 ```
 
 within the folder containing the `receivers.bp` folder.
+
+
+## Code Coverage
+
+**FUnTiDES** supports code coverage analysis. To enable this feature, set the CMake option `ENABLE_COVERAGE` to `ON`. 
+
+> **Note:** The application will run significantly slower when this option is enabled. Currently, this feature is fully supported on **CPU** but has not been tested on device-specific code (GPU). Ensure that your **Kokkos** installation was not compiled with CUDA or ROCm/AMD support enabled.
+
+### Running Tests
+First, compile the code, then execute the tests using the following command:
+
+```bash
+ctest -LE "benchmark|validation" --output-on-failure
+```
+This command runs all standard tests while excluding benchmarks and validation tests, which can be time-consuming.
+
+### Generating Reports
+To generate a readable **HTML report**, execute the following commands:
+
+```bash
+# Capture coverage data
+lcov --capture --directory . --output-file coverage.info --ignore-errors inconsistent,source
+
+# Filter out external libraries, tests, and build files
+lcov --remove coverage.info '/usr/*' '*/_deps/*' '*/tests/*' '*/buildCov/*' --output-file coverage_cleaned.info --ignore-errors inconsistent,source
+
+# Generate the HTML report
+genhtml coverage_cleaned.info \
+    --output-directory html_report \
+    --ignore-errors inconsistent,source,range \
+    --filter missing
+```

--- a/cmake/CompilerConfig.cmake
+++ b/cmake/CompilerConfig.cmake
@@ -53,3 +53,24 @@ set(CMAKE_CXX_EXTENSIONS OFF CACHE BOOL "Disable gnu++ extensions" FORCE)
 set(CMAKE_CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER} CACHE STRING "" FORCE)
 set(CMAKE_CUDA_ARCHITECTURES native CACHE STRING "Auto-detect CUDA arch" FORCE)
 set(CMAKE_CUDA_STANDARD 17 CACHE STRING "" FORCE)
+
+# Coverage
+option(ENABLE_COVERAGE "Enable code coverage instrumentation" OFF)
+
+if(ENABLE_COVERAGE)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
+        message(STATUS "Coverage: Enabling GCC/Clang instrumentation")
+
+        # Add coverage flags to all languages and linkers
+        add_compile_options(--coverage)
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} --coverage")
+
+        # Crucial: Force -O0 for accurate line mapping.
+        # Optimized code (-O2/-O3) confuses coverage reports.
+        add_compile_options(-O0 -g)
+
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES "NVHPC|PGI")
+        message(WARNING "Coverage: NVHPC may require specific flags (e.g., -Mprof=line)")
+    endif()
+endif()

--- a/src/gradient/impl/common/src/differentiator_factory.cc
+++ b/src/gradient/impl/common/src/differentiator_factory.cc
@@ -87,7 +87,7 @@ std::unique_ptr<Differentiator> makeDifferentiatorSem(int order, meshType mesh, 
                                                       physicType physic) {
   bool const isModelOnNodes = (modelLocation == modelLocationType::kOnNodes);
 
-// Définir une macro de fallback au cas où CMake ne passe pas les variables
+// macro fallback in case of cmake error
 #ifndef MAX_DIFFERENTIATOR_ACOUSTIC_ORDER
 #define MAX_DIFFERENTIATOR_ACOUSTIC_ORDER 3
 #endif

--- a/src/gradient/impl/common/src/differentiator_factory.cc
+++ b/src/gradient/impl/common/src/differentiator_factory.cc
@@ -1,10 +1,10 @@
 #include "differentiator_factory.h"
 
-#include <Integrals.h>
-#include <differentiator_acoustic.h>
-#include <differentiator_elastic.h>
-#include <model_struct.h>
-#include <model_unstruct.h>
+#include "Integrals.h"
+#include "differentiator_acoustic.h"
+#include "differentiator_elastic.h"
+#include "model_struct.h"
+#include "model_unstruct.h"
 
 namespace gradient {
 
@@ -14,9 +14,9 @@ using modelLocationType = utils::enums::modelLocationType;
 using implemType = utils::enums::implemType;
 
 /**
- * @brief Template récursif C++17 qui remplace le switch codé en dur.
- * Il s'arrête exactement à CurrentOrder (défini par CMake) et descend
- * jusqu'à 1.
+ * @brief C++17 recursive template that replaces a hard-coded switch statement.
+ * It stops exactly at CurrentOrder (defined via CMake) and recurses
+ * down to 1.
  */
 template <int CurrentOrder, typename FUNC>
 std::unique_ptr<Differentiator> orderDispatch(int const order, FUNC&& func) {

--- a/src/solver/fe/impl/common/src/solver_factory.cc
+++ b/src/solver/fe/impl/common/src/solver_factory.cc
@@ -95,18 +95,6 @@ std::unique_ptr<Solver> makeSemSolver(int order, feenum::meshType mesh, feenum::
                                       feenum::physicType physic) {
   bool const isModelOnNodes = (modelLocation == feenum::modelLocationType::kOnNodes);
 
-  // // fallback macro
-  // // Used for IDE static analysis
-  // #ifndef MAX_SOLVER_ACOUSTIC_ORDER
-  // #define MAX_SOLVER_ACOUSTIC_ORDER 9
-  // #endif
-  // #ifndef MAX_SOLVER_ELASTIC_ORDER
-  // #define MAX_SOLVER_ELASTIC_ORDER 9
-  // #endif
-  // #ifndef MAX_SOLVER_ELASTOACOUSTIC_ORDER
-  // #define MAX_SOLVER_ELASTOACOUSTIC_ORDER 9
-  // #endif
-
   if (physic == feenum::physicType::kAcoustic) {
     return orderDispatch<MAX_SOLVER_ACOUSTIC_ORDER>(order, [&](auto orderIC) {
       constexpr int ORDER = decltype(orderIC)::value;

--- a/tests/units/gradient/impl/CMakeLists.txt
+++ b/tests/units/gradient/impl/CMakeLists.txt
@@ -1,2 +1,3 @@
+add_subdirectory(common)
 add_subdirectory(acoustic)
 add_subdirectory(elastic)

--- a/tests/units/gradient/impl/common/CMakeLists.txt
+++ b/tests/units/gradient/impl/common/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_gtest(differentiator_factory_test
+  test_differentiator_factory.cc
+  funtides_gradient
+)

--- a/tests/units/gradient/impl/common/test_differentiator_factory.cc
+++ b/tests/units/gradient/impl/common/test_differentiator_factory.cc
@@ -1,0 +1,106 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <stdexcept>
+
+#include "differentiator.h"
+#include "differentiator_factory.h"
+
+namespace gradient {
+namespace testing {
+
+namespace feenum = utils::enums;
+
+// Helper function to provide a valid baseline configuration
+std::unique_ptr<Differentiator> createDefaultTestDifferentiator(
+    feenum::physicType physic = feenum::physicType::kAcoustic, feenum::meshType mesh = feenum::meshType::kStruct,
+    feenum::modelLocationType loc = feenum::modelLocationType::kOnNodes, int order = 1) {
+  return createDifferentiator(feenum::implemType::kMakutu, mesh, loc, physic, order);
+}
+
+TEST(DifferentiatorFactoryTest, CreatesAcousticStructuredOnNodes) {
+  auto diff = createDefaultTestDifferentiator(feenum::physicType::kAcoustic, feenum::meshType::kStruct,
+                                              feenum::modelLocationType::kOnNodes, 1);
+
+  EXPECT_NE(diff, nullptr);
+}
+
+TEST(DifferentiatorFactoryTest, CreatesElasticUnstructuredOnElements) {
+  // Casting to an unknown value triggers the 'else' branch for isModelOnNodes
+  auto diff = createDefaultTestDifferentiator(feenum::physicType::kElastic, feenum::meshType::kUnstruct,
+                                              static_cast<feenum::modelLocationType>(99), 1);
+
+  EXPECT_NE(diff, nullptr);
+}
+
+TEST(DifferentiatorFactoryTest, ThrowsOnUnsupportedPolynomialOrder) {
+  int unsupported_order = 999;
+
+  EXPECT_THROW(
+      {
+        createDefaultTestDifferentiator(feenum::physicType::kAcoustic, feenum::meshType::kStruct,
+                                        feenum::modelLocationType::kOnNodes, unsupported_order);
+      },
+      std::runtime_error);
+}
+
+TEST(DifferentiatorFactoryTest, ThrowsOnUnsupportedImplementationType) {
+  auto invalid_implem = static_cast<feenum::implemType>(999);
+
+  EXPECT_THROW(
+      {
+        createDifferentiator(invalid_implem, feenum::meshType::kStruct, feenum::modelLocationType::kOnNodes,
+                             feenum::physicType::kAcoustic, 1);
+      },
+      std::runtime_error);
+}
+
+TEST(DifferentiatorFactoryTest, ThrowsOnUnknownPhysicsType) {
+  auto invalid_physic = static_cast<feenum::physicType>(999);
+
+  EXPECT_THROW(
+      {
+        createDefaultTestDifferentiator(invalid_physic, feenum::meshType::kStruct, feenum::modelLocationType::kOnNodes,
+                                        1);
+      },
+      std::runtime_error);
+}
+TEST(DifferentiatorFactoryTest, CreatesAcousticStructuredOnElements) {
+  auto diff = createDefaultTestDifferentiator(
+      feenum::physicType::kAcoustic, feenum::meshType::kStruct,
+      static_cast<feenum::modelLocationType>(99),  // Passe dans le 'else' de isModelOnNodes
+      1);
+  EXPECT_NE(diff, nullptr);
+}
+
+TEST(DifferentiatorFactoryTest, CreatesElasticStructuredOnNodes) {
+  auto diff = createDefaultTestDifferentiator(feenum::physicType::kElastic, feenum::meshType::kStruct,
+                                              feenum::modelLocationType::kOnNodes, 1);
+  EXPECT_NE(diff, nullptr);
+}
+
+TEST(DifferentiatorFactoryTest, CreatesElasticStructuredOnElements) {
+  auto diff = createDefaultTestDifferentiator(feenum::physicType::kElastic, feenum::meshType::kStruct,
+                                              static_cast<feenum::modelLocationType>(99), 1);
+  EXPECT_NE(diff, nullptr);
+}
+
+TEST(DifferentiatorFactoryTest, CreatesAcousticUnstructuredOnNodes) {
+  auto diff = createDefaultTestDifferentiator(feenum::physicType::kAcoustic, feenum::meshType::kUnstruct,
+                                              feenum::modelLocationType::kOnNodes, 1);
+  EXPECT_NE(diff, nullptr);
+}
+
+TEST(DifferentiatorFactoryTest, CreatesAcousticUnstructuredOnElements) {
+  auto diff = createDefaultTestDifferentiator(feenum::physicType::kAcoustic, feenum::meshType::kUnstruct,
+                                              static_cast<feenum::modelLocationType>(99), 1);
+  EXPECT_NE(diff, nullptr);
+}
+
+TEST(DifferentiatorFactoryTest, CreatesElasticUnstructuredOnNodes) {
+  auto diff = createDefaultTestDifferentiator(feenum::physicType::kElastic, feenum::meshType::kUnstruct,
+                                              feenum::modelLocationType::kOnNodes, 1);
+  EXPECT_NE(diff, nullptr);
+}
+}  // namespace testing
+}  // namespace gradient

--- a/tests/units/solver/impl/CMakeLists.txt
+++ b/tests/units/solver/impl/CMakeLists.txt
@@ -25,6 +25,11 @@ add_gtest(solver_data_test
   proxy_solver
 )
 
+add_gtest(solver_factory_test
+  test_solver_factory.cc
+  proxy_solver
+)
+
 if(USE_MPI)
 add_executable(test_mpi_partitioning test_mpi_partitioning.cc)
 target_link_libraries(test_mpi_partitioning

--- a/tests/units/solver/impl/CMakeLists.txt
+++ b/tests/units/solver/impl/CMakeLists.txt
@@ -20,6 +20,11 @@ add_gtest(rhs_elastic_test
   proxy_solver
 )
 
+add_gtest(solver_data_test
+  test_solver_data.cc
+  proxy_solver
+)
+
 if(USE_MPI)
 add_executable(test_mpi_partitioning test_mpi_partitioning.cc)
 target_link_libraries(test_mpi_partitioning
@@ -35,14 +40,14 @@ endif()
 
 # target_link_libraries(attenuation_test PRIVATE proxy_model_builder_cartesian)
 
-add_gtest(attenuation_receiver_test
-  test_attenuation_receiver.cc
-  proxy_solver
-)
-target_link_libraries(attenuation_receiver_test PRIVATE proxy_model_builder_cartesian)
+# add_gtest(attenuation_receiver_test
+#   test_attenuation_receiver.cc
+#   proxy_solver
+# )
+# target_link_libraries(attenuation_receiver_test PRIVATE proxy_model_builder_cartesian)
 
-add_gtest(attenuation_reference_test
-  test_attenuation_reference.cc
-  proxy_solver
-)
-target_link_libraries(attenuation_reference_test PRIVATE proxy_model_builder_cartesian)
+# add_gtest(attenuation_reference_test
+#   test_attenuation_reference.cc
+#   proxy_solver
+# )
+# target_link_libraries(attenuation_reference_test PRIVATE proxy_model_builder_cartesian)

--- a/tests/units/solver/impl/test_solver_data.cc
+++ b/tests/units/solver/impl/test_solver_data.cc
@@ -1,0 +1,132 @@
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include "rhs_acoustic.h"
+#include "rhs_elastic.h"
+#include "sem_solver_data.h"
+#include "wavefield_acoustic.h"
+#include "wavefield_elastic.h"
+
+namespace solver {
+namespace fe {
+namespace testing {
+
+// ============================================================================
+// Print Method Tests (Using standard cout redirection)
+// ============================================================================
+
+class SEMSolverDataPrintTest : public ::testing::Test {
+ protected:
+  std::stringstream buffer;
+  std::streambuf* originalCoutBuffer;
+
+  void SetUp() override {
+    // Redirect std::cout to the local buffer before each test
+    originalCoutBuffer = std::cout.rdbuf(buffer.rdbuf());
+  }
+
+  void TearDown() override {
+    // Restore the original std::cout buffer after each test
+    std::cout.rdbuf(originalCoutBuffer);
+  }
+};
+
+TEST_F(SEMSolverDataPrintTest, PrintMethodOutputsAcousticInfo) {
+  WavefieldAcoustic mock_wavefield;
+  RhsAcoustic mock_rhs;
+
+  SEMsolverDataAcoustic solver_data(mock_wavefield, mock_rhs);
+
+  solver_data.print();
+
+  std::string output = buffer.str();
+
+  // Verify key components of the output string
+  EXPECT_TRUE(output.find("SEMsolverData<") != std::string::npos);
+  EXPECT_TRUE(output.find("Field[0]") != std::string::npos);
+  EXPECT_TRUE(output.find("size:") != std::string::npos);
+  EXPECT_TRUE(output.find("RHS[0] size:") != std::string::npos);
+  EXPECT_TRUE(output.find("RHS Element size:") != std::string::npos);
+  EXPECT_TRUE(output.find("RHS Weights size:") != std::string::npos);
+}
+
+TEST_F(SEMSolverDataPrintTest, PrintMethodOutputsElasticInfo) {
+  WavefieldElastic mock_wavefield;
+  RhsElastic mock_rhs;
+  bool is_distributed = true;
+
+  SEMsolverDataElastic solver_data(mock_wavefield, mock_rhs, is_distributed);
+
+  solver_data.print();
+
+  std::string output = buffer.str();
+
+  EXPECT_TRUE(output.find("SEMsolverData<") != std::string::npos);
+  EXPECT_TRUE(output.find("Field[0]") != std::string::npos);
+  EXPECT_TRUE(output.find("Field[1]") != std::string::npos);
+  EXPECT_TRUE(output.find("Field[2]") != std::string::npos);
+  EXPECT_TRUE(output.find("RHS Element size:") != std::string::npos);
+}
+
+// ============================================================================
+// General Acoustic Tests
+// ============================================================================
+
+TEST(SEMsolverDataAcousticTest, InitializesAndDelegatesCorrectly) {
+  WavefieldAcoustic wavefield;
+  RhsAcoustic rhs;
+
+  SEMsolverDataAcoustic solver_data(wavefield, rhs);
+
+  // Verify delegation by comparing the extent of the returned views
+  EXPECT_EQ(solver_data.getCurrentField(0).extent(0), wavefield.getCurrentField(0).extent(0));
+
+  EXPECT_EQ(solver_data.getPreviousField(0).extent(0), wavefield.getPreviousField(0).extent(0));
+
+  EXPECT_EQ(solver_data.getRhsTerm(0).extent(0), rhs.getTerm(0).extent(0));
+
+  EXPECT_EQ(solver_data.getRhsElement().extent(0), rhs.getElement().extent(0));
+
+  EXPECT_EQ(solver_data.getRhsWeights().extent(0), rhs.getWeights().extent(0));
+}
+
+TEST(SEMsolverDataAcousticTest, SwapsWavefieldsWithoutThrowing) {
+  WavefieldAcoustic wavefield;
+  RhsAcoustic rhs;
+  SEMsolverDataAcoustic solver_data(wavefield, rhs);
+
+  EXPECT_NO_THROW(solver_data.swapWavefields());
+}
+
+// ============================================================================
+// General Elastic Tests
+// ============================================================================
+
+TEST(SEMsolverDataElasticTest, InitializesAndDelegatesCorrectly) {
+  WavefieldElastic wavefield;
+  RhsElastic rhs;
+
+  SEMsolverDataElastic solver_data(wavefield, rhs, false);
+
+  for (int i = 0; i < SEMsolverDataElastic::kNumFields; ++i) {
+    EXPECT_EQ(solver_data.getCurrentField(i).extent(0), wavefield.getCurrentField(i).extent(0));
+  }
+
+  EXPECT_FALSE(solver_data.isDistributed);
+}
+
+TEST(SEMsolverDataElasticTest, RespectsDistributedFlag) {
+  WavefieldElastic wavefield;
+  RhsElastic rhs;
+
+  SEMsolverDataElastic solver_data(wavefield, rhs, true);
+
+  EXPECT_TRUE(solver_data.isDistributed);
+}
+
+}  // namespace testing
+}  // namespace fe
+}  // namespace solver

--- a/tests/units/solver/impl/test_solver_factory.cc
+++ b/tests/units/solver/impl/test_solver_factory.cc
@@ -1,0 +1,89 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <stdexcept>
+
+#include "solver.h"
+#include "solver_factory.h"
+
+namespace solver::fe::solver_factory {
+
+namespace feenum = utils::enums;
+
+struct SolverTestParams {
+  feenum::physicType physic;
+  feenum::meshType mesh;
+  feenum::modelLocationType location;
+  int order;
+};
+
+class SolverFactoryMatrixTest : public ::testing::TestWithParam<SolverTestParams> {};
+
+/* Validates all physics, mesh types, and model locations (OnNodes vs OnElements) */
+TEST_P(SolverFactoryMatrixTest, ProducesNonNullSolver) {
+  auto const& p = GetParam();
+
+  std::unique_ptr<Solver> s;
+  EXPECT_NO_THROW({
+    s = createSolver(feenum::methodType::kSem, feenum::implemType::kMakutu, p.mesh, p.location, p.physic, p.order);
+  });
+
+  ASSERT_NE(s, nullptr);
+}
+
+INSTANTIATE_TEST_SUITE_P(FullMatrix, SolverFactoryMatrixTest,
+                         ::testing::Values(
+                             /* Structured Mesh: Covering both OnNodes and OnElements for all physics */
+                             SolverTestParams{feenum::physicType::kAcoustic, feenum::meshType::kStruct,
+                                              feenum::modelLocationType::kOnNodes, 1},
+                             SolverTestParams{feenum::physicType::kAcoustic, feenum::meshType::kStruct,
+                                              feenum::modelLocationType::kOnElements, 1},
+                             SolverTestParams{feenum::physicType::kElastic, feenum::meshType::kStruct,
+                                              feenum::modelLocationType::kOnNodes, 2},
+                             SolverTestParams{feenum::physicType::kElastic, feenum::meshType::kStruct,
+                                              feenum::modelLocationType::kOnElements, 2},
+                             SolverTestParams{feenum::physicType::kAcoustoElastic, feenum::meshType::kStruct,
+                                              feenum::modelLocationType::kOnNodes, 1},
+                             SolverTestParams{feenum::physicType::kAcoustoElastic, feenum::meshType::kStruct,
+                                              feenum::modelLocationType::kOnElements, 1},
+
+                             /* Unstructured Mesh: Covering both OnNodes and OnElements for all physics */
+                             SolverTestParams{feenum::physicType::kAcoustic, feenum::meshType::kUnstruct,
+                                              feenum::modelLocationType::kOnNodes, 1},
+                             SolverTestParams{feenum::physicType::kAcoustic, feenum::meshType::kUnstruct,
+                                              feenum::modelLocationType::kOnElements, 1},
+                             SolverTestParams{feenum::physicType::kElastic, feenum::meshType::kUnstruct,
+                                              feenum::modelLocationType::kOnNodes, 2},
+                             SolverTestParams{feenum::physicType::kElastic, feenum::meshType::kUnstruct,
+                                              feenum::modelLocationType::kOnElements, 2},
+                             SolverTestParams{feenum::physicType::kAcoustoElastic, feenum::meshType::kUnstruct,
+                                              feenum::modelLocationType::kOnNodes, 1},
+                             SolverTestParams{feenum::physicType::kAcoustoElastic, feenum::meshType::kUnstruct,
+                                              feenum::modelLocationType::kOnElements, 1}));
+
+class SolverFactoryErrorTest : public ::testing::Test {};
+
+/* Covers the 'throw std::runtime_error("Unknown physics type")' line */
+TEST_F(SolverFactoryErrorTest, ThrowsOnUnknownPhysics) {
+  auto unknownPhysic = static_cast<feenum::physicType>(99);
+  EXPECT_THROW(createSolver(feenum::methodType::kSem, feenum::implemType::kMakutu, feenum::meshType::kStruct,
+                            feenum::modelLocationType::kOnNodes, unknownPhysic, 1),
+               std::runtime_error);
+}
+
+/* Covers orderDispatch failure paths */
+TEST_F(SolverFactoryErrorTest, ThrowsOnInvalidPolynomialOrder) {
+  EXPECT_THROW(createSolver(feenum::methodType::kSem, feenum::implemType::kMakutu, feenum::meshType::kStruct,
+                            feenum::modelLocationType::kOnNodes, feenum::physicType::kAcoustic, 999),
+               std::runtime_error);
+}
+
+/* Covers unsupported implementation fallback */
+TEST_F(SolverFactoryErrorTest, ThrowsOnUnsupportedMethodOrImpl) {
+  auto unsupportedMethod = static_cast<feenum::methodType>(99);
+  EXPECT_THROW(createSolver(unsupportedMethod, feenum::implemType::kMakutu, feenum::meshType::kStruct,
+                            feenum::modelLocationType::kOnNodes, feenum::physicType::kAcoustic, 1),
+               std::runtime_error);
+}
+
+}  // namespace solver::fe::solver_factory


### PR DESCRIPTION
## Description:

This PR aims to add code coverage for tests case. Then to enforce code coverage verification in CI/CD. Current Coverage is low with only 36% of line covered by test. This is due to no test for FD or SEM Elastoacoutic solver.

Note that coverage is intended to work on CPU build. Disable Kokkos Cuda support to test it.

## New Features:

- Add `ENABLE_COVERAGE` option for cmake that sets compilers flags.
- Add GH Action for code coverage.
- Add unit tests for sem data.
- Add unit tests for solver factory.
- Extend README.md to include coverage with GNU tools.

## Miscs

- Remove commented code in `solver_factory.cc`
- Commented attenuation test. @sframba see #277 to re-enable them. Otherwise, coverage tests are way too long.
- cleaning differentiator factory comments in french and head inclusion.

## Current Coverage on CPU (No FD)
<img width="982" height="781" alt="image" src="https://github.com/user-attachments/assets/a250a982-225f-46e1-9888-c5d5b9ee236e" />
