### PR TITLE
Fix flux computation for DG

### DIFF
--- a/src/discretization/fe/impl/makutu/include/Qk_Hexahedron_Lagrange_GaussLobatto.h
+++ b/src/discretization/fe/impl/makutu/include/Qk_Hexahedron_Lagrange_GaussLobatto.h
@@ -440,6 +440,44 @@ class Qk_Hexahedron_Lagrange_GaussLobatto {
                                                   real_t const (&invJ3D)[3][3], FUNC &&func);
 
   /**
+   * @brief Two-channel variant of computeGradPhiPhi() that also reports the face-normal
+   *   derivative contributions.
+   *
+   * The gradient of a trial function at a face quadrature point splits into two tangential
+   * contributions and one face-normal contribution. The tangential ones only involve basis
+   * functions whose support point lies ON the face, so a single face-indexed callback carries
+   * them. The normal one does not: it reads the (ORDER+1) support points of the line running
+   * through the quadrature point PERPENDICULAR to the face, of which only one is a face dof.
+   *
+   * The single-callback form above collapses that line onto the face dof itself, which makes the
+   * trial value constant over the line; what is left is the coefficient sum
+   * sum_m dPhi_m/dxi(kQFixed) = 0, the derivative of the partition of unity. The normal
+   * derivative therefore cancels exactly and never reaches the caller. On a Cartesian mesh the
+   * inverse Jacobian is diagonal, so the face normal selects the normal direction only and the
+   * whole consistency term of the numerical flux vanishes.
+   *
+   * This variant keeps the tangential contributions on @p func, unchanged, and routes the normal
+   * ones to @p funcNormal with the line depth as first index so the caller can address the
+   * off-face dofs. The single-callback form is left untouched and stays bit-for-bit identical
+   * for callers that have not migrated.
+   *
+   * @tparam kQfa The 1d face quadrature point index in the first face direction.
+   * @tparam kQfb The 1d face quadrature point index in the second face direction.
+   * @param kDir Face-normal direction (kFaceId / 2).
+   * @param kQFixed Quadrature index along the face-normal direction (0 or ORDER).
+   * @param kX Coordinates of the 4 face corner support points.
+   * @param invJ3D Inverse of the volumetric Jacobian at the quadrature point.
+   * @param func Callback (i, j, k, C_ijk) for the tangential contributions, i and j both face
+   *   dofs, see computeGradPhiPhi().
+   * @param funcNormal Callback (m, j, k, C_mjk) for the face-normal contributions. @p m is the
+   *   depth along the face normal, in [0, ORDER]: the trial dof is the element support point at
+   *   depth @p m on the line through face dof @p j. @p j is the face dof of the quadrature point.
+   */
+  template <int kQfa, int kQfb, typename FUNC, typename FUNC_NORMAL>
+  PROXY_HOST_DEVICE static void computeGradPhiPhi(int const kDir, int const kQFixed, real_t const (&kX)[4][3],
+                                                  real_t const (&invJ3D)[3][3], FUNC &&func, FUNC_NORMAL &&funcNormal);
+
+  /**
    * @brief computes the non-zero contributions of the interface flux
    *   block matrix CKL, i.e., the integration of "Grad(Phi_i)*Phi_j"
    *   over a face with the test function "Phi_i" in the element K
@@ -464,6 +502,25 @@ class Qk_Hexahedron_Lagrange_GaussLobatto {
   template <typename FUNC>
   PROXY_HOST_DEVICE static void computeInterfaceFluxTerm(real_t const (&kX)[4][3], real_t const (&X8)[8][3],
                                                          int const kFaceId, FUNC &&func);
+
+  /**
+   * @brief Two-channel variant of computeInterfaceFluxTerm().
+   *
+   * Same quadrature, but the face-normal derivative contributions are reported separately so the
+   * caller can reach the off-face dofs they involve. Without this the consistency term of the
+   * numerical flux is identically zero on a Cartesian mesh; see computeGradPhiPhi() for the
+   * derivation.
+   *
+   * @param kX Coordinates of the 4 face corner support points.
+   * @param X8 Coordinates of the 8 element corner support points.
+   * @param kFaceId Integer (0..5) to specify the integrated face.
+   * @param func Callback (i, j, k, C_ijk) for the tangential contributions.
+   * @param funcNormal Callback (m, j, k, C_mjk) for the face-normal contributions, @p m being the
+   *   depth along the normal and @p j the face dof of the quadrature point.
+   */
+  template <typename FUNC, typename FUNC_NORMAL>
+  PROXY_HOST_DEVICE static void computeInterfaceFluxTerm(real_t const (&kX)[4][3], real_t const (&X8)[8][3],
+                                                         int const kFaceId, FUNC &&func, FUNC_NORMAL &&funcNormal);
 
   /**
    * @brief computes the matrix B, defined as J^{-T}J^{-1}/det(J), where J is
@@ -1043,6 +1100,70 @@ PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeInt
     real_t invJ3D[3][3] = {{0}};
     invJacobianTransformation(kQfa, kQfb, kQFixed, X8, invJ3D);
     computeGradPhiPhi<kQfa, kQfb>(kDir, kQFixed, kX, invJ3D, func);
+  });
+}
+
+template <typename GL_BASIS>
+template <int kQfa, int kQfb, typename FUNC, typename FUNC_NORMAL>
+PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeGradPhiPhi(
+    int const kDir, int const kQFixed, real_t const (&kX)[4][3], real_t const (&invJ3D)[3][3], FUNC &&func,
+    FUNC_NORMAL &&funcNormal) {
+  int ifa, ifb;
+  switch (kDir) {
+    case 0:
+      ifa = 1;
+      ifb = 2;
+      break;
+    case 1:
+      ifa = 0;
+      ifb = 2;
+      break;
+    default:
+      ifa = 0;
+      ifb = 1;
+      break;
+  }
+  const real_t kW2D = static_cast<real_t>(GL_BASIS::weight(kQfa) * GL_BASIS::weight(kQfb));
+  real_t B[3];
+  real_t J[3][2] = {{0}};
+  jacobianTransformation2d(kQfa, kQfb, kX, J);
+  // compute J^T.J, using Voigt notation for B
+  B[0] = J[0][0] * J[0][0] + J[1][0] * J[1][0] + J[2][0] * J[2][0];
+  B[1] = J[0][1] * J[0][1] + J[1][1] * J[1][1] + J[2][1] * J[2][1];
+  B[2] = J[0][0] * J[0][1] + J[1][0] * J[1][1] + J[2][0] * J[2][1];
+  const real_t kDetJ = sqrt(std::abs(symDeterminant(B)));
+  const real_t kVal = kW2D * kDetJ;
+  const int kAbj = GL_BASIS::TensorProduct2D::linearIndex(kQfa, kQfb);
+  for (int i = 0; i < num1dNodes; i++) {
+    const int kIb = GL_BASIS::TensorProduct2D::linearIndex(i, kQfb);
+    const int kAi = GL_BASIS::TensorProduct2D::linearIndex(kQfa, i);
+    const real_t kGifa = basisGradientAt(i, kQfa);
+    const real_t kGifb = basisGradientAt(i, kQfb);
+    const real_t kGiFixed = basisGradientAt(i, kQFixed);
+    for (int k = 0; k < 3; ++k) {
+      // Tangential: the trial support point stays on the face, so a face index carries it.
+      func(kIb, kAbj, k, kVal * invJ3D[ifa][k] * kGifa);
+      func(kAi, kAbj, k, kVal * invJ3D[ifb][k] * kGifb);
+      // Normal: i is the depth along the line perpendicular to the face. Reporting it as a face
+      // index instead (as the single-callback form does) makes the trial value constant over the
+      // line and the sum collapses to sum_i dPhi_i/dxi(kQFixed) = 0.
+      funcNormal(i, kAbj, k, kVal * invJ3D[kDir][k] * kGiFixed);
+    }
+  }
+}
+
+template <typename GL_BASIS>
+template <typename FUNC, typename FUNC_NORMAL>
+PROXY_HOST_DEVICE void Qk_Hexahedron_Lagrange_GaussLobatto<GL_BASIS>::computeInterfaceFluxTerm(
+    real_t const (&kX)[4][3], real_t const (&X8)[8][3], int const kFaceId, FUNC &&func, FUNC_NORMAL &&funcNormal) {
+  const int kDir = kFaceId / 2;
+  const int kQFixed = (kFaceId % 2 == 0) ? 0 : num1dNodes - 1;
+  double_loop<num1dNodes, num1dNodes>([&](auto const kIcqfa, auto const kIcqfb) {
+    constexpr int kQfa = decltype(kIcqfa)::value;
+    constexpr int kQfb = decltype(kIcqfb)::value;
+    real_t invJ3D[3][3] = {{0}};
+    invJacobianTransformation(kQfa, kQfb, kQFixed, X8, invJ3D);
+    computeGradPhiPhi<kQfa, kQfb>(kDir, kQFixed, kX, invJ3D, func, funcNormal);
   });
 }
 

--- a/src/solver/fe/DG/impl/common/include/dg_penalty.h
+++ b/src/solver/fe/DG/impl/common/include/dg_penalty.h
@@ -79,20 +79,10 @@ PROXY_HOST_DEVICE real_t computeHexVolume(real_t const (&X)[8][3]) {
 /**
  * @brief Force a face normal to point OUT of the element, whatever convention produced it.
  *
- * ModelApi::faceNormal has no single orientation convention across its implementations:
- * ModelStruct returns the outward normal (v[face/2] = face%2 ? +1 : -1) while ModelUnstruct
- * returns normalize(t1 x t2) with a vertex ordering that yields the INWARD normal on all six
- * faces. The mismatch stayed invisible for a long time because the interface flux terms -- the
- * only consumers whose result depends on the orientation -- summed to zero on a Cartesian mesh,
- * so the normal multiplied nothing but zeros. The unit tests do not catch it either: the unstruct
- * ones assert only that the normal is unit-length and that opposite faces are antiparallel, both
- * of which a globally flipped normal satisfies.
- *
- * Rather than change faceNormal (its orientation is also consumed by the elastic SEM damping and
- * by the acoustoelastic coupling, which may already compensate for it), the DG kernels orient it
- * here. The outward direction is the one pointing from the element centroid towards the face
- * centroid, which is geometric and therefore valid for deformed hexahedra as well -- and a no-op
- * whenever faceNormal already returned the outward normal.
+ * ModelApi::faceNormal is not consistently outward across implementations (ModelUnstruct returns
+ * the inward normal on all six faces). Rather than touch faceNormal itself, orient it here from
+ * element/face centroids -- geometric, so valid for deformed hexahedra too, and a no-op when the
+ * normal was already outward.
  *
  * @param n        Normal to orient in place.
  * @param X8       Element corner coordinates, ordered X8[iv + 2*jv + 4*kv].
@@ -106,7 +96,6 @@ PROXY_HOST_DEVICE void orientNormalOutward(real_t (&n)[3], real_t const (&X8)[8]
   for (int v = 0; v < 8; ++v)
     for (int d = 0; d < 3; ++d) elemCentroid[d] += 0.125f * X8[v][d];
 
-  // The 4 corners of the face are those whose bit in direction kDir matches the face's side.
   real_t faceCentroid[3] = {0.0f, 0.0f, 0.0f};
   for (int v = 0; v < 8; ++v) {
     if (((v >> kDir) & 1) != kHigh) continue;

--- a/src/solver/fe/DG/impl/common/include/dg_penalty.h
+++ b/src/solver/fe/DG/impl/common/include/dg_penalty.h
@@ -77,6 +77,50 @@ PROXY_HOST_DEVICE real_t computeHexVolume(real_t const (&X)[8][3]) {
 }
 
 /**
+ * @brief Force a face normal to point OUT of the element, whatever convention produced it.
+ *
+ * ModelApi::faceNormal has no single orientation convention across its implementations:
+ * ModelStruct returns the outward normal (v[face/2] = face%2 ? +1 : -1) while ModelUnstruct
+ * returns normalize(t1 x t2) with a vertex ordering that yields the INWARD normal on all six
+ * faces. The mismatch stayed invisible for a long time because the interface flux terms -- the
+ * only consumers whose result depends on the orientation -- summed to zero on a Cartesian mesh,
+ * so the normal multiplied nothing but zeros. The unit tests do not catch it either: the unstruct
+ * ones assert only that the normal is unit-length and that opposite faces are antiparallel, both
+ * of which a globally flipped normal satisfies.
+ *
+ * Rather than change faceNormal (its orientation is also consumed by the elastic SEM damping and
+ * by the acoustoelastic coupling, which may already compensate for it), the DG kernels orient it
+ * here. The outward direction is the one pointing from the element centroid towards the face
+ * centroid, which is geometric and therefore valid for deformed hexahedra as well -- and a no-op
+ * whenever faceNormal already returned the outward normal.
+ *
+ * @param n        Normal to orient in place.
+ * @param X8       Element corner coordinates, ordered X8[iv + 2*jv + 4*kv].
+ * @param kFaceId  Local face index (0..5), i.e. 2*direction + (0 for Minus, 1 for Plus).
+ */
+PROXY_HOST_DEVICE void orientNormalOutward(real_t (&n)[3], real_t const (&X8)[8][3], int const kFaceId) {
+  int const kDir = kFaceId / 2;
+  int const kHigh = kFaceId % 2;
+
+  real_t elemCentroid[3] = {0.0f, 0.0f, 0.0f};
+  for (int v = 0; v < 8; ++v)
+    for (int d = 0; d < 3; ++d) elemCentroid[d] += 0.125f * X8[v][d];
+
+  // The 4 corners of the face are those whose bit in direction kDir matches the face's side.
+  real_t faceCentroid[3] = {0.0f, 0.0f, 0.0f};
+  for (int v = 0; v < 8; ++v) {
+    if (((v >> kDir) & 1) != kHigh) continue;
+    for (int d = 0; d < 3; ++d) faceCentroid[d] += 0.25f * X8[v][d];
+  }
+
+  real_t outward = 0.0f;
+  for (int d = 0; d < 3; ++d) outward += n[d] * (faceCentroid[d] - elemCentroid[d]);
+
+  if (outward < 0.0f)
+    for (int d = 0; d < 3; ++d) n[d] = -n[d];
+}
+
+/**
  * @brief Compute the SIPG penalty parameter gamma for a face.
  *
  * Formula: gamma = penalty_factor * p * (p+1) / h_f

--- a/src/solver/fe/DG/impl/common/include/dg_solver.h
+++ b/src/solver/fe/DG/impl/common/include/dg_solver.h
@@ -258,6 +258,43 @@ class DGsolver : public Solver {
   /// @brief Lookup table: kFaceToElemDof[face_id][face_dof_2d] → element-local DOF.
   /// Replaces runtime calls to model::faceLocalToElemLocal(..., ORDER) in GPU kernels.
   static constexpr auto kFaceToElemDof = buildFaceToElemDof();
+
+  /// @brief Compile-time helper: maps (face_id, face_dof_2d, depth) → element-local DOF index,
+  /// where depth walks the line running through the face dof PERPENDICULAR to the face
+  /// (0 = the face at index 0 of that direction, ORDER = the opposite face).
+  ///
+  /// The face-normal part of a trial function's gradient reads that whole line, not just the face
+  /// dof, so the interface-flux kernels need to address its off-face support points. At depth
+  /// equal to the face's own fixed index this reduces to faceToElemDofImpl(face_id, dof).
+  static constexpr int faceToElemDofAtDepthImpl(int face_id, int face_dof_2d, int depth) {
+    const int n = ORDER + 1;
+    const int u = face_dof_2d % n;
+    const int v = face_dof_2d / n;
+    switch (face_id) {
+      case 0:
+      case 1:
+        return depth + u * n + v * n * n;  // kXMinus / kXPlus: normal runs along x
+      case 2:
+      case 3:
+        return u + depth * n + v * n * n;  // kYMinus / kYPlus: normal runs along y
+      case 4:
+      case 5:
+        return u + v * n + depth * n * n;  // kZMinus / kZPlus: normal runs along z
+      default:
+        return -1;
+    }
+  }
+
+  static constexpr auto buildFaceToElemDofAtDepth() {
+    std::array<std::array<std::array<int, ORDER + 1>, knumNodesPerFace>, 6> t{};
+    for (int f = 0; f < 6; ++f)
+      for (int i = 0; i < knumNodesPerFace; ++i)
+        for (int m = 0; m <= ORDER; ++m) t[f][i][m] = faceToElemDofAtDepthImpl(f, i, m);
+    return t;
+  }
+
+  /// @brief Lookup table: kFaceToElemDofAtDepth[face_id][face_dof_2d][depth] → element-local DOF.
+  static constexpr auto kFaceToElemDofAtDepth = buildFaceToElemDofAtDepth();
 };
 
 // Backward Compatibility Aliases

--- a/src/solver/fe/DG/impl/common/include/dg_solver_impl.h
+++ b/src/solver/fe/DG/impl/common/include/dg_solver_impl.h
@@ -218,8 +218,8 @@ void DGsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::comp
   int const n_iter = list_on ? m_n_face_list_ : kNumFaces;
 
   auto face_connectivity_local = m_face_connectivity_;
-  auto const face_to_elem_dof = kFaceToElemDof;               // local copy for device capture
-  auto const face_to_elem_dof_depth = kFaceToElemDofAtDepth;  // idem, for the face-normal line
+  auto const face_to_elem_dof = kFaceToElemDof;  // local copy for device capture
+  auto const face_to_elem_dof_depth = kFaceToElemDofAtDepth;
   arrayReal stiff_local_view = m_stiff_local_;
   real_t const penalty_local = m_penalty_factor_;
 
@@ -258,8 +258,6 @@ void DGsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::comp
         real_t const inv_rho_o = 1.0f / mesh_local.getModelRhoOnElement(owner_e);
         real_t const inv_rho_n = 1.0f / mesh_local.getModelRhoOnElement(neighbor_e);
 
-        // Oriented explicitly: faceNormal's convention differs between mesh implementations and
-        // the flux terms below are the first consumers that depend on it (see orientNormalOutward).
         float normal[3];
         mesh_local.faceNormal(owner_e, static_cast<model::CubicFace>(fid_o), normal);
         orientNormalOutward(normal, owner_coords, fid_o);
@@ -283,10 +281,6 @@ void DGsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::comp
               stiff_o[ej] += inv_rho_o * (-0.5f * val * current_field(owner_e, ei) * nk);
               stiff_n[ej_perm] += inv_rho_o * (0.5f * val * current_field(owner_e, ei) * nk);
             },
-            // Same three terms with the trial dof at depth m on the face-normal line instead of on
-            // the face itself (see computeGradPhiPhiAt: the single-callback form drops this term
-            // entirely on a Cartesian mesh). em fits inside stiff_o (sized kPointsPerElement), so
-            // it is a plain local write, not an atomic one.
             [&](const int m, const int j, const int k, const real_t val) {
               int const em = face_to_elem_dof_depth[fid_o][j][m];
               int const ej = face_to_elem_dof[fid_o][j];

--- a/src/solver/fe/DG/impl/common/include/dg_solver_impl.h
+++ b/src/solver/fe/DG/impl/common/include/dg_solver_impl.h
@@ -218,7 +218,8 @@ void DGsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::comp
   int const n_iter = list_on ? m_n_face_list_ : kNumFaces;
 
   auto face_connectivity_local = m_face_connectivity_;
-  auto const face_to_elem_dof = kFaceToElemDof;  // local copy for device capture
+  auto const face_to_elem_dof = kFaceToElemDof;               // local copy for device capture
+  auto const face_to_elem_dof_depth = kFaceToElemDofAtDepth;  // idem, for the face-normal line
   arrayReal stiff_local_view = m_stiff_local_;
   real_t const penalty_local = m_penalty_factor_;
 
@@ -257,8 +258,11 @@ void DGsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::comp
         real_t const inv_rho_o = 1.0f / mesh_local.getModelRhoOnElement(owner_e);
         real_t const inv_rho_n = 1.0f / mesh_local.getModelRhoOnElement(neighbor_e);
 
+        // Oriented explicitly: faceNormal's convention differs between mesh implementations and
+        // the flux terms below are the first consumers that depend on it (see orientNormalOutward).
         float normal[3];
         mesh_local.faceNormal(owner_e, static_cast<model::CubicFace>(fid_o), normal);
+        orientNormalOutward(normal, owner_coords, fid_o);
 
         real_t const gamma_o = computeSIPGPenalty<ORDER>(faceCoords, owner_coords, penalty_local);
         real_t const gamma_n = computeSIPGPenalty<ORDER>(faceCoords, neighbor_coords, penalty_local);
@@ -268,7 +272,8 @@ void DGsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::comp
 
         // --- Owner side (outward normal = normal[]) ---
         INTEGRAL_TYPE::computeInterfaceFluxTerm(
-            faceCoords, owner_coords, fid_o, [&](const int i, const int j, const int k, const real_t val) {
+            faceCoords, owner_coords, fid_o,
+            [&](const int i, const int j, const int k, const real_t val) {
               int const ei = face_to_elem_dof[fid_o][i];
               int const ej = face_to_elem_dof[fid_o][j];
               int const ej_perm = face_to_elem_dof[fid_n][face_connectivity_local.getNeighborFaceDof(f, j)];
@@ -277,6 +282,20 @@ void DGsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::comp
                                           0.5f * val * current_field(neighbor_e, ej_perm) * nk);
               stiff_o[ej] += inv_rho_o * (-0.5f * val * current_field(owner_e, ei) * nk);
               stiff_n[ej_perm] += inv_rho_o * (0.5f * val * current_field(owner_e, ei) * nk);
+            },
+            // Same three terms with the trial dof at depth m on the face-normal line instead of on
+            // the face itself (see computeGradPhiPhiAt: the single-callback form drops this term
+            // entirely on a Cartesian mesh). em fits inside stiff_o (sized kPointsPerElement), so
+            // it is a plain local write, not an atomic one.
+            [&](const int m, const int j, const int k, const real_t val) {
+              int const em = face_to_elem_dof_depth[fid_o][j][m];
+              int const ej = face_to_elem_dof[fid_o][j];
+              int const ej_perm = face_to_elem_dof[fid_n][face_connectivity_local.getNeighborFaceDof(f, j)];
+              float const nk = normal[k];
+              stiff_o[em] += inv_rho_o * (-0.5f * val * current_field(owner_e, ej) * nk +
+                                          0.5f * val * current_field(neighbor_e, ej_perm) * nk);
+              stiff_o[ej] += inv_rho_o * (-0.5f * val * current_field(owner_e, em) * nk);
+              stiff_n[ej_perm] += inv_rho_o * (0.5f * val * current_field(owner_e, em) * nk);
             });
 
         for (int i = 0; i < knumNodesPerFace; ++i) {
@@ -288,7 +307,8 @@ void DGsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::comp
 
         // --- Neighbor side (outward normal = -normal[]) ---
         INTEGRAL_TYPE::computeInterfaceFluxTerm(
-            faceCoords, neighbor_coords, fid_n, [&](const int i, const int j, const int k, const real_t val) {
+            faceCoords, neighbor_coords, fid_n,
+            [&](const int i, const int j, const int k, const real_t val) {
               int const ei = face_to_elem_dof[fid_n][i];
               int const ej = face_to_elem_dof[fid_n][j];
               int const ej_perm = face_to_elem_dof[fid_o][face_connectivity_local.getOwnerFaceDof(f, j)];
@@ -297,6 +317,16 @@ void DGsolver<ORDER, INTEGRAL_TYPE, MESH_TYPE, IS_MODEL_ON_NODES, PHYSICS>::comp
                                           0.5f * val * current_field(owner_e, ej_perm) * nk);
               stiff_n[ej] += inv_rho_n * (-0.5f * val * current_field(neighbor_e, ei) * nk);
               stiff_o[ej_perm] += inv_rho_n * (0.5f * val * current_field(neighbor_e, ei) * nk);
+            },
+            [&](const int m, const int j, const int k, const real_t val) {
+              int const em = face_to_elem_dof_depth[fid_n][j][m];
+              int const ej = face_to_elem_dof[fid_n][j];
+              int const ej_perm = face_to_elem_dof[fid_o][face_connectivity_local.getOwnerFaceDof(f, j)];
+              float const nk = -normal[k];
+              stiff_n[em] += inv_rho_n * (-0.5f * val * current_field(neighbor_e, ej) * nk +
+                                          0.5f * val * current_field(owner_e, ej_perm) * nk);
+              stiff_n[ej] += inv_rho_n * (-0.5f * val * current_field(neighbor_e, em) * nk);
+              stiff_o[ej_perm] += inv_rho_n * (0.5f * val * current_field(neighbor_e, em) * nk);
             });
 
         for (int i = 0; i < knumNodesPerFace; ++i) {

--- a/tests/units/discretization/fe/makutu/impl/face_interface.h
+++ b/tests/units/discretization/fe/makutu/impl/face_interface.h
@@ -153,6 +153,51 @@ TYPED_TEST(InterfaceFluxTest, InterfaceFluxIsZero) {
   }
 }
 
+// The interface flux operator must reproduce the EXACT normal derivative of a field, not only its
+// tangential part. A field varying only along the face normal is the case that isolates this: such
+// a field is constant over the face dofs, so any operator restricted to face dofs sees a constant
+// and returns zero by partition of unity -- which is precisely what InterfaceFluxIsZero asserts.
+// Reproducing it requires the dofs of the line perpendicular to the face, hence the funcNormal
+// channel.
+//
+// Unit cube, p = the physical coordinate running along the face normal. Then grad(p) = e_kDir and
+//   sum_i p_i C_i,j,kDir = int_F (dp/dx_kDir) phi_j = int_F phi_j = computeDampingTerm(j, X).
+// The face normal's own sign is applied by the caller, not by the operator, so it does not enter
+// the expected value.
+TYPED_TEST(InterfaceFluxTest, ReproducesNormalDerivativeOfLinearField) {
+  using QK = TypeParam;
+  constexpr int numNodesPerFace = QK::numNodesPerFace;
+  constexpr int num1dNodes = QK::num1dNodes;
+
+  real_t X8[8][3] = {{0, 0, 0}, {1, 0, 0}, {0, 1, 0}, {1, 1, 0}, {0, 0, 1}, {1, 0, 1}, {0, 1, 1}, {1, 1, 1}};
+  real_t X[4][3] = {{0, 0, 0}, {1, 0, 0}, {0, 1, 0}, {1, 1, 0}};
+
+  // Nodal values of that coordinate along one direction, in [0, 1] on the unit cube.
+  real_t coord1d[num1dNodes];
+  for (int m = 0; m < num1dNodes; ++m) coord1d[m] = QK::interpolationCoord(m, 1);
+
+  for (int faceId = 0; faceId < 6; ++faceId) {
+    const int kDir = faceId / 2;
+    const int kQFixed = (faceId % 2 == 0) ? 0 : num1dNodes - 1;
+
+    real_t acc[numNodesPerFace] = {0};
+    QK::computeInterfaceFluxTerm(
+        X, X8, faceId,
+        // Tangential channel: i is a face dof, where p takes its face-constant value.
+        [&](int i, int j, int k, real_t Cijk) {
+          (void)i;
+          if (k == kDir) acc[j] += coord1d[kQFixed] * Cijk;
+        },
+        // Normal channel: m is the depth along the line through face dof j, where p varies.
+        [&](int m, int j, int k, real_t Cijk) {
+          if (k == kDir) acc[j] += coord1d[m] * Cijk;
+        });
+
+    for (int j = 0; j < numNodesPerFace; ++j)
+      EXPECT_NEAR(acc[j], QK::computeDampingTerm(j, X), TOL_NUMERICAL) << "faceId=" << faceId << ", face dof " << j;
+  }
+}
+
 // ============================================================================
 // VIRTUAL METHOD TESTS
 // ============================================================================

--- a/tests/units/discretization/fe/makutu/impl/face_interface.h
+++ b/tests/units/discretization/fe/makutu/impl/face_interface.h
@@ -153,17 +153,8 @@ TYPED_TEST(InterfaceFluxTest, InterfaceFluxIsZero) {
   }
 }
 
-// The interface flux operator must reproduce the EXACT normal derivative of a field, not only its
-// tangential part. A field varying only along the face normal is the case that isolates this: such
-// a field is constant over the face dofs, so any operator restricted to face dofs sees a constant
-// and returns zero by partition of unity -- which is precisely what InterfaceFluxIsZero asserts.
-// Reproducing it requires the dofs of the line perpendicular to the face, hence the funcNormal
-// channel.
-//
-// Unit cube, p = the physical coordinate running along the face normal. Then grad(p) = e_kDir and
-//   sum_i p_i C_i,j,kDir = int_F (dp/dx_kDir) phi_j = int_F phi_j = computeDampingTerm(j, X).
-// The face normal's own sign is applied by the caller, not by the operator, so it does not enter
-// the expected value.
+// funcNormal must reproduce the exact normal derivative of a field linear along the face normal:
+// grad(p) = e_kDir, so sum_i p_i C_i,j,kDir = int_F phi_j = computeDampingTerm(j, X).
 TYPED_TEST(InterfaceFluxTest, ReproducesNormalDerivativeOfLinearField) {
   using QK = TypeParam;
   constexpr int numNodesPerFace = QK::numNodesPerFace;


### PR DESCRIPTION
This PR fix an error when we compute the flux in the case of DG method.

A part of the normal direction of the flux was missing leading to flux equals to 0 and all the physic dependant on the penalty coefficient. This exmplain why the coefficient needed to be verfy high which has an impact on the CFL condition.

With this fix, the penalty coefficient returns on an usual range (around 10~12) ans the CFl is better.