### PR TITLE
remove main and grid folder from coverage test

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -76,7 +76,7 @@ jobs:
             --html-details build/coverage-report/coverage.html \
             --xml build/coverage-report/coverage.xml \
             --filter '^src/' \
-            --exclude '.*/fd/.*' \
+            --exclude '.*/fd/.*' '.*/main/*' '.*/grid/*' \
             -j $(nproc)
 
       - name: Parse Coverage XML for GitHub

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -76,7 +76,9 @@ jobs:
             --html-details build/coverage-report/coverage.html \
             --xml build/coverage-report/coverage.xml \
             --filter '^src/' \
-            --exclude '.*/fd/.*' '.*/main/*' '.*/grid/*' \
+            --exclude '.*/fd/.*' \
+            --exclude '.*/main/.*' \
+            --exclude '.*/grid/.*' \
             -j $(nproc)
 
       - name: Parse Coverage XML for GitHub


### PR DESCRIPTION
Code in main should not be examined in coverage.
The same goes for `grid` that belongs to FD, which is not covered.