### PR TITLE
test: limit ModelStruct mesh tests to compiled polynomial orders

### DIFF
--- a/tests/units/model/impl/mesh/struct/CMakeLists.txt
+++ b/tests/units/model/impl/mesh/struct/CMakeLists.txt
@@ -3,6 +3,12 @@ add_gtest(mesh_struct_test
   fun_model
 )
 
+# Restrict the polynomial orders exercised by the typed tests to those actually
+# compiled on this machine (higher orders are not built here).
+target_compile_definitions(mesh_struct_test PRIVATE
+    MAX_SOLVER_ORDER=${TARGET_SOLVER_ACOUSTIC_ORDER}
+)
+
 add_gtest(gllpoints_test
   test_gllpoints.cc
   fun_model

--- a/tests/units/model/impl/mesh/struct/test_struct_mesh.cc
+++ b/tests/units/model/impl/mesh/struct/test_struct_mesh.cc
@@ -8,6 +8,14 @@
 
 #include "model_struct.h"
 
+// Highest polynomial order compiled on this machine. Provided by CMake via
+// MAX_SOLVER_ORDER (see tests/units/model/impl/mesh/struct/CMakeLists.txt).
+// Fall back to the full implementation range when the build does not restrict
+// it, so environments compiling all orders still exercise them.
+#ifndef MAX_SOLVER_ORDER
+#define MAX_SOLVER_ORDER 9
+#endif
+
 namespace model {
 namespace {
 
@@ -57,6 +65,7 @@ struct DoubleOrder3 {
 };
 
 // Order 4 wrappers
+#if MAX_SOLVER_ORDER >= 4
 struct FloatOrder4 {
   using FloatType = float;
   using ScalarType = int;
@@ -68,8 +77,10 @@ struct DoubleOrder4 {
   using ScalarType = int;
   static constexpr int Order = 4;
 };
+#endif
 
 // Order 5 wrappers
+#if MAX_SOLVER_ORDER >= 5
 struct FloatOrder5 {
   using FloatType = float;
   using ScalarType = int;
@@ -81,6 +92,7 @@ struct DoubleOrder5 {
   using ScalarType = int;
   static constexpr int Order = 5;
 };
+#endif
 
 // ============================================================================
 // Test Fixture
@@ -120,9 +132,18 @@ class ModelStructTest : public ::testing::Test {
   std::unique_ptr<ModelStructType> model_;
 };
 
-// Register type wrappers for typed tests
+// Register type wrappers for typed tests. Orders 4 and 5 are only included
+// when they are compiled on the current machine (see MAX_SOLVER_ORDER above).
+#if MAX_SOLVER_ORDER >= 5
 using TypeWrappers = ::testing::Types<FloatOrder1, FloatOrder2, FloatOrder3, FloatOrder4, FloatOrder5, DoubleOrder1,
                                       DoubleOrder2, DoubleOrder3, DoubleOrder4, DoubleOrder5>;
+#elif MAX_SOLVER_ORDER == 4
+using TypeWrappers = ::testing::Types<FloatOrder1, FloatOrder2, FloatOrder3, FloatOrder4, DoubleOrder1, DoubleOrder2,
+                                      DoubleOrder3, DoubleOrder4>;
+#else
+using TypeWrappers =
+    ::testing::Types<FloatOrder1, FloatOrder2, FloatOrder3, DoubleOrder1, DoubleOrder2, DoubleOrder3>;
+#endif
 
 TYPED_TEST_SUITE(ModelStructTest, TypeWrappers);
 
@@ -937,11 +958,27 @@ TYPED_TEST(ModelStructTest, MinSpacingForAllOrders) {
 
   // h = lx/ex = 100/10 = 10 for all orders
   FloatType h = 10.0f;
-  if constexpr (Order == 1) EXPECT_NEAR(min_spacing, h, 1e-4f);
-  if constexpr (Order == 2) EXPECT_NEAR(min_spacing, h * 0.5000000000f, 1e-4f);
-  if constexpr (Order == 3) EXPECT_NEAR(min_spacing, h * 0.2763932023f, 1e-4f);
-  if constexpr (Order == 4) EXPECT_NEAR(min_spacing, h * 0.1726731646f, 1e-4f);
-  if constexpr (Order == 5) EXPECT_NEAR(min_spacing, h * 0.1174723380f, 1e-4f);
+  // NOTE: braces are required around each EXPECT here — nvc++ mis-parses an
+  // un-braced gtest macro used as the body of `if constexpr`.
+  if constexpr (Order == 1) {
+    EXPECT_NEAR(min_spacing, h, 1e-4f);
+  }
+  if constexpr (Order == 2) {
+    EXPECT_NEAR(min_spacing, h * 0.5000000000f, 1e-4f);
+  }
+  if constexpr (Order == 3) {
+    EXPECT_NEAR(min_spacing, h * 0.2763932023f, 1e-4f);
+  }
+#if MAX_SOLVER_ORDER >= 4
+  if constexpr (Order == 4) {
+    EXPECT_NEAR(min_spacing, h * 0.1726731646f, 1e-4f);
+  }
+#endif
+#if MAX_SOLVER_ORDER >= 5
+  if constexpr (Order == 5) {
+    EXPECT_NEAR(min_spacing, h * 0.1174723380f, 1e-4f);
+  }
+#endif
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

On machines that build FUnTiDES with a reduced maximum polynomial order (e.g. `-DMAX_SOLVER_ORDER=3`), the `mesh_struct_test` unit test failed to build. The typed `ModelStructTest` suite was instantiated over orders **1–5**, but orders 4 and 5 are not compiled in a reduced-order build.

This PR restricts the orders exercised by the test to those actually compiled, so the test builds and runs correctly regardless of the configured `MAX_SOLVER_ORDER`, while still covering all orders on full builds.

## Changes

- **`tests/units/model/impl/mesh/struct/test_struct_mesh.cc`**
  - Gate the `FloatOrder4/5` and `DoubleOrder4/5` type wrappers and the `TypeWrappers` list behind `MAX_SOLVER_ORDER`, with a fallback default of `9` (full implementation range) when the macro is not defined, so unrestricted builds keep testing every order.
  - Add braces around the `EXPECT_NEAR` statements inside the `if constexpr` branches of `MinSpacingForAllOrders`. `nvc++` mis-parses an un-braced gtest macro used as the body of `if constexpr` and reports `identifier "gtest_ar" is undefined`; the braces resolve this. (Reproduced in isolation with the exact `nvc++` flags — the error occurs even for orders 1–3, so it is independent of the order count.)
- **`tests/units/model/impl/mesh/struct/CMakeLists.txt`**
  - Pass `MAX_SOLVER_ORDER=${TARGET_SOLVER_ACOUSTIC_ORDER}` as a private compile definition to `mesh_struct_test`, so the tested orders automatically track the orders compiled by the build.

## Verification

- Full build on a `MAX_SOLVER_ORDER=3` machine (NVHPC 23.01 / `nvc++`, CUDA 11.8): completes with no errors (previously failed).
- `ctest -LE "benchmark|validation"`: `mesh_struct_test` builds and all its cases pass, including the 20 `MinSpacingForAllOrders` cases.
- On a full build the macro defaults to 9, so orders 1–5 are still exercised as before.
