### PR TITLE
remove cuda warning with order 4 and 5

### DIFF
--- a/src/discretization/fe/impl/common/LagrangeBasis4GL.h
+++ b/src/discretization/fe/impl/common/LagrangeBasis4GL.h
@@ -438,6 +438,7 @@ class LagrangeBasis4GL {
      * @param N Array to hold the value of the basis functions at each support
      * point.
      */
+    PROXY_HOST_DEVICE
     static void value(const double (&coords)[3], double (&N)[numSupportPoints]) {
       for (int a = 0; a < 5; ++a) {
         for (int b = 0; b < 5; ++b) {

--- a/src/discretization/fe/impl/common/LagrangeBasis5GL.h
+++ b/src/discretization/fe/impl/common/LagrangeBasis5GL.h
@@ -636,6 +636,7 @@ class LagrangeBasis5GL {
      * @param N Array to hold the value of the basis functions at each support
      * point.
      */
+    PROXY_HOST_DEVICE
     static void value(const double (&coords)[3], double (&N)[numSupportPoints]) {
       for (int a = 0; a < 6; ++a) {
         for (int b = 0; b < 6; ++b) {


### PR DESCRIPTION
Add some `PROXY_HOST_DEVICE` in GL for order 4 and 5. This remove compilation warnings.