### PR TITLE
improve perf of acoustic solver element contribution

### DIFF
--- a/src/solver/fe/impl/common/include/sem_solver_impl.h
+++ b/src/solver/fe/impl/common/include/sem_solver_impl.h
@@ -358,20 +358,22 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::com
     local_workVectorsGlobal[f] = workVectorsGlobal_[f];
   }
 
+  using Policy = Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>;
+
   Kokkos::parallel_for(
-      "Solver Element Contribution Acoustic", Kokkos::RangePolicy(0, n_iter), KOKKOS_LAMBDA(const int _loop_idx) {
+      "Solver Element Contribution Acoustic", Policy(0, n_iter), KOKKOS_LAMBDA(const int _loop_idx) {
         int const elementNumber = list_on ? list_local[_loop_idx] : _loop_idx;
 
-        int const dim = mesh_local.getOrder() + 1;
-        float localFields[kNumFields][kPointsPerElement] = {{0}};
+        constexpr int dim = ORDER + 1;
+
+        float localFields[kNumFields][kPointsPerElement];
         float localWork[kNumFields][kPointsPerElement] = {{0}};
 
-        for (int i = 0; i < dim; ++i) {
+        for (int k = 0; k < dim; ++k) {
           for (int j = 0; j < dim; ++j) {
-            for (int k = 0; k < dim; ++k) {
+            for (int i = 0; i < dim; ++i) {
               int const globalIdx = mesh_local.globalNodeIndex(elementNumber, i, j, k);
               int const localIdx = i + j * dim + k * dim * dim;
-
               for (int f = 0; f < kNumFields; ++f) {
                 localFields[f][localIdx] = data.getCurrentField(f)(globalIdx);
               }
@@ -404,12 +406,11 @@ void SEMsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::com
               }
             });
 
-        for (int i = 0; i < dim; ++i) {
+        for (int k = 0; k < dim; ++k) {
           for (int j = 0; j < dim; ++j) {
-            for (int k = 0; k < dim; ++k) {
+            for (int i = 0; i < dim; ++i) {
               int const globalIdx = mesh_local.globalNodeIndex(elementNumber, i, j, k);
               int const localIdx = i + j * dim + k * dim * dim;
-
               for (int f = 0; f < kNumFields; ++f) {
                 ATOMICADD(local_workVectorsGlobal[f][globalIdx], localWork[f][localIdx]);
               }


### PR DESCRIPTION
> *This PR description was drafted with AI assistance based on the `git diff` and the attached Nsight Compute (NCU) profiling report.*

# Optimize `computeElementContributions_Acoustic_Flat` launch configuration and loop ordering

## Summary

This PR targets the low-order acoustic flat kernel (`computeElementContributions_Acoustic_Flat`), which had been identified as underperforming relative to its potential occupancy on GPU. Three targeted changes bring the kernel from **4.03 ms → 1.89 ms** (≈2.13× speedup) on a representative 100×100×100 workload, profiled with Nsight Compute on a Quadro RTX Ada Generation Laptop GPU.

## Changes

### 1. Explicit `LaunchBounds` on the `RangePolicy`

```cpp
using Policy = Kokkos::RangePolicy<Kokkos::LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>>;

Kokkos::parallel_for(
    "Solver Element Contribution Acoustic", Policy(0, n_iter), KOKKOS_LAMBDA(const int _loop_idx) { ... });
```

Previously this kernel launched with a plain `Kokkos::RangePolicy(0, n_iter)`, giving the compiler no hint about the desired register budget per thread. All the other `parallel_for` kernels in this file already use the `LaunchBounds<LaunchMaxThreadsPerBlock, LaunchMinBlocksPerSM>` pattern; this brings the acoustic flat kernel in line and lets `nvcc` cap register usage to hit the target occupancy instead of maximizing single-thread ILP.

### 2. Compile-time `dim` instead of runtime `mesh_local.getOrder() + 1`

```cpp
constexpr int dim = ORDER + 1;
```

`ORDER` is already a template parameter of `SEMsolver`, so `dim` was a compile-time constant hiding behind a runtime mesh query. Making it `constexpr` lets the compiler fully unroll the `dim`-bounded loops and removes a per-thread load + add that was previously repeated on every kernel launch.

### 3. Loop reordering (`i,j,k` → `k,j,i`) in the gather/scatter loops

Both the field-gather loop (global → local) and the contribution-scatter loop (local → global, via `ATOMICADD`) had their nesting flipped so that `i` (the fastest-varying index in `localIdx = i + j*dim + k*dim*dim`) is now the innermost loop, matching the memory layout used by `globalNodeIndex(elementNumber, i, j, k)`. This improves spatial locality of consecutive-thread accesses into `getCurrentField` / `local_workVectorsGlobal`.

### 4. Removed redundant zero-initialization of `localFields`

```cpp
- float localFields[kNumFields][kPointsPerElement] = {{0}};
+ float localFields[kNumFields][kPointsPerElement];
```

`localFields` is fully overwritten by the gather loop before it is ever read, so the zero-init was dead work on every thread. `localWork` still needs its `{{0}}` initializer since it is accumulated into via `ATOMICADD`.

## Performance

NCU comparison, `o2-100x100x100-flat-corr` workload, 128 threads/block:

| Metric | Baseline | Current | Δ |
|---|---|---|---|
| Duration | 4.03 ms | 1.89 ms | **-53.0%** |
| Elapsed cycles | 7,003,657 | 3,288,535 | -53.1% |
| Compute (SM) throughput | ~23.6% | 45.13% | +90.9% |
| Memory throughput | ~36.2% | 70.08% | +93.6% |
| Achieved occupancy | ~16.3% | 32.89% | +102.1% |
| Registers/thread | ~200 | 128 | -36.0% |
| Waves per SM | ~195 | 97.66 | -50.0% |

The `LaunchBounds` hint caps register usage at 128/thread, which doubles the number of resident blocks per SM (`Block Limit Registers` 2 → 4) and roughly doubles both theoretical and achieved occupancy. That, combined with the removal of dead work and the improved access pattern, is what drives the throughput and duration gains.

## Known trade-off / follow-up work

Capping registers at 128 is not free: NCU now reports **local memory spilling** that did not exist in the baseline (4,531,250 spill requests, appearing only in the current run), accounting for ~43% of L1TEX sector traffic, with 82.8% of local loads and 98.6% of local stores attributable to spilling. In this case the occupancy gain still outweighs the spilling cost (net 2.13× speedup), but this is a genuine trade-off, not a strict win on every axis.

NCU flags two remaining opportunities on top of this change, left for a follow-up PR:

- **Register spilling / local memory usage** — est. speedup 33.82%. `localFields` / `localWork` (`kNumFields × kPointsPerElement`) may need to shrink further or move to shared memory instead of relying purely on the register cap.
- **Uncoalesced global loads** — est. speedup 41.05% (L1TEX Global Load Access Pattern only ~20.5/32 bytes utilized per sector). The `i,j,k → k,j,i` reorder improves locality but `globalNodeIndex` still produces a stride across threads that isn't fully coalesced; likely needs a change to the node numbering / indirection itself rather than loop order alone.

## Testing

No functional or numerical change is expected — this is a pure loop-order and launch-configuration change over the same math, so the existing typed test suite (partition of unity, symmetry, volume integration, zero-force for constant fields) should be re-run per polynomial order to confirm floating-point-tolerance equivalence with `main` before merge.
